### PR TITLE
refactor!: properly handle chained fit file and improve control flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rustyfit"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
 ]

--- a/README.md
+++ b/README.md
@@ -19,53 +19,74 @@ Missing features, test completeness, and more robust documentation may be added 
 
 #### Decode
 
-Decoder's `decode` allows us to interact with FIT files directly through their original protocol messages' structure.
+Decoder's `decode` allows us to interact with FIT files directly through their original protocol messages' structure. 
+First call will return either Ok(Some(fit)) or Err(err), never Ok(None).
+On next call, it may return Ok(None) to indicate that no more FIT sequence in the file.
 
 ```rust
-use rustyfit::{
-    Decoder,
-    profile::{mesgdef, typedef},
-};
-use std::{fs::File, io::BufReader};
+use rustyfit::{Decoder, profile::{mesgdef, typedef}};
+use std::{error::Error, fs::File, io::BufReader};
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let name = "Activity.fit";
-    let f = File::open(name).unwrap();
+    let f = File::open(name)?;
     let br = BufReader::new(f);
     let mut dec = Decoder::new(br);
 
-    let fit = dec.decode().unwrap();
+    let fit = dec.decode()?.unwrap(); // First decode call is either Ok(Some(fit)) or Err(err), never Ok(None).
 
     println!("file_header's data_size: {}", fit.file_header.data_size);
     println!("messages count: {}", fit.messages.len());
-    for field in &fit.messages[0].fields { // first message: file_id
+    for field in &fit.messages[0].fields {
+        // first message: file_id
         if field.num == mesgdef::FileId::TYPE {
             println!("file type: {}", typedef::File(field.value.as_u8()));
         }
     }
+    
+    Ok(())
+    
     // # Output:
     // file_header's data_size: 94080
     // messages count: 3611
     // file type: activity
 }
+```
 
+The `decode` method can be invoked multiple times to decode chained FIT file until it return Ok(None) or Err(err). 
+We can decode chained FIT file using `while let`, e.g:
+
+```rust
+    while let Some(fit) = dec.decode()? {
+        println!("file_header's data_size: {}", fit.file_header.data_size);
+        println!("messages count: {}", fit.messages.len());
+        for field in &fit.messages[0].fields {
+            // first message: file_id
+            if field.num == mesgdef::FileId::TYPE {
+                println!("file type: {}", typedef::File(field.value.as_u8()));
+            }
+        }
+    }
 ```
 
 #### Decode with Closure
 
-Decoder's `decode_fn` allow us to retrieve message definition or message data event as soon as it is being decoded. This way, users can have fine-grained control on how to interact with the data.
+Decoder's `decode_with` allow us to retrieve event data (FileHeader, MessageDefinition, Message, CRC) as soon as it is being decoded. 
+This way, users can have fine-grained control on how to interact with the data.
 
 ```rust
 use rustyfit::{Decoder, DecoderEvent,profile::{mesgdef, typedef}};
-use std::{fs::File, io::BufReader};
+use std::{error::Error, fs::File, io::BufReader};
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let name = "Activity.fit";
-    let f = File::open(name).unwrap();
+    let f = File::open(name)?;
     let br = BufReader::new(f);
     let mut dec = Decoder::new(br);
 
-    dec.decode_fn(|event| match event {
+    dec.decode_with(|event| match event {
+        DecoderEvent::FileHeader(_) => {},
+        DecoderEvent::MessageDefinition(_) => {},
         DecoderEvent::Message(mesg) => {
             if mesg.num == typedef::MesgNum::SESSION {
                 // Convert mesg into Session struct
@@ -76,9 +97,10 @@ fn main() {
                 );
             }
         }
-        DecoderEvent::MessageDefinition(_) => {}
-    })
-    .unwrap();
+        DecoderEvent::Crc(_) => {}
+    })?;
+    
+    Ok(())
 
     // # Output
     // session:
@@ -86,7 +108,23 @@ fn main() {
     //  sport: stand_up_paddleboarding
     //  num_laps: 1
 }
+```
 
+The `decode_with` method can be invoked multiple times to decode chained FIT file until it return Ok(false) or Err(err). 
+
+```rust
+    while dec.decode_with(|event| {
+        if let DecoderEvent::Message(mesg) = event {
+            if mesg.num == typedef::MesgNum::SESSION {
+                // Convert mesg into Session struct
+                let ses = mesgdef::Session::from(mesg);
+                println!(
+                    "session:\n start_time: {}\n sport: {}\n num_laps: {}",
+                    ses.start_time.0, ses.sport, ses.num_laps
+                );
+            }
+        }
+    })? {}
 ```
 
 #### DecoderBuilder
@@ -107,25 +145,14 @@ let mut dec: Decoder = DecoderBuilder::new(br)
 Here is the example of manually encode FIT protocol using this library to give the idea how it works.
 
 ```rust
-use std::{
-    fs::File,
-    io::{BufWriter, Write},
-};
+use std::{error::Error, fs::File, io::{BufWriter, Write}};
+use rustyfit::{Encoder, profile::{ProfileType, mesgdef, typedef::{self}}, proto::{FIT, Field, Message, Value}};
 
-use rustyfit::{
-    Encoder,
-    profile::{
-        ProfileType, mesgdef,
-        typedef::{self},
-    },
-    proto::{FIT, Field, Message, Value},
-};
-
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let fout_name = "output.fit";
-    let fout = File::create(fout_name).unwrap();
-    let bw = BufWriter::new(fout);
-    let mut enc = Encoder::new(bw);
+    let fout = File::create(fout_name)?;
+    let mut bw = BufWriter::new(fout);
+    let mut enc = Encoder::new(&mut bw);
 
     let mut fit = FIT {
         messages: vec![
@@ -159,7 +186,7 @@ fn main() {
                     Field {
                         num: mesgdef::Record::DISTANCE,
                         profile_type: ProfileType::UINT32,
-                        value: Value::Uint16(100 * 100), // 100 m
+                        value: Value::Uint32(100 * 100), // 100 m
                         is_expanded: false,
                     },
                     Field {
@@ -181,10 +208,11 @@ fn main() {
         ..Default::default()
     };
 
-    enc.encode(&mut fit).unwrap();
-    bw.flush().unwrap();
-}
+    enc.encode(&mut fit)?;
+    bw.flush()?;
 
+    Ok(())
+}
 ```
 
 #### Encode using mesgdef module
@@ -192,25 +220,14 @@ fn main() {
 Alternatively, users can create messages using the mesgdef module for convenience.
 
 ```rust
-use std::{
-    fs::File,
-    io::{BufWriter, Write},
-};
+use std::{error::Error, fs::File, io::{BufWriter, Write}};
+use rustyfit::{Encoder, profile::{mesgdef, typedef::{self}}, proto::{FIT, Message}};
 
-use rustyfit::{
-    Encoder,
-    profile::{
-        mesgdef,
-        typedef::{self},
-    },
-    proto::{FIT, Message},
-};
-
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let fout_name = "output.fit";
-    let fout = File::create(fout_name).unwrap();
-    let bw = BufWriter::new(fout);
-    let mut enc = Encoder::new(bw);
+    let fout = File::create(fout_name)?;
+    let mut bw = BufWriter::new(fout);
+    let mut enc = Encoder::new(&mut bw);
 
     let mut fit = FIT {
         messages: vec![
@@ -232,10 +249,11 @@ fn main() {
         ..Default::default()
     };
 
-    enc.encode(&mut fit).unwrap();
-    bw.flush().unwrap();
-}
+    enc.encode(&mut fit)?;
+    bw.flush()?;
 
+    Ok(())
+}
 ```
 
 #### EncoderBuilder

--- a/rustyfit/Cargo.toml
+++ b/rustyfit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustyfit"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "This project hosts the Rust implementation for The Flexible and Interoperable Data Transfer (FIT) Protocol"
 authors = ["Hikmatulloh Hari Mukti <muktihaz@gmail.com>"]

--- a/rustyfit/benches/decoder.rs
+++ b/rustyfit/benches/decoder.rs
@@ -25,20 +25,20 @@ pub fn bench_decode(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("decode fn", |b| {
+    c.bench_function("decode_with", |b| {
         b.iter(|| {
             let mut dec = Decoder::new(black_box(Cursor::new(&file_bytes)));
-            dec.decode_fn(|_| {}).unwrap();
+            dec.decode_with(|_| {}).unwrap();
         })
     });
 
-    c.bench_function("decode fn no checksum no expand", |b| {
+    c.bench_function("decode_with no checksum no expand", |b| {
         b.iter(|| {
             let mut dec = DecoderBuilder::new(black_box(Cursor::new(&file_bytes)))
                 .checksum(false)
                 .expand_components(false)
                 .build();
-            dec.decode_fn(|_| {}).unwrap();
+            dec.decode_with(|_| {}).unwrap();
         })
     });
 }

--- a/rustyfit/benches/encoder.rs
+++ b/rustyfit/benches/encoder.rs
@@ -8,37 +8,40 @@ const TEST_FILE: &str = "tests/data/large.fit";
 pub fn bench_encode(c: &mut Criterion) {
     let file_bytes = std::fs::read(TEST_FILE).unwrap();
     let mut dec = Decoder::new(Cursor::new(&file_bytes));
-    let mut fit = dec.decode().unwrap();
-
     let mut buf = Vec::<u8>::with_capacity(10_000 >> 10); // 10 MB, large enough to avoid realloc.
 
-    c.bench_function("encode default", |b| {
-        b.iter(|| {
-            let cur = Cursor::new(&mut buf);
-            let mut enc = Encoder::new(black_box(cur));
-            enc.encode(&mut fit).unwrap();
-        })
-    });
+    while let Some(fit) = &mut dec.decode().unwrap() {
+        c.bench_function("encode default", |b| {
+            b.iter(|| {
+                let cur = Cursor::new(&mut buf);
+                let mut enc = Encoder::new(black_box(cur));
+                enc.encode(fit).unwrap();
+                buf.clear();
+            })
+        });
 
-    c.bench_function("encode normal interleave 15", |b| {
-        b.iter(|| {
-            let cur = Cursor::new(&mut buf);
-            let mut enc = EncoderBuilder::new(black_box(cur))
-                .header_option(HeaderOption::Normal(15))
-                .build();
-            enc.encode(&mut fit).unwrap();
-        })
-    });
+        c.bench_function("encode normal interleave 15", |b| {
+            b.iter(|| {
+                let cur = Cursor::new(&mut buf);
+                let mut enc = EncoderBuilder::new(black_box(cur))
+                    .header_option(HeaderOption::Normal(15))
+                    .build();
+                enc.encode(fit).unwrap();
+                buf.clear();
+            })
+        });
 
-    c.bench_function("encode compress interleave 3", |b| {
-        b.iter(|| {
-            let cur = Cursor::new(&mut buf);
-            let mut enc = EncoderBuilder::new(black_box(cur))
-                .header_option(HeaderOption::Compressed(3))
-                .build();
-            enc.encode(&mut fit).unwrap();
-        })
-    });
+        c.bench_function("encode compress interleave 3", |b| {
+            b.iter(|| {
+                let cur = Cursor::new(&mut buf);
+                let mut enc = EncoderBuilder::new(black_box(cur))
+                    .header_option(HeaderOption::Compressed(3))
+                    .build();
+                enc.encode(fit).unwrap();
+                buf.clear();
+            })
+        });
+    }
 }
 
 criterion_group!(benches, bench_encode);

--- a/rustyfit/src/crc16.rs
+++ b/rustyfit/src/crc16.rs
@@ -24,7 +24,7 @@ impl Crc16 {
         self.0 = crc;
     }
 
-    pub fn sum16(&mut self) -> u16 {
+    pub fn sum16(&self) -> u16 {
         self.0
     }
 

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 use accumulator::Accumulator;
 use bits::Bits;
-use core::fmt;
 use std::{
+    error, fmt,
     io::{ErrorKind, Read},
     mem,
 };
@@ -85,12 +85,18 @@ impl fmt::Display for Error {
     }
 }
 
-/// Event produced by decode_fn.
+impl error::Error for Error {}
+
+/// Event is FIT segments encountered by the Decoder.
 pub enum Event<'a> {
-    /// Message ref when the Decoder encounter a Message.
-    Message(&'a Message),
-    /// MessageDefinition ref when the Decoder encounter a MessageDefinition.
+    /// Returned when the Decoder encounter FileHeader.
+    FileHeader(&'a FileHeader),
+    /// Returned when the Decoder encounter MessageDefinition.
     MessageDefinition(&'a MessageDefinition),
+    /// Returned when the Decoder encounter Message.
+    Message(&'a Message),
+    /// Returned when the Decoder encounter File's CRC.
+    Crc(&'a u16),
 }
 
 struct Options {
@@ -122,40 +128,53 @@ impl<R: Read> Decoder<R> {
     }
 
     /// Decode return a single FIT sequence. If it's a chained FIT file, call this method multiple times.
-    pub fn decode(&mut self) -> Result<FIT, Error> {
-        let file_header = self.decode_file_header()?;
+    /// First call will return either Ok(Some(fit)) or Err(err), never Ok(None).
+    /// On next call, it may return Ok(None) to indicate that no more FIT sequence in the file.
+    pub fn decode(&mut self) -> Result<Option<FIT>, Error> {
+        let file_header = match self.decode_file_header()? {
+            Some(file_header) => file_header,
+            None => return Ok(None),
+        };
 
         let mut messages = Vec::new();
-        self.decode_message_fn(file_header.data_size, |event| match event {
-            Event::Message(mesg) => messages.push(mesg.clone()),
-            Event::MessageDefinition(_) => {}
+        self.decode_message_with(file_header.data_size, |event| {
+            if let Event::Message(mesg) = event {
+                messages.push(mesg.clone())
+            }
         })?;
 
         let crc = self.decode_crc()?;
         self.reset();
-        Ok(FIT {
+        Ok(Some(FIT {
             file_header,
             messages,
             crc,
-        })
+        }))
     }
 
-    /// Similar to Decode but with a closure for retrieving DecoderEvent (Message or MessageDefinition)
-    /// for the current FIT sequence.
-    pub fn decode_fn<F>(&mut self, f: F) -> Result<(), Error>
+    /// Similar to Decode but with a closure for retrieving DecoderEvent for the current FIT sequence.
+    pub fn decode_with<F>(&mut self, mut f: F) -> Result<bool, Error>
     where
         F: FnMut(Event),
     {
-        let file_header = self.decode_file_header()?;
-        self.decode_message_fn(file_header.data_size, f)?;
-        _ = self.decode_crc()?;
+        let file_header = match self.decode_file_header()? {
+            Some(file_header) => file_header,
+            None => return Ok(false),
+        };
+        f(Event::FileHeader(&file_header));
+        self.decode_message_with(file_header.data_size, &mut f)?;
+        let crc = self.decode_crc()?;
+        f(Event::Crc(&crc));
         self.reset();
-        Ok(())
+        Ok(true)
     }
 
-    fn decode_file_header(&mut self) -> Result<FileHeader, Error> {
+    fn decode_file_header(&mut self) -> Result<Option<FileHeader>, Error> {
         let mut arr = [0u8; 14];
         if let Err(err) = self.reader.read_exact(&mut arr[..1]) {
+            if self.n > 0 && err.kind() == ErrorKind::UnexpectedEof {
+                return Ok(None); // No chained FIT sequence
+            }
             return Err(Error::Io {
                 error_kind: err.kind(),
                 byte_pos: self.n,
@@ -163,18 +182,18 @@ impl<R: Read> Decoder<R> {
         };
         self.n += 1;
 
-        let n = arr[0];
+        let n = arr[0] as usize;
         if n != 12 && n != 14 {
             return Err(Error::NotFITFile);
         }
 
-        if let Err(err) = self.reader.read_exact(&mut arr[1..n as usize]) {
+        if let Err(err) = self.reader.read_exact(&mut arr[1..n]) {
             return Err(Error::Io {
                 error_kind: err.kind(),
                 byte_pos: self.n,
             });
         }
-        self.n += n as usize - 1;
+        self.n += n - 1;
 
         if &arr[8..12] != DATA_TYPE.as_bytes() {
             return Err(Error::NotFITFile);
@@ -196,14 +215,14 @@ impl<R: Read> Decoder<R> {
             self.crc16.reset();
         }
 
-        Ok(FileHeader {
-            size: n,
+        Ok(Some(FileHeader {
+            size: n as u8,
             protocol_version: ProtocolVersion(arr[1]),
             profile_version: u16::from_le_bytes([arr[12], arr[13]]),
             data_size: u32::from_le_bytes(arr[4..8].try_into().unwrap()),
             data_type: DATA_TYPE,
             crc,
-        })
+        }))
     }
 
     /// Reads the exact number of bytes required to fill buf, increment n read bytes and calculate checksum.
@@ -222,7 +241,7 @@ impl<R: Read> Decoder<R> {
         Ok(())
     }
 
-    fn decode_message_fn<F>(&mut self, data_size: u32, mut f: F) -> Result<(), Error>
+    fn decode_message_with<F>(&mut self, data_size: u32, mut f: F) -> Result<(), Error>
     where
         F: FnMut(Event),
     {
@@ -398,7 +417,7 @@ impl<R: Read> Decoder<R> {
         let mut arr = [0u8; 255];
 
         for field_def in &mesg_def.field_definitions {
-            let buf = &mut arr[..field_def.size as usize];
+            let mut buf = &mut arr[..field_def.size as usize];
             self.read_exact_inc(buf)?;
 
             let num = field_def.num;
@@ -427,6 +446,15 @@ impl<R: Read> Decoder<R> {
                     }
                 }
             };
+
+            if field_def.size < base_type.size() {
+                buf = slice_buffer_to_match_type_size(
+                    &mut arr,
+                    mesg_def.arch,
+                    field_def.size as usize,
+                    base_type.size() as usize,
+                );
+            }
 
             let value = Value::unmarshal(buf, array, base_type, mesg_def.arch);
 
@@ -527,7 +555,7 @@ impl<R: Read> Decoder<R> {
         let mut arr = [0u8; 255];
 
         for dev_field_def in &mesg_def.developer_field_definitions {
-            let buf = &mut arr[..dev_field_def.size as usize];
+            let mut buf = &mut arr[..dev_field_def.size as usize];
             self.read_exact_inc(buf)?;
 
             let field_desc = match self.field_descriptions.iter().find(|v| {
@@ -540,11 +568,12 @@ impl<R: Read> Decoder<R> {
 
             let base_type = field_desc.fit_base_type_id;
             if dev_field_def.size < base_type.size() {
-                return Err(Error::BaseTypeSizeMismatch {
-                    expected: base_type.size(),
-                    got: dev_field_def.size,
-                    base_type,
-                });
+                buf = slice_buffer_to_match_type_size(
+                    &mut arr,
+                    mesg_def.arch,
+                    dev_field_def.size as usize,
+                    base_type.size() as usize,
+                );
             }
 
             let size = dev_field_def.size;
@@ -595,6 +624,22 @@ impl<R: Read> Decoder<R> {
         self.timestamp = 0;
         self.last_time_offset = 0;
         self.field_descriptions.clear();
+    }
+}
+
+fn slice_buffer_to_match_type_size(
+    arr: &mut [u8; 255],
+    arch: u8,
+    current_len: usize,
+    target_len: usize,
+) -> &mut [u8] {
+    if arch == 0 {
+        arr[current_len..target_len].fill(0);
+        &mut arr[..target_len]
+    } else {
+        arr.copy_within(..current_len, target_len - current_len);
+        arr[..target_len - current_len].fill(0);
+        &mut arr[..target_len]
     }
 }
 
@@ -674,8 +719,8 @@ impl<R: Read> Builder<R> {
         Self {
             reader,
             options: Options {
-                checksum: false,
-                expand_components: false,
+                checksum: true,
+                expand_components: true,
             },
         }
     }

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use lru::Lru;
 use std::{
+    error,
     fmt::{self},
     io::{self, Seek, SeekFrom, Write},
 };
@@ -56,6 +57,8 @@ impl fmt::Display for Error {
         }
     }
 }
+
+impl error::Error for Error {}
 
 /// IO related error when reading from the Reader.
 #[derive(Debug, Clone, Copy)]

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -1,6 +1,6 @@
 #![warn(missing_docs)]
 
-use core::fmt;
+use std::{error, fmt};
 
 use crate::profile::{
     ProfileType,
@@ -69,6 +69,8 @@ impl fmt::Display for Error {
         }
     }
 }
+
+impl error::Error for Error {}
 
 /// FIT is FIT protocol data representative.
 #[derive(Default, Debug)]

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -16,46 +16,49 @@ fn decode_encode_roundtrip() {
     let walk_fn = |path: &PathBuf| {
         let file = File::open(path).unwrap();
         let br = BufReader::new(file);
-
+        let mut buf = Vec::<u8>::with_capacity(10_000 >> 10); // 10 MB, large enough to avoid realloc.
         let mut dec = Decoder::new(br);
 
-        let mut fit = match dec.decode() {
+        'decode: while let Some(fit) = &mut match dec.decode() {
             Ok(fit) => fit,
             Err(err) => {
                 if let DecoderError::ChecksumMismatch { .. } = err {
-                    // NOTE: Doubts exist regarding the integrity of these files.
-                    let exceptions = ["WeightScaleMultiUser.fit", "Settings.fit"];
-                    for v in exceptions {
-                        if path.file_name().unwrap() == v {
-                            return;
+                    if let Some(file_name) = path.file_name() {
+                        // NOTE: Doubts exist regarding the integrity of these files.
+                        if ["WeightScaleMultiUser.fit", "Settings.fit"]
+                            .iter()
+                            .any(|x| *x == file_name)
+                        {
+                            continue 'decode;
                         }
                     }
                 }
                 panic!("decode: {:?}, err: {:?}", path, err);
             }
-        };
+        } {
+            let mut cursor = Cursor::new(&mut buf);
 
-        let mut cursor = Cursor::new(Vec::new());
+            let mut enc = EncoderBuilder::new(&mut cursor)
+                .endianness(Endianness::BigEndian)
+                .build();
 
-        let mut enc = EncoderBuilder::new(&mut cursor)
-            .endianness(Endianness::BigEndian)
-            .build();
+            if let Err(err) = enc.encode(fit) {
+                panic!("encode: {:?}, err: {:?}", path, err);
+            }
 
-        if let Err(err) = enc.encode(&mut fit) {
-            panic!("encode: {:?}, err: {:?}", path, err);
-        }
+            cursor.seek(SeekFrom::Start(0)).unwrap();
 
-        cursor.seek(SeekFrom::Start(0)).unwrap();
+            let mut dec = Decoder::new(&mut cursor);
+            if let Err(err) = dec.decode() {
+                panic!("re-decode the encoded file: {:?}, err: {:?}", path, err);
+            }
 
-        let mut dec = Decoder::new(&mut cursor);
-        if let Err(err) = dec.decode() {
-            panic!("re-decode the encoded file: {:?}, err: {:?}", path, err);
+            buf.clear();
         }
     };
 
-    match walk_path(&path, &walk_fn) {
-        Ok(_) => {}
-        Err(err) => panic!("walk_path: {}", err),
+    if let Err(err) = walk_path(&path, &walk_fn) {
+        panic!("walk_path: {}", err);
     }
 }
 


### PR DESCRIPTION
- method `decode` now returns `Result<Option<FIT>, Error>` to enable us decoding chained file safely. During first call, it will either return Ok(Some(fit)) or Err(err), when called again, it may return Ok(None) to indicate that no more fit sequence in the file.
- rename method `decode_fn` into `decode_with` for more idiomatic method naming.
- method `decode_with` now return Result<bool, Error>, it return Ok(false) when no more fit sequence in the file.
- more control over the data by expanding `DecoderEvent` enum values into `FileHeader`, `MessageDefinition`, `Message`, `Crc`. 
- make the library consistent by using `std` instead of `core`, since this library is currently built for normal rust program not embedded rust.
- implement `std::error::Error` for all top-level errors so we can use it on `Box<dyn Error>`.
- feat: gracefully handle bad encoded fit file instead of returning the error when type size is mismatch, this way we can retrieve as much as data as possible.
- fix: decoder didn't do checksum and expand the components by default, now it does.