### PR TITLE
fix: decoder compressed timestamp field profile_type from UINT32 to DATE_TIME

### DIFF
--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -332,7 +332,7 @@ impl<R: Read> Decoder<R> {
 
             mesg.fields.push(Field {
                 num: FIELD_NUM_TIMESTAMP,
-                profile_type: ProfileType::UINT32,
+                profile_type: ProfileType::DATE_TIME,
                 is_expanded: false,
                 value: Value::Uint32(self.timestamp),
             });


### PR DESCRIPTION
All timestamps in `mesgdef` use type value `typedef::DateTime`, so the Field decoded from a compressed timestamp header should have `profile_type::DATE_TIME` as well.