### PR TITLE
feat!: make decoder accumulator 64 bit

### DIFF
--- a/rustyfit/src/decoder/accumulator.rs
+++ b/rustyfit/src/decoder/accumulator.rs
@@ -9,110 +9,116 @@ impl Accumulator {
         Self { values: Vec::new() }
     }
 
-    fn collect_u32(&mut self, mesg_num: MesgNum, field_num: u8, value: u32) {
-        for v in &mut self.values {
-            if v.mesg_num == mesg_num && v.field_num == field_num {
-                v.value = value;
-                v.last = value;
-                break;
-            }
-        }
-        self.values.push(AccuValue {
-            mesg_num,
-            field_num,
-            value,
-            last: value,
-        });
-    }
-
     pub(super) fn collect(&mut self, mesg_num: MesgNum, field_num: u8, value: &Value) {
         match value {
-            Value::Uint8(v) => self.collect_u32(mesg_num, field_num, *v as u32),
-            Value::Int8(v) => self.collect_u32(mesg_num, field_num, *v as u32),
-            Value::Uint16(v) => self.collect_u32(mesg_num, field_num, *v as u32),
-            Value::Int16(v) => self.collect_u32(mesg_num, field_num, *v as u32),
-            Value::Uint32(v) => self.collect_u32(mesg_num, field_num, *v),
-            Value::Int32(v) => self.collect_u32(mesg_num, field_num, *v as u32),
-            Value::Float32(v) => self.collect_u32(mesg_num, field_num, *v as u32),
-            Value::Float64(v) => self.collect_u32(mesg_num, field_num, *v as u32),
-            Value::Int64(v) => self.collect_u32(mesg_num, field_num, *v as u32),
-            Value::Uint64(v) => self.collect_u32(mesg_num, field_num, *v as u32),
+            Value::Uint8(v) => self.collect_u64(mesg_num, field_num, *v as u64),
+            Value::Int8(v) => self.collect_u64(mesg_num, field_num, *v as u64),
+            Value::Uint16(v) => self.collect_u64(mesg_num, field_num, *v as u64),
+            Value::Int16(v) => self.collect_u64(mesg_num, field_num, *v as u64),
+            Value::Uint32(v) => self.collect_u64(mesg_num, field_num, *v as u64),
+            Value::Int32(v) => self.collect_u64(mesg_num, field_num, *v as u64),
+            Value::Float32(v) => self.collect_u64(mesg_num, field_num, *v as u64),
+            Value::Float64(v) => self.collect_u64(mesg_num, field_num, *v as u64),
+            Value::Int64(v) => self.collect_u64(mesg_num, field_num, *v as u64),
+            Value::Uint64(v) => self.collect_u64(mesg_num, field_num, *v),
             Value::VecInt8(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x as u32);
+                    self.collect_u64(mesg_num, field_num, x as u64);
                 }
             }
             Value::VecUint8(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x as u32);
+                    self.collect_u64(mesg_num, field_num, x as u64);
                 }
             }
             Value::VecInt16(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x as u32);
+                    self.collect_u64(mesg_num, field_num, x as u64);
                 }
             }
             Value::VecUint16(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x as u32);
+                    self.collect_u64(mesg_num, field_num, x as u64);
                 }
             }
             Value::VecInt32(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x as u32);
+                    self.collect_u64(mesg_num, field_num, x as u64);
                 }
             }
             Value::VecUint32(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x);
+                    self.collect_u64(mesg_num, field_num, x as u64);
                 }
             }
             Value::VecFloat32(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x as u32);
+                    self.collect_u64(mesg_num, field_num, x as u64);
                 }
             }
             Value::VecFloat64(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x as u32);
+                    self.collect_u64(mesg_num, field_num, x as u64);
                 }
             }
             Value::VecInt64(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x as u32);
+                    self.collect_u64(mesg_num, field_num, x as u64);
                 }
             }
             Value::VecUint64(v) => {
                 if let Some(&x) = v.last() {
-                    self.collect_u32(mesg_num, field_num, x as u32);
+                    self.collect_u64(mesg_num, field_num, x);
                 }
             }
             _ => {}
         }
     }
 
+    fn collect_u64(&mut self, mesg_num: MesgNum, field_num: u8, value: u64) {
+        self.values
+            .iter_mut()
+            .find(|v| v.mesg_num == mesg_num && v.field_num == field_num)
+            .and_then(|v| {
+                v.value = value;
+                v.last = value;
+                Some(())
+            })
+            .unwrap_or_else(|| {
+                self.values.push(AccuValue {
+                    mesg_num,
+                    field_num,
+                    value,
+                    last: value,
+                });
+            });
+    }
+
     pub(super) fn accumulate(
         &mut self,
         mesg_num: MesgNum,
         field_num: u8,
-        value: u32,
+        value: u64,
         bits: u8,
-    ) -> u32 {
-        for v in &mut self.values {
-            if v.mesg_num == mesg_num && v.field_num == field_num {
-                let mask: u32 = (1 << bits) - 1;
+    ) -> u64 {
+        self.values
+            .iter_mut()
+            .find(|v| v.mesg_num == mesg_num && v.field_num == field_num)
+            .and_then(|v| {
+                let mask: u64 = (1 << bits) - 1;
                 v.value += (value.wrapping_sub(v.last)) & mask;
                 v.last = value;
-                return v.value;
-            }
-        }
-        self.values.push(AccuValue {
-            mesg_num,
-            field_num,
-            value,
-            last: value,
-        });
-        value
+                Some(v.value)
+            })
+            .unwrap_or_else(|| {
+                self.values.push(AccuValue {
+                    mesg_num,
+                    field_num,
+                    value,
+                    last: value,
+                });
+                value
+            })
     }
 
     pub(super) fn reset(&mut self) {
@@ -120,9 +126,146 @@ impl Accumulator {
     }
 }
 
+#[cfg_attr(test, derive(PartialEq, Debug))]
 struct AccuValue {
     mesg_num: MesgNum,
     field_num: u8,
-    value: u32,
-    last: u32,
+    value: u64,
+    last: u64,
+}
+
+#[test]
+fn test_collect() {
+    let expected = vec![AccuValue {
+        mesg_num: MesgNum(1),
+        field_num: 1,
+        value: 2,
+        last: 2,
+    }];
+
+    let tt = [
+        Value::Int8(2),
+        Value::Uint8(2),
+        Value::Int16(2),
+        Value::Uint16(2),
+        Value::Int32(2),
+        Value::Uint32(2),
+        Value::Float32(2.0),
+        Value::Float64(2.0),
+        Value::Int64(2),
+        Value::Uint64(2),
+        Value::VecInt8(vec![1, 2]),
+        Value::VecUint8(vec![1, 2]),
+        Value::VecInt16(vec![1, 2]),
+        Value::VecUint16(vec![1, 2]),
+        Value::VecInt32(vec![1, 2]),
+        Value::VecUint32(vec![1, 2]),
+        Value::VecFloat32(vec![1.0, 2.0]),
+        Value::VecFloat64(vec![1.0, 2.0]),
+        Value::VecInt64(vec![1, 2]),
+        Value::VecUint64(vec![1, 2]),
+    ];
+
+    for tc in tt {
+        let mut accumu = Accumulator::new();
+        accumu.collect(MesgNum(1), 1, &tc);
+        assert_eq!(expected, accumu.values, "case: {:?}", tc);
+    }
+
+    let tt = [
+        Value::Invalid,
+        Value::String(String::new()),
+        Value::VecString(vec![]),
+    ];
+
+    for tc in tt {
+        let mut accumu = Accumulator::new();
+        accumu.collect(MesgNum(1), 1, &tc);
+        assert_eq!(Vec::<AccuValue>::new(), accumu.values, "case: {:?}", tc);
+    }
+}
+
+#[test]
+fn test_collect_64() {
+    let mut accumu = Accumulator::new();
+
+    accumu.collect_u64(MesgNum(0), 0, 10);
+    assert_eq!(
+        vec![AccuValue {
+            mesg_num: MesgNum(0),
+            field_num: 0,
+            value: 10,
+            last: 10
+        }],
+        accumu.values,
+    );
+
+    accumu.collect_u64(MesgNum(0), 0, 11);
+    assert_eq!(
+        vec![AccuValue {
+            mesg_num: MesgNum(0),
+            field_num: 0,
+            value: 11,
+            last: 11
+        }],
+        accumu.values,
+    );
+
+    accumu.collect_u64(MesgNum(0), 1, 11);
+    assert_eq!(
+        vec![
+            AccuValue {
+                mesg_num: MesgNum(0),
+                field_num: 0,
+                value: 11,
+                last: 11
+            },
+            AccuValue {
+                mesg_num: MesgNum(0),
+                field_num: 1,
+                value: 11,
+                last: 11
+            }
+        ],
+        accumu.values,
+    );
+}
+
+#[test]
+fn test_accumulate() {
+    let mut accumu = Accumulator::new();
+
+    accumu.collect_u64(MesgNum(1), 1, 1);
+    let val = accumu.accumulate(MesgNum(2), 2, 2, 8);
+    assert_eq!(2, val, "accumulate non-existing value");
+
+    let val = accumu.accumulate(MesgNum(1), 1, 10, 8);
+    assert_eq!(10, val, "accumulate first value");
+    assert_eq!(
+        vec![
+            AccuValue {
+                mesg_num: MesgNum(1),
+                field_num: 1,
+                value: 10,
+                last: 10,
+            },
+            AccuValue {
+                mesg_num: MesgNum(2),
+                field_num: 2,
+                value: 2,
+                last: 2,
+            }
+        ],
+        accumu.values,
+        "first value is updated, non-existing value is appended"
+    );
+}
+
+#[test]
+fn reset() {
+    let mut accumu = Accumulator::new();
+    accumu.collect_u64(MesgNum(1), 1, 1);
+    assert_eq!(1, accumu.values.len());
+    accumu.reset();
+    assert_eq!(0, accumu.values.len());
 }

--- a/rustyfit/src/decoder/bits.rs
+++ b/rustyfit/src/decoder/bits.rs
@@ -2,7 +2,7 @@ use crate::{profile::lookup, proto::Value};
 
 const N: usize = ((lookup::MAX_COMPONENT_BITS / 8) + 7) / 8;
 
-#[derive(Debug, PartialEq)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub(super) struct Bits {
     store: [u64; N],
     size: u64,
@@ -43,7 +43,7 @@ impl Bits {
         Some(bits)
     }
 
-    pub(super) fn pull(&mut self, bits: u8) -> Option<u32> {
+    pub(super) fn pull(&mut self, bits: u8) -> Option<u64> {
         if self.size == 0 {
             return None;
         }
@@ -51,7 +51,7 @@ impl Bits {
         self.size = self.size.saturating_sub(bits as u64);
 
         let mask = (1u64 << bits) - 1;
-        let val = (self.store[0] & mask) as u32;
+        let val = self.store[0] & mask;
         self.store[0] >>= bits;
 
         for i in 1..self.store.len() {
@@ -347,7 +347,7 @@ fn make_bits() {
 fn pull() {
     struct Pull {
         bits: u8,
-        value: Option<u32>,
+        value: Option<u64>,
         vbits: Bits,
     }
 

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -468,8 +468,8 @@ impl<R: Read> Decoder<R> {
             };
 
             let scaled_val = val as f64 / component.scale - component.offset;
-            val = ((scaled_val + field_ref.offset) * field_ref.scale) as u32;
-            let value = convert_u32_to_value(val, field_ref.base_type);
+            val = ((scaled_val + field_ref.offset) * field_ref.scale) as u64;
+            let value = convert_u64_to_value(val, field_ref.base_type);
 
             match mesg.fields.iter_mut().find(|v| v.num == field_num) {
                 Some(v) => {
@@ -504,7 +504,7 @@ impl<R: Read> Decoder<R> {
                 continue;
             }
 
-            let value = convert_u32_to_value(val, field_ref.base_type);
+            let value = convert_u64_to_value(val, field_ref.base_type);
             if !value.is_valid(field_ref.base_type) {
                 continue;
             }
@@ -608,7 +608,7 @@ fn slice_buffer_to_match_type_size(
     }
 }
 
-fn convert_u32_to_value(val: u32, base_type: FitBaseType) -> Value {
+fn convert_u64_to_value(val: u64, base_type: FitBaseType) -> Value {
     match base_type {
         FitBaseType::SINT8 => Value::Int8(val as i8),
         FitBaseType::ENUM | FitBaseType::BYTE | FitBaseType::UINT8 | FitBaseType::UINT8Z => {
@@ -617,11 +617,11 @@ fn convert_u32_to_value(val: u32, base_type: FitBaseType) -> Value {
         FitBaseType::SINT16 => Value::Int16(val as i16),
         FitBaseType::UINT16 | FitBaseType::UINT16Z => Value::Uint16(val as u16),
         FitBaseType::SINT32 => Value::Int32(val as i32),
-        FitBaseType::UINT32 | FitBaseType::UINT32Z => Value::Uint32(val),
+        FitBaseType::UINT32 | FitBaseType::UINT32Z => Value::Uint32(val as u32),
         FitBaseType::FLOAT32 => Value::Float32(val as f32),
         FitBaseType::FLOAT64 => Value::Float64(val as f64),
         FitBaseType::SINT64 => Value::Int64(val as i64),
-        FitBaseType::UINT64 | FitBaseType::UINT64Z => Value::Uint64(val as u64),
+        FitBaseType::UINT64 | FitBaseType::UINT64Z => Value::Uint64(val),
         _ => Value::Invalid,
     }
 }
@@ -728,5 +728,34 @@ impl<R: Read> Builder<R> {
             field_descriptions: Vec::new(),
             options: self.options,
         }
+    }
+}
+
+#[test]
+fn test_convert_u64_to_value() {
+    let input = 1u64;
+
+    let tt = [
+        (FitBaseType::SINT8, Value::Int8(1)),
+        (FitBaseType::ENUM, Value::Uint8(1)),
+        (FitBaseType::BYTE, Value::Uint8(1)),
+        (FitBaseType::UINT8, Value::Uint8(1)),
+        (FitBaseType::UINT8Z, Value::Uint8(1)),
+        (FitBaseType::SINT16, Value::Int16(1)),
+        (FitBaseType::UINT16, Value::Uint16(1)),
+        (FitBaseType::UINT16Z, Value::Uint16(1)),
+        (FitBaseType::SINT32, Value::Int32(1)),
+        (FitBaseType::UINT32, Value::Uint32(1)),
+        (FitBaseType::UINT32Z, Value::Uint32(1)),
+        (FitBaseType::FLOAT32, Value::Float32(1.0)),
+        (FitBaseType::FLOAT64, Value::Float64(1.0)),
+        (FitBaseType::SINT64, Value::Int64(1)),
+        (FitBaseType::UINT64, Value::Uint64(1)),
+        (FitBaseType::UINT64Z, Value::Uint64(1)),
+    ];
+
+    for tc in tt {
+        let val = convert_u64_to_value(input, tc.0);
+        assert_eq!(tc.1, val, "input: {:?}", tc);
     }
 }

--- a/rustyfit/src/encoder/validator.rs
+++ b/rustyfit/src/encoder/validator.rs
@@ -10,7 +10,7 @@ use crate::{
     proto::{Message, Value},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum MessageValidatorError {
     /// Message has no fields.
     NoFields,
@@ -65,7 +65,7 @@ impl fmt::Display for MessageValidatorError {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum IntegrityError {
     /// Value and base type is not align
     ValueBaseTypeNotAlign {


### PR DESCRIPTION
Garmin changed the C++ implementation of Accumulator from using `uint32` to `uint64` to support 64-bit value and they mark it as a fix in their v21.201 release. More detail about this change: https://github.com/muktihari/fit/pull/624

Also includes:
- Use iterator for more idiomatic rust
- Use `#[cfg_attr(test, derive(Debug, PartialEq))]` for internal struct in decoder when it's solely used for testing.
- Remove `derive(Clone)` from encoder's `MessageValidatorError` and `IntegrityError`.