### PR TITLE
perf: mesgdef improve struct From<&Message>

### DIFF
--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -67,11 +67,13 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			maxLenFields = len(mesg.Fields)
 		}
 		var (
+			knownNums     [4]uint64
 			maxFieldNum   byte
 			dynamicFields []DynamicField
 			fields        = make([]Field, 0, len(mesg.Fields))
 		)
 		for _, parserField := range mesg.Fields {
+			knownNums[parserField.Num>>6] |= 1 << (parserField.Num & 63)
 			if parserField.Num > maxFieldNum {
 				maxFieldNum = parserField.Num
 			}
@@ -167,6 +169,7 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			Name:              strutil.ToTitle(mesg.Name),
 			Fields:            fields,
 			DynamicFields:     dynamicFields,
+			KnownNums:         knownNums,
 			StateSize:         (maxFieldExpandNum + 8) / 8,
 			MaxFieldNum:       maxFieldNum + 1,
 			MaxFieldExpandNum: maxFieldExpandNum + 1,

--- a/fitgen/internal/profile/mesgdef/data.go
+++ b/fitgen/internal/profile/mesgdef/data.go
@@ -19,6 +19,7 @@ type Message struct {
 	NameSnakeCase     string
 	Fields            []Field
 	DynamicFields     []DynamicField
+	KnownNums         [4]uint64
 	StateSize         byte
 	MaxFieldNum       byte
 	MaxFieldExpandNum byte

--- a/fitgen/internal/profile/mesgdef/mesgdef.tmpl
+++ b/fitgen/internal/profile/mesgdef/mesgdef.tmpl
@@ -12,7 +12,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 {{ if gt .MaxFieldExpandNum 1 -}}
@@ -177,11 +177,18 @@ impl From<&Message> for {{ .Name }} {
         let mut vals: [&Value; {{ .MaxFieldNum }}] = [const { &Value::Invalid }; {{ .MaxFieldNum }}];
         {{ if gt .MaxFieldExpandNum 1 -}}
 		let mut state = [0u8; {{ .StateSize }}];
-		{{ end -}}
-        let mut unknown_fields: Vec<Field> = Vec::new();
+		{{ end }}
+		
+        {{/* 256 bits flags for indicating known Field Number declared in Profile.xslx */ -}}
+        const KNOWN_NUMS: [u64; 4] = [{{- range $_, $v := .KnownNums }} {{ $v -}}, {{ end -}}];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize>>6]>>(field.num&63))&1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize>>6]>>(field.num&63))&1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/Cargo.toml
+++ b/rustyfit/Cargo.toml
@@ -24,3 +24,7 @@ harness = false
 [[bench]]
 name = "encoder"
 harness = false
+
+[[bench]]
+name = "mesgdef"
+harness = false

--- a/rustyfit/benches/README.md
+++ b/rustyfit/benches/README.md
@@ -1,0 +1,4 @@
+## How to compare benchmarks
+
+cargo bench --bench mesgdef -- --save-baseline old      # benchmark and save this as the baseline named "old"
+cargo bench --bench mesgdef -- --baseline old           # benchmark and compare it with "old" baseline

--- a/rustyfit/benches/bench_main.rs
+++ b/rustyfit/benches/bench_main.rs
@@ -2,11 +2,12 @@ use criterion::{Criterion, criterion_group, criterion_main};
 
 mod decoder;
 mod encoder;
+mod mesgdef;
 
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = decoder::bench_decode, encoder::bench_encode,
+    targets = decoder::bench_decode, encoder::bench_encode, mesgdef::bench_from
 }
 
 criterion_main!(benches);

--- a/rustyfit/benches/mesgdef.rs
+++ b/rustyfit/benches/mesgdef.rs
@@ -1,0 +1,49 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use rustyfit::{
+    profile::{ProfileType, mesgdef::Record, typedef::MesgNum},
+    proto::{Field, Message, Value},
+};
+
+pub fn bench_from(c: &mut Criterion) {
+    let mesg = Message {
+        num: MesgNum::RECORD,
+        fields: vec![
+            Field {
+                num: Record::DISTANCE,
+                profile_type: ProfileType::UINT32,
+                value: Value::Uint32(1000),
+                is_expanded: false,
+            },
+            Field {
+                num: 255,
+                ..Default::default()
+            },
+            Field {
+                num: 255,
+                ..Default::default()
+            },
+            Field {
+                num: 255,
+                ..Default::default()
+            },
+            Field {
+                num: 255,
+                ..Default::default()
+            },
+            Field {
+                num: 255,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    c.bench_function("mesgdef From<&Message>", |b| {
+        b.iter(|| {
+            let _ = Record::from(black_box(&mesg));
+        })
+    });
+}
+
+criterion_group!(benches, bench_from);
+criterion_main!(benches);

--- a/rustyfit/src/profile/mesgdef/aad_accel_features.rs
+++ b/rustyfit/src/profile/mesgdef/aad_accel_features.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -78,10 +78,16 @@ impl From<&Message> for AadAccelFeatures {
     /// from creates new AadAccelFeatures struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/accelerometer_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -84,10 +84,16 @@ impl From<&Message> for AccelerometerData {
     /// from creates new AccelerometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [2047, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/activity.rs
+++ b/rustyfit/src/profile/mesgdef/activity.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -81,10 +81,16 @@ impl From<&Message> for Activity {
     /// from creates new Activity struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/ant_channel_id.rs
+++ b/rustyfit/src/profile/mesgdef/ant_channel_id.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -51,10 +51,16 @@ impl From<&Message> for AntChannelId {
     /// from creates new AntChannelId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 5] = [const { &Value::Invalid }; 5];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/ant_rx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_rx.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -104,10 +104,16 @@ impl From<&Message> for AntRx {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 1];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/ant_tx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_tx.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -104,10 +104,16 @@ impl From<&Message> for AntTx {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 1];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/aviation_attitude.rs
+++ b/rustyfit/src/profile/mesgdef/aviation_attitude.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -262,10 +262,16 @@ impl From<&Message> for AviationAttitude {
     /// from creates new AviationAttitude struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [2047, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/barometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/barometer_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -52,10 +52,16 @@ impl From<&Message> for BarometerData {
     /// from creates new BarometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/beat_intervals.rs
+++ b/rustyfit/src/profile/mesgdef/beat_intervals.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -47,10 +47,16 @@ impl From<&Message> for BeatIntervals {
     /// from creates new BeatIntervals struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/bike_profile.rs
+++ b/rustyfit/src/profile/mesgdef/bike_profile.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -257,10 +257,16 @@ impl From<&Message> for BikeProfile {
     /// from creates new BikeProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [21852827156479, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/blood_pressure.rs
+++ b/rustyfit/src/profile/mesgdef/blood_pressure.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -78,10 +78,16 @@ impl From<&Message> for BloodPressure {
     /// from creates new BloodPressure struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1023, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/cadence_zone.rs
+++ b/rustyfit/src/profile/mesgdef/cadence_zone.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -46,10 +46,16 @@ impl From<&Message> for CadenceZone {
     /// from creates new CadenceZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/camera_event.rs
+++ b/rustyfit/src/profile/mesgdef/camera_event.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -53,10 +53,16 @@ impl From<&Message> for CameraEvent {
     /// from creates new CameraEvent struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/capabilities.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -50,10 +50,16 @@ impl From<&Message> for Capabilities {
     /// from creates new Capabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 24] = [const { &Value::Invalid }; 24];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [10485763, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -65,10 +65,16 @@ impl From<&Message> for ChronoShotData {
     /// from creates new ChronoShotData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -160,10 +160,16 @@ impl From<&Message> for ChronoShotSession {
     /// from creates new ChronoShotSession struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/climb_pro.rs
+++ b/rustyfit/src/profile/mesgdef/climb_pro.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -61,10 +61,16 @@ impl From<&Message> for ClimbPro {
     /// from creates new ClimbPro struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/connectivity.rs
+++ b/rustyfit/src/profile/mesgdef/connectivity.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -78,10 +78,16 @@ impl From<&Message> for Connectivity {
     /// from creates new Connectivity struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 13] = [const { &Value::Invalid }; 13];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [8191, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/course.rs
+++ b/rustyfit/src/profile/mesgdef/course.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -48,10 +48,16 @@ impl From<&Message> for Course {
     /// from creates new Course struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 8] = [const { &Value::Invalid }; 8];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [240, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -82,10 +82,16 @@ impl From<&Message> for CoursePoint {
     /// from creates new CoursePoint struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [382, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/developer_data_id.rs
+++ b/rustyfit/src/profile/mesgdef/developer_data_id.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -49,10 +49,16 @@ impl From<&Message> for DeveloperDataId {
     /// from creates new DeveloperDataId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 5] = [const { &Value::Invalid }; 5];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -71,10 +71,16 @@ impl From<&Message> for DeviceAuxBatteryInfo {
     /// from creates new DeviceAuxBatteryInfo struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/device_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_info.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -139,10 +139,16 @@ impl From<&Message> for DeviceInfo {
     /// from creates new DeviceInfo struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [4470869247, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/device_settings.rs
+++ b/rustyfit/src/profile/mesgdef/device_settings.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -159,10 +159,16 @@ impl From<&Message> for DeviceSettings {
     /// from creates new DeviceSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 175] = [const { &Value::Invalid }; 175];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1117105531807338551, 3326148608, 70368744177728, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/dive_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_alarm.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -126,10 +126,16 @@ impl From<&Message> for DiveAlarm {
     /// from creates new DiveAlarm struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [4095, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -126,10 +126,16 @@ impl From<&Message> for DiveApneaAlarm {
     /// from creates new DiveApneaAlarm struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [4095, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/dive_gas.rs
+++ b/rustyfit/src/profile/mesgdef/dive_gas.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -53,10 +53,16 @@ impl From<&Message> for DiveGas {
     /// from creates new DiveGas struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/dive_settings.rs
+++ b/rustyfit/src/profile/mesgdef/dive_settings.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -313,10 +313,16 @@ impl From<&Message> for DiveSettings {
     /// from creates new DiveSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [242397216767, 0, 0, 6917529027641081856];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/dive_summary.rs
+++ b/rustyfit/src/profile/mesgdef/dive_summary.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -372,10 +372,16 @@ impl From<&Message> for DiveSummary {
     /// from creates new DiveSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [63176703, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/event.rs
+++ b/rustyfit/src/profile/mesgdef/event.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -175,10 +175,16 @@ impl From<&Message> for Event {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 4];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31522719, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -98,10 +98,16 @@ impl From<&Message> for ExdDataConceptConfiguration {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 12] = [const { &Value::Invalid }; 12];
         let mut state = [0u8; 1];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3967, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -84,10 +84,16 @@ impl From<&Message> for ExdDataFieldConfiguration {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 6] = [const { &Value::Invalid }; 6];
         let mut state = [0u8; 1];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -49,10 +49,16 @@ impl From<&Message> for ExdScreenConfiguration {
     /// from creates new ExdScreenConfiguration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 4] = [const { &Value::Invalid }; 4];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/exercise_title.rs
+++ b/rustyfit/src/profile/mesgdef/exercise_title.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -48,10 +48,16 @@ impl From<&Message> for ExerciseTitle {
     /// from creates new ExerciseTitle struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/field_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/field_capabilities.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -51,10 +51,16 @@ impl From<&Message> for FieldCapabilities {
     /// from creates new FieldCapabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/field_description.rs
+++ b/rustyfit/src/profile/mesgdef/field_description.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -76,10 +76,16 @@ impl From<&Message> for FieldDescription {
     /// from creates new FieldDescription struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 16] = [const { &Value::Invalid }; 16];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [59391, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/file_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/file_capabilities.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -55,10 +55,16 @@ impl From<&Message> for FileCapabilities {
     /// from creates new FileCapabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/file_creator.rs
+++ b/rustyfit/src/profile/mesgdef/file_creator.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -42,10 +42,16 @@ impl From<&Message> for FileCreator {
     /// from creates new FileCreator struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 2] = [const { &Value::Invalid }; 2];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/file_id.rs
+++ b/rustyfit/src/profile/mesgdef/file_id.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -58,10 +58,16 @@ impl From<&Message> for FileId {
     /// from creates new FileId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 9] = [const { &Value::Invalid }; 9];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [319, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/goal.rs
+++ b/rustyfit/src/profile/mesgdef/goal.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -75,10 +75,16 @@ impl From<&Message> for Goal {
     /// from creates new Goal struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [4095, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -154,10 +154,16 @@ impl From<&Message> for GpsMetadata {
     /// from creates new GpsMetadata struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/gyroscope_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -72,10 +72,16 @@ impl From<&Message> for GyroscopeData {
     /// from creates new GyroscopeData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hr.rs
+++ b/rustyfit/src/profile/mesgdef/hr.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -156,10 +156,16 @@ impl From<&Message> for Hr {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 2];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1603, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hr_zone.rs
+++ b/rustyfit/src/profile/mesgdef/hr_zone.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -46,10 +46,16 @@ impl From<&Message> for HrZone {
     /// from creates new HrZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [6, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hrm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/hrm_profile.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -51,10 +51,16 @@ impl From<&Message> for HrmProfile {
     /// from creates new HrmProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hrv.rs
+++ b/rustyfit/src/profile/mesgdef/hrv.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -70,10 +70,16 @@ impl From<&Message> for Hrv {
     /// from creates new Hrv struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 1] = [const { &Value::Invalid }; 1];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -180,10 +180,16 @@ impl From<&Message> for HrvStatusSummary {
     /// from creates new HrvStatusSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hrv_value.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_value.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -62,10 +62,16 @@ impl From<&Message> for HrvValue {
     /// from creates new HrvValue struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -154,10 +154,16 @@ impl From<&Message> for HsaAccelerometerData {
     /// from creates new HsaAccelerometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -56,10 +56,16 @@ impl From<&Message> for HsaBodyBatteryData {
     /// from creates new HsaBodyBatteryData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -48,10 +48,16 @@ impl From<&Message> for HsaConfigurationData {
     /// from creates new HsaConfigurationData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_event.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_event.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -44,10 +44,16 @@ impl From<&Message> for HsaEvent {
     /// from creates new HsaEvent struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -154,10 +154,16 @@ impl From<&Message> for HsaGyroscopeData {
     /// from creates new HsaGyroscopeData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -52,10 +52,16 @@ impl From<&Message> for HsaHeartRateData {
     /// from creates new HsaHeartRateData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -78,10 +78,16 @@ impl From<&Message> for HsaRespirationData {
     /// from creates new HsaRespirationData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -52,10 +52,16 @@ impl From<&Message> for HsaSpo2Data {
     /// from creates new HsaSpo2Data struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_step_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_step_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -48,10 +48,16 @@ impl From<&Message> for HsaStepData {
     /// from creates new HsaStepData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -47,10 +47,16 @@ impl From<&Message> for HsaStressData {
     /// from creates new HsaStressData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -78,10 +78,16 @@ impl From<&Message> for HsaWristTemperatureData {
     /// from creates new HsaWristTemperatureData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -142,10 +142,16 @@ impl From<&Message> for Jump {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 2];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [511, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -1908,10 +1908,21 @@ impl From<&Message> for Lap {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 18];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [
+            18446744000829325311,
+            2305842996261682304,
+            8438416128,
+            6917529027641081856,
+        ];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/length.rs
+++ b/rustyfit/src/profile/mesgdef/length.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -237,10 +237,16 @@ impl From<&Message> for Length {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 3];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [66854655, 0, 0, 6917529027641081856];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/magnetometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/magnetometer_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -72,10 +72,16 @@ impl From<&Message> for MagnetometerData {
     /// from creates new MagnetometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/max_met_data.rs
+++ b/rustyfit/src/profile/mesgdef/max_met_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -84,10 +84,16 @@ impl From<&Message> for MaxMetData {
     /// from creates new MaxMetData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 14] = [const { &Value::Invalid }; 14];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [13157, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/memo_glob.rs
+++ b/rustyfit/src/profile/mesgdef/memo_glob.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -60,10 +60,16 @@ impl From<&Message> for MemoGlob {
     /// from creates new MemoGlob struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 251] = [const { &Value::Invalid }; 251];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 288230376151711744];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -51,10 +51,16 @@ impl From<&Message> for MesgCapabilities {
     /// from creates new MesgCapabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/met_zone.rs
+++ b/rustyfit/src/profile/mesgdef/met_zone.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -88,10 +88,16 @@ impl From<&Message> for MetZone {
     /// from creates new MetZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [14, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/monitoring.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -349,10 +349,16 @@ impl From<&Message> for Monitoring {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 4];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [34343608319, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -48,10 +48,16 @@ impl From<&Message> for MonitoringHrData {
     /// from creates new MonitoringHrData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/monitoring_info.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_info.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -119,10 +119,16 @@ impl From<&Message> for MonitoringInfo {
     /// from creates new MonitoringInfo struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [59, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/nmea_sentence.rs
+++ b/rustyfit/src/profile/mesgdef/nmea_sentence.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -48,10 +48,16 @@ impl From<&Message> for NmeaSentence {
     /// from creates new NmeaSentence struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/obdii_data.rs
+++ b/rustyfit/src/profile/mesgdef/obdii_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -72,10 +72,16 @@ impl From<&Message> for ObdiiData {
     /// from creates new ObdiiData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/ohr_settings.rs
+++ b/rustyfit/src/profile/mesgdef/ohr_settings.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -43,10 +43,16 @@ impl From<&Message> for OhrSettings {
     /// from creates new OhrSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -60,10 +60,16 @@ impl From<&Message> for OneDSensorCalibration {
     /// from creates new OneDSensorCalibration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/power_zone.rs
+++ b/rustyfit/src/profile/mesgdef/power_zone.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -46,10 +46,16 @@ impl From<&Message> for PowerZone {
     /// from creates new PowerZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [6, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/raw_bbi.rs
+++ b/rustyfit/src/profile/mesgdef/raw_bbi.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -88,10 +88,16 @@ impl From<&Message> for RawBbi {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 1];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -1344,10 +1344,21 @@ impl From<&Message> for Record {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 14];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [
+            5764606990190788607,
+            18013290270358914040,
+            2050,
+            2305843009213693952,
+        ];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/respiration_rate.rs
+++ b/rustyfit/src/profile/mesgdef/respiration_rate.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -62,10 +62,16 @@ impl From<&Message> for RespirationRate {
     /// from creates new RespirationRate struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/schedule.rs
+++ b/rustyfit/src/profile/mesgdef/schedule.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -62,10 +62,16 @@ impl From<&Message> for Schedule {
     /// from creates new Schedule struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 7] = [const { &Value::Invalid }; 7];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/sdm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/sdm_profile.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -102,10 +102,16 @@ impl From<&Message> for SdmProfile {
     /// from creates new SdmProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [191, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/segment_file.rs
+++ b/rustyfit/src/profile/mesgdef/segment_file.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -71,10 +71,16 @@ impl From<&Message> for SegmentFile {
     /// from creates new SegmentFile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3994, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/segment_id.rs
+++ b/rustyfit/src/profile/mesgdef/segment_id.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -72,10 +72,16 @@ impl From<&Message> for SegmentId {
     /// from creates new SegmentId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 9] = [const { &Value::Invalid }; 9];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [511, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -1296,10 +1296,16 @@ impl From<&Message> for SegmentLap {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 12];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [18446744073709551615, 1056964607, 0, 6917529027641081856];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
+++ b/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -82,10 +82,16 @@ impl From<&Message> for SegmentLeaderboardEntry {
     /// from creates new SegmentLeaderboardEntry struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/segment_point.rs
+++ b/rustyfit/src/profile/mesgdef/segment_point.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -179,10 +179,16 @@ impl From<&Message> for SegmentPoint {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 1];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [126, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -2251,10 +2251,21 @@ impl From<&Message> for Session {
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 23];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [
+            18446742974197919743,
+            18446678103011623167,
+            932252819858127487,
+            6917529027641541103,
+        ];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/set.rs
+++ b/rustyfit/src/profile/mesgdef/set.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -113,10 +113,16 @@ impl From<&Message> for Set {
     /// from creates new Set struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [4089, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
+++ b/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -54,10 +54,16 @@ impl From<&Message> for SkinTempOvernight {
     /// from creates new SkinTempOvernight struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [23, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/slave_device.rs
+++ b/rustyfit/src/profile/mesgdef/slave_device.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -42,10 +42,16 @@ impl From<&Message> for SlaveDevice {
     /// from creates new SlaveDevice struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 2] = [const { &Value::Invalid }; 2];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/sleep_assessment.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_assessment.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -111,10 +111,16 @@ impl From<&Message> for SleepAssessment {
     /// from creates new SleepAssessment struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 16] = [const { &Value::Invalid }; 16];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [53247, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -42,10 +42,16 @@ impl From<&Message> for SleepDisruptionOvernightSeverity {
     /// from creates new SleepDisruptionOvernightSeverity struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -45,10 +45,16 @@ impl From<&Message> for SleepDisruptionSeverityPeriod {
     /// from creates new SleepDisruptionSeverityPeriod struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 6917529027641081856];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/sleep_level.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_level.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -43,10 +43,16 @@ impl From<&Message> for SleepLevel {
     /// from creates new SleepLevel struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/software.rs
+++ b/rustyfit/src/profile/mesgdef/software.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -65,10 +65,16 @@ impl From<&Message> for Software {
     /// from creates new Software struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [40, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/speed_zone.rs
+++ b/rustyfit/src/profile/mesgdef/speed_zone.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -65,10 +65,16 @@ impl From<&Message> for SpeedZone {
     /// from creates new SpeedZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/split.rs
+++ b/rustyfit/src/profile/mesgdef/split.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -260,10 +260,16 @@ impl From<&Message> for Split {
     /// from creates new Split struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [534798879, 70368744178688, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/split_summary.rs
+++ b/rustyfit/src/profile/mesgdef/split_summary.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -203,10 +203,16 @@ impl From<&Message> for SplitSummary {
     /// from creates new SplitSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [16377, 8192, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/spo2_data.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -51,10 +51,16 @@ impl From<&Message> for Spo2Data {
     /// from creates new Spo2Data struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/sport.rs
+++ b/rustyfit/src/profile/mesgdef/sport.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -45,10 +45,16 @@ impl From<&Message> for Sport {
     /// from creates new Sport struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 4] = [const { &Value::Invalid }; 4];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [11, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/stress_level.rs
+++ b/rustyfit/src/profile/mesgdef/stress_level.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -43,10 +43,16 @@ impl From<&Message> for StressLevel {
     /// from creates new StressLevel struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 2] = [const { &Value::Invalid }; 2];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/tank_summary.rs
+++ b/rustyfit/src/profile/mesgdef/tank_summary.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -112,10 +112,16 @@ impl From<&Message> for TankSummary {
     /// from creates new TankSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/tank_update.rs
+++ b/rustyfit/src/profile/mesgdef/tank_update.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -66,10 +66,16 @@ impl From<&Message> for TankUpdate {
     /// from creates new TankUpdate struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -89,10 +89,16 @@ impl From<&Message> for ThreeDSensorCalibration {
     /// from creates new ThreeDSensorCalibration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/time_in_zone.rs
+++ b/rustyfit/src/profile/mesgdef/time_in_zone.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -246,10 +246,16 @@ impl From<&Message> for TimeInZone {
     /// from creates new TimeInZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [65535, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
+++ b/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -102,10 +102,16 @@ impl From<&Message> for TimestampCorrelation {
     /// from creates new TimestampCorrelation struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/totals.rs
+++ b/rustyfit/src/profile/mesgdef/totals.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -72,10 +72,16 @@ impl From<&Message> for Totals {
     /// from creates new Totals struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [639, 0, 0, 6917529027641081856];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/training_file.rs
+++ b/rustyfit/src/profile/mesgdef/training_file.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -54,10 +54,16 @@ impl From<&Message> for TrainingFile {
     /// from creates new TrainingFile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/training_settings.rs
+++ b/rustyfit/src/profile/mesgdef/training_settings.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -109,10 +109,16 @@ impl From<&Message> for TrainingSettings {
     /// from creates new TrainingSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 154] = [const { &Value::Invalid }; 154];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [15032385536, 0, 33554432, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/user_profile.rs
+++ b/rustyfit/src/profile/mesgdef/user_profile.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -212,10 +212,16 @@ impl From<&Message> for UserProfile {
     /// from creates new UserProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [703695778447359, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/video.rs
+++ b/rustyfit/src/profile/mesgdef/video.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -46,10 +46,16 @@ impl From<&Message> for Video {
     /// from creates new Video struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 3] = [const { &Value::Invalid }; 3];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/video_clip.rs
+++ b/rustyfit/src/profile/mesgdef/video_clip.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -59,10 +59,16 @@ impl From<&Message> for VideoClip {
     /// from creates new VideoClip struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 8] = [const { &Value::Invalid }; 8];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [223, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/video_description.rs
+++ b/rustyfit/src/profile/mesgdef/video_description.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -47,10 +47,16 @@ impl From<&Message> for VideoDescription {
     /// from creates new VideoDescription struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/video_frame.rs
+++ b/rustyfit/src/profile/mesgdef/video_frame.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -48,10 +48,16 @@ impl From<&Message> for VideoFrame {
     /// from creates new VideoFrame struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/video_title.rs
+++ b/rustyfit/src/profile/mesgdef/video_title.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -47,10 +47,16 @@ impl From<&Message> for VideoTitle {
     /// from creates new VideoTitle struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/watchface_settings.rs
+++ b/rustyfit/src/profile/mesgdef/watchface_settings.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -45,10 +45,16 @@ impl From<&Message> for WatchfaceSettings {
     /// from creates new WatchfaceSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/weather_alert.rs
+++ b/rustyfit/src/profile/mesgdef/weather_alert.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -59,10 +59,16 @@ impl From<&Message> for WeatherAlert {
     /// from creates new WeatherAlert struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -116,10 +116,16 @@ impl From<&Message> for WeatherConditions {
     /// from creates new WeatherConditions struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [32767, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/weight_scale.rs
+++ b/rustyfit/src/profile/mesgdef/weight_scale.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -261,10 +261,16 @@ impl From<&Message> for WeightScale {
     /// from creates new WeightScale struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [16319, 0, 0, 2305843009213693952];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/workout.rs
+++ b/rustyfit/src/profile/mesgdef/workout.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -85,10 +85,16 @@ impl From<&Message> for Workout {
     /// from creates new Workout struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [182640, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/workout_session.rs
+++ b/rustyfit/src/profile/mesgdef/workout_session.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -77,10 +77,16 @@ impl From<&Message> for WorkoutSession {
     /// from creates new WorkoutSession struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/workout_step.rs
+++ b/rustyfit/src/profile/mesgdef/workout_step.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -113,10 +113,16 @@ impl From<&Message> for WorkoutStep {
     /// from creates new WorkoutStep struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [7880703, 0, 0, 4611686018427387904];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }

--- a/rustyfit/src/profile/mesgdef/zones_target.rs
+++ b/rustyfit/src/profile/mesgdef/zones_target.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
 
-use crate::profile::{ProfileType, lookup, typedef};
+use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 
 #[derive(Debug, Clone)]
@@ -51,10 +51,16 @@ impl From<&Message> for ZonesTarget {
     /// from creates new ZonesTarget struct based on given mesg.
     fn from(mesg: &Message) -> Self {
         let mut vals: [&Value; 8] = [const { &Value::Invalid }; 8];
-        let mut unknown_fields: Vec<Field> = Vec::new();
+
+        const KNOWN_NUMS: [u64; 4] = [174, 0, 0, 0];
+        let mut n = 0u64;
+        for field in &mesg.fields {
+            n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
+        }
+        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if lookup::field_reference(mesg.num, field.num).is_none() {
+            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
                 unknown_fields.push(field.clone());
                 continue;
             }


### PR DESCRIPTION
Unknown fields are common in FIT files. Current code on producing unknown fields for mesgdef is not efficient enough since we dynamically allocate the vector. This PR solves it by changing the generated code to use constant value and bitwise operation on it to check the unknown fields and allocate once exactly what we needed. 

This PR eliminate the overhead of lookup and the vector grow.

### Benchmark
Rust allocates 4 capacity during first push, and allocate double of it (8 capacity) on the 5th push. Ref: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=74f4da881b22051f39bcde5ab2fcd0ec. 

This benchmark use 5 unknown fields to test the difference between alloc once, vs dynamic alloc (2x on this case):

```js
mesgdef From<&Message>  time:   [210.34 ns 212.08 ns 214.19 ns]
                        change: [-41.583% -39.638% -37.769%] (p = 0.00 < 0.05)
                        Performance has improved.
```