### PR TITLE
chore: update license in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rustyfit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
 ]

--- a/rustyfit/Cargo.toml
+++ b/rustyfit/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rustyfit"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "This project hosts the Rust implementation for The Flexible and Interoperable Data Transfer (FIT) Protocol"
 authors = ["Hikmatulloh Hari Mukti <muktihaz@gmail.com>"]
 readme = "../README.md"
-license-file = "../LICENSE-BSD-3-CLAUSE"
+license = "BSD-3-Clause"
 include = ["Cargo.toml", "src/**"]
 categories = ["encoding", "parser-implementations"]
 repository = "https://github.com/muktihari/rustyfit"


### PR DESCRIPTION
Even after changing the name of the LICENSE, crates still mark it as non standard. Let's try using string literal instead of refer to the license file. Let's see if crates can recognize it.