### PR TITLE
feat: add DateTime to Unix seconds conversion

### DIFF
--- a/fitgen/internal/profile/typedef/typedef.tmpl
+++ b/fitgen/internal/profile/typedef/typedef.tmpl
@@ -39,6 +39,31 @@ impl {{ .TypeName }} {
         0
     }
     {{ end -}}
+    
+    {{- if or (eq .TypeName "DateTime") (eq .TypeName "LocalDateTime") }}
+    /// Offset duration in secs between UNIX_EPOCH (1 January 1970 UTC) and FIT_EPOCH (31 December 1989 UTC).
+    const FIT_EPOCH_OFFSET: u64 = 631065600;
+    
+    /// Creates a new DateTime (relative to 31 December 1989 UTC) from Unix seconds (relative to 1 January 1970 UTC)
+    /// if the value is within a valid range. None otherwise.
+    pub fn new(unix_secs: u64) -> Option<{{ .TypeName }}> {
+    	let t = unix_secs.checked_sub(Self::FIT_EPOCH_OFFSET)?;
+    	if t < u32::MAX as u64 {
+            Some({{ .TypeName }}(t as u32))
+        } else {
+            None
+        }
+    }
+    
+    /// Returns Some(t) where t is Unix seconds (relative to 1 January 1970 UTC) if `self` is a valid {{ .TypeName }}. None otherwise.
+    pub fn checked_unix_secs(&self) -> Option<u64> {
+    	if self.0 == u32::MAX {
+     		None
+        } else {
+            Some(self.0 as u64 + Self::FIT_EPOCH_OFFSET)
+        }
+    }
+    {{ end -}}
 }
 
 impl Default for {{ .TypeName }} {

--- a/rustyfit/src/profile/typedef/date_time.rs
+++ b/rustyfit/src/profile/typedef/date_time.rs
@@ -14,6 +14,29 @@ pub struct DateTime(pub u32);
 impl DateTime {
     /// if date_time is < 0x10000000 then it is system time (seconds from device power on)
     pub const MIN: DateTime = DateTime(0x10000000);
+
+    /// Offset duration in secs between UNIX_EPOCH (1 January 1970 UTC) and FIT_EPOCH (31 December 1989 UTC).
+    const FIT_EPOCH_OFFSET: u64 = 631065600;
+
+    /// Creates a new DateTime (relative to 31 December 1989 UTC) from Unix seconds (relative to 1 January 1970 UTC)
+    /// if the value is within a valid range. None otherwise.
+    pub fn new(unix_secs: u64) -> Option<DateTime> {
+        let t = unix_secs.checked_sub(Self::FIT_EPOCH_OFFSET)?;
+        if t < u32::MAX as u64 {
+            Some(DateTime(t as u32))
+        } else {
+            None
+        }
+    }
+
+    /// Returns Some(t) where t is Unix seconds (relative to 1 January 1970 UTC) if `self` is a valid DateTime. None otherwise.
+    pub fn checked_unix_secs(&self) -> Option<u64> {
+        if self.0 == u32::MAX {
+            None
+        } else {
+            Some(self.0 as u64 + Self::FIT_EPOCH_OFFSET)
+        }
+    }
 }
 
 impl Default for DateTime {

--- a/rustyfit/src/profile/typedef/local_date_time.rs
+++ b/rustyfit/src/profile/typedef/local_date_time.rs
@@ -14,6 +14,29 @@ pub struct LocalDateTime(pub u32);
 impl LocalDateTime {
     /// if date_time is < 0x10000000 then it is system time (seconds from device power on)
     pub const MIN: LocalDateTime = LocalDateTime(0x10000000);
+
+    /// Offset duration in secs between UNIX_EPOCH (1 January 1970 UTC) and FIT_EPOCH (31 December 1989 UTC).
+    const FIT_EPOCH_OFFSET: u64 = 631065600;
+
+    /// Creates a new DateTime (relative to 31 December 1989 UTC) from Unix seconds (relative to 1 January 1970 UTC)
+    /// if the value is within a valid range. None otherwise.
+    pub fn new(unix_secs: u64) -> Option<LocalDateTime> {
+        let t = unix_secs.checked_sub(Self::FIT_EPOCH_OFFSET)?;
+        if t < u32::MAX as u64 {
+            Some(LocalDateTime(t as u32))
+        } else {
+            None
+        }
+    }
+
+    /// Returns Some(t) where t is Unix seconds (relative to 1 January 1970 UTC) if `self` is a valid LocalDateTime. None otherwise.
+    pub fn checked_unix_secs(&self) -> Option<u64> {
+        if self.0 == u32::MAX {
+            None
+        } else {
+            Some(self.0 as u64 + Self::FIT_EPOCH_OFFSET)
+        }
+    }
 }
 
 impl Default for LocalDateTime {


### PR DESCRIPTION
This applies to `DateTime` and `LocalDateTime`.  The new constructor `new` and method `checked_unix_secs` is added to make it easier for us to convert it into [SystemTime](https://doc.rust-lang.org/std/time/struct.SystemTime.html) or 3rd party time handling crate such as [chrono](https://crates.io/crates/chrono).

```rs
let unix_secs: u64 = 1626815480;      // 2021-07-20 21:11:20 +0000 UTC
let dt = DateTime::new(unix_secs)?;   // DateTime(995749880)
let us = dt.checked_unix_secs()?;     // 1626815480

// SystemTime { tv_sec: 1626815480, tv_nsec: 0 }
let st = SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(us))?; 
```