### PR TITLE
chore: use const when it makes sense

### DIFF
--- a/rustyfit/src/decoder/bits.rs
+++ b/rustyfit/src/decoder/bits.rs
@@ -68,15 +68,15 @@ impl Bits {
     }
 }
 
-trait AsU64 {
-    fn as_u64(&self) -> u64;
+trait AsU64: Copy {
+    fn as_u64(self) -> u64;
 }
 
 macro_rules! impl_as_u64 {
     ($($type:ident),*) => {
         $(impl AsU64 for $type {
-            fn as_u64(&self) -> u64 {
-                *self as u64
+            fn as_u64(self) -> u64 {
+                self as u64
             }
         })*
     };

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -680,7 +680,7 @@ pub struct Builder<R: Read> {
 
 impl<R: Read> Builder<R> {
     /// Create new DecoderBuilder.
-    pub fn new(reader: R) -> Self {
+    pub const fn new(reader: R) -> Self {
         Self {
             reader,
             options: Options {
@@ -692,13 +692,13 @@ impl<R: Read> Builder<R> {
 
     /// Toggle for checksum calculation (default: `true`).
     /// If you want to retrieve the data regardless its integrity, set this to `false`.
-    pub fn checksum(mut self, v: bool) -> Self {
+    pub const fn checksum(mut self, v: bool) -> Self {
         self.options.checksum = v;
         self
     }
 
     /// Toggle for field's components expansion (default: `true`).
-    pub fn expand_components(mut self, v: bool) -> Self {
+    pub const fn expand_components(mut self, v: bool) -> Self {
         self.options.expand_components = v;
         self
     }

--- a/rustyfit/src/encoder/lru.rs
+++ b/rustyfit/src/encoder/lru.rs
@@ -1,4 +1,3 @@
-#[derive(Default)]
 pub(super) struct Lru {
     items: Vec<Vec<u8>>,
     bucket: Vec<usize>,

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -111,16 +111,6 @@ struct Options {
     header_option: HeaderOption,
 }
 
-impl Default for Options {
-    fn default() -> Self {
-        Self {
-            protocol_version: ProtocolVersion(0),
-            endianness: Endianness::LittleEndian,
-            header_option: HeaderOption::Normal(0),
-        }
-    }
-}
-
 /// Encoder for encoding FIT file.
 pub struct Encoder<W: Write + Seek> {
     writer: W,
@@ -392,30 +382,34 @@ pub struct Builder<W: Write + Seek> {
 
 impl<W: Write + Seek> Builder<W> {
     /// Create new DecoderBuilder.
-    pub fn new(writer: W) -> Builder<W> {
+    pub const fn new(writer: W) -> Builder<W> {
         Self {
             writer,
-            options: Options::default(),
+            options: Options {
+                protocol_version: ProtocolVersion(0),
+                endianness: Endianness::LittleEndian,
+                header_option: HeaderOption::Normal(0),
+            },
         }
     }
 
     /// Use this protocol version.
     /// Default: `file_header.protocol_version` or `ProtocolVersion::V1`
-    pub fn protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
+    pub const fn protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
         self.options.protocol_version = protocol_version;
         self
     }
 
     /// Use this endianness.
     /// Default: `Endianness::LittleEndian`
-    pub fn endianness(mut self, endianness: Endianness) -> Self {
+    pub const fn endianness(mut self, endianness: Endianness) -> Self {
         self.options.endianness = endianness;
         self
     }
 
     /// Use this header option.
     /// Default: `HeaderOption::Normal(0)`
-    pub fn header_option(mut self, header_option: HeaderOption) -> Self {
+    pub const fn header_option(mut self, header_option: HeaderOption) -> Self {
         self.options.header_option = header_option;
         self
     }

--- a/rustyfit/src/encoder/validator.rs
+++ b/rustyfit/src/encoder/validator.rs
@@ -100,7 +100,7 @@ pub(super) struct MessageValidator {
 }
 
 impl MessageValidator {
-    pub(super) fn new() -> Self {
+    pub(super) const fn new() -> Self {
         Self {
             developer_data_index_seen: [0u64; 4],
             field_descriptions: Vec::new(),


### PR DESCRIPTION
- Builder is only consumed once and usually instantiated with constant value, let's make constant so compiler can optimize it to reduce runtime cost. Users building using non-constant value will not get the benefit.
- Also include change on
   - decoder's bits: make `Copy` as supertrait of `AsU64` trait and make `as_u64` method non reference self, copy is cheaper than reference for primitive types.
   - encoder's lru: remove derive `Default` since we don't use it anywhere, reduce compiler cost.