### PR TITLE
perf: transmute vector when converting mesgdef struct into Message

### DIFF
--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -92,6 +92,7 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			}
 
 			baseType := b.lookup.BaseType(parserField.Type)
+			rustType := baseTypeToRustTypeReplacer.Replace(baseType.String())
 
 			field := Field{
 				Num:  parserField.Num,
@@ -105,21 +106,19 @@ func (b *Builder) Build() ([]generator.Data, error) {
 				NameUpperCase: strings.ToUpper(parserField.Name),
 				String:        parserField.Name,
 				BaseType:      strings.ToUpper(baseType.String()),
-				BaseType0:     rustTypeReplacer.Replace(baseType.GoType()),
+				BaseType0:     rustType,
 				BaseType0Invalid: func() string {
 					if strings.HasSuffix(baseType.String(), "z") {
-						return fmt.Sprintf("%s::MIN", rustTypeReplacer.Replace(baseType.GoType()))
+						return fmt.Sprintf("%s::MIN", rustType)
 					}
-					return fmt.Sprintf("%s::MAX", rustTypeReplacer.Replace(baseType.GoType()))
+					return fmt.Sprintf("%s::MAX", rustType)
 				}(),
 				ProfileType: fmt.Sprintf("ProfileType::%s", strings.ToUpper(parserField.Type)),
 				MaxValue: func() string {
-					bt := baseType.GoType()
-					rtyp := rustTypeReplacer.Replace(bt)
-					if bt == "string" {
+					if rustType == "String" {
 						return ""
 					}
-					return fmt.Sprintf("%s::MAX", rtyp)
+					return fmt.Sprintf("%s::MAX", rustType)
 				}(),
 				Type:           b.transformType(parserField.Type, parserField.Array, fixedArraySize),
 				TypedValue:     b.transformTypedValue(parserField.Num, parserField.Type, parserField.Array, fixedArraySize),
@@ -334,18 +333,10 @@ func (b *Builder) createDynamicField(mesgName string, field *Field, parserField 
 	}
 }
 
-var rustTypeReplacer = strings.NewReplacer(
-	"byte", "u8",
-	"int", "i",
-	"uint", "u",
-	"float", "f",
-	"string", "String",
-)
-
 func (b *Builder) transformType(fieldType, fieldArray string, fixedArraySize byte) string {
 	var typ string
 	if v := b.lookup.BaseType(fieldType).String(); v == fieldType {
-		typ = rustTypeReplacer.Replace(b.lookup.GoType(fieldType))
+		typ = goTypeToRustTypeReplacer.Replace(b.lookup.GoType(fieldType))
 	} else {
 		typ = fmt.Sprintf("typedef::%s", strutil.ToTitle(fieldType))
 	}
@@ -361,66 +352,55 @@ func (b *Builder) transformType(fieldType, fieldArray string, fixedArraySize byt
 	return fmt.Sprintf("Vec<%s>", typ)
 }
 
-var baseTypeReplacer = strings.NewReplacer(
-	"Enum", "Uint8",
-	"Sint", "Int",
-	"Byte", "Uint8",
-)
-
 func (b *Builder) transformToProtoValue(fieldName, fieldType, array string, fixedArraySize uint8) string {
 	baseType := b.lookup.BaseType(fieldType).String()
 
-	typ := strutil.ToTitle(baseType)
-	typ = baseTypeReplacer.Replace(typ)
-	typ = strings.TrimSuffix(typ, "z")
+	valueEnum := strutil.ToTitle(baseType)
+	valueEnum = baseTypeToValueEnumReplacer.Replace(valueEnum)
+
+	rustType := baseTypeToRustTypeReplacer.Replace(baseType)
 
 	if baseType != fieldType {
 		if array != "" {
+			// SAFETY: From<T> for Message has move semantics.
 			return fmt.Sprintf(`Value::Vec%s({
-				let mut v = Vec::with_capacity(m.%s.len());
-				for x in &m.%s {
-					v.push(x.0)
-				}
-				v
-			})`, typ, fieldName, fieldName)
+				let (ptr, len, capacity) = m.%s.into_raw_parts();
+				unsafe { Vec::from_raw_parts(ptr.cast::<%s>(), len, capacity) }
+			})`, valueEnum, fieldName, rustType)
 		}
-		return fmt.Sprintf("Value::%s(m.%s.0)", typ, fieldName)
+		return fmt.Sprintf("Value::%s(m.%s.0)", valueEnum, fieldName)
 	}
 
 	if array != "" {
 		if fixedArraySize > 0 {
-			return fmt.Sprintf("Value::Vec%s(Vec::from(&m.%s))", typ, fieldName)
+			return fmt.Sprintf("Value::Vec%s(Vec::from(&m.%s))", valueEnum, fieldName)
 		}
-		return fmt.Sprintf("Value::Vec%s(m.%s)", typ, fieldName)
+		return fmt.Sprintf("Value::Vec%s(m.%s)", valueEnum, fieldName)
 	}
 
-	return fmt.Sprintf("Value::%s(m.%s)", typ, fieldName)
+	return fmt.Sprintf("Value::%s(m.%s)", valueEnum, fieldName)
 }
 
 func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedArraySize uint8) string {
 	baseType := b.lookup.BaseType(fieldType).String()
 	baseTypeTitleCase := strutil.ToTitle(baseType)
-	typ := baseTypeReplacer.Replace(baseTypeTitleCase)
-	rustType := strings.NewReplacer(
+	valueEnumType := baseTypeToValueEnumReplacer.Replace(baseTypeTitleCase)
+	rustAsType := strings.NewReplacer(
 		"enum", "u8",
 		"byte", "u8",
 		"sint", "i",
 		"uint", "u",
 		"float", "f",
-	).Replace(baseType)
-
-	if array != "" && strings.HasSuffix(typ, "z") {
-		typ = strings.TrimSuffix(typ, "z")
-	}
+	).Replace(baseType) // uint8z -> u8z (*.as_u8z())
 
 	var value string
 	if array == "" {
-		value = fmt.Sprintf(`vals[%d].as_%s()`, num, rustType)
+		value = fmt.Sprintf(`vals[%d].as_%s()`, num, rustAsType)
 	} else if fixedArraySize == 0 { // vector
-		value = fmt.Sprintf(`vals[%d].as_vec_%s()`, num, strings.TrimSuffix(rustType, "z"))
+		value = fmt.Sprintf(`vals[%d].as_vec_%s()`, num, strings.TrimSuffix(rustAsType, "z"))
 	} else { // array
-		rtype := rustTypeReplacer.Replace(strings.TrimSuffix(strings.ToLower(typ), "z"))
-		arrayValue := fmt.Sprintf("[%s::MAX; %d]", rtype, fixedArraySize)
+		rustType := baseTypeToRustTypeReplacer.Replace(baseType)
+		arrayValue := fmt.Sprintf("[%s::MAX; %d]", rustType, fixedArraySize)
 		rshValue := "*x"
 
 		if fieldType == "string" {
@@ -439,8 +419,8 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 			_ => %s,
 		}`,
 			num,
-			strings.TrimSuffix(typ, "z"),
-			rtype, fixedArraySize, arrayValue,
+			valueEnumType,
+			rustType, fixedArraySize, arrayValue,
 			rshValue,
 			arrayValue,
 		)
@@ -465,24 +445,21 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 			vs
 		},
 		_ => Vec::new(),
-	}`, num, strings.TrimSuffix(typ, "z"), typdef)
+	}`, num, strings.TrimSuffix(valueEnumType, "z"), typdef)
 }
 
 func (b *Builder) invalidValueOf(fieldType, array string, fixedArraySize byte) string {
 	baseType := b.lookup.BaseType(fieldType).String()
-	baseTypeTitleCase := strutil.ToTitle(baseType)
-	typ := baseTypeReplacer.Replace(baseTypeTitleCase)
-	typ = strings.ToLower(typ)
-	z := strings.HasSuffix(typ, "z")
-	typ = rustTypeReplacer.Replace(strings.TrimSuffix(typ, "z"))
+	rustType := baseTypeToRustTypeReplacer.Replace(baseType)
+
 	var invalid string
 	if baseType == "string" {
 		invalid = "String::new()"
 	} else {
-		if z {
-			invalid = fmt.Sprintf("%s::MIN", typ)
+		if strings.HasSuffix(baseType, "z") {
+			invalid = fmt.Sprintf("%s::MIN", rustType)
 		} else {
-			invalid = fmt.Sprintf("%s::MAX", typ)
+			invalid = fmt.Sprintf("%s::MAX", rustType)
 		}
 	}
 
@@ -494,7 +471,7 @@ func (b *Builder) invalidValueOf(fieldType, array string, fixedArraySize byte) s
 			if baseType != fieldType {
 				return fmt.Sprintf("Vec::<typedef::%s>::new()", strutil.ToTitle(fieldType))
 			}
-			return fmt.Sprintf("Vec::<%s>::new()", typ)
+			return fmt.Sprintf("Vec::<%s>::new()", rustType)
 		}
 		if baseType == "string" {
 			invalid = fmt.Sprintf("const { %s }", invalid)
@@ -536,3 +513,28 @@ func offsetOrDefault(offsets []float64, index int) float64 {
 	}
 	return 0.0
 }
+
+var baseTypeToValueEnumReplacer = strings.NewReplacer(
+	"Enum", "Uint8",
+	"Sint", "Int",
+	"Byte", "Uint8",
+	"z", "", // Uint8z -> Uint8
+)
+
+var baseTypeToRustTypeReplacer = strings.NewReplacer(
+	"enum", "u8",
+	"byte", "u8",
+	"sint", "i",
+	"uint", "u",
+	"float", "f",
+	"string", "String",
+	"z", "", // u8z -> u8
+)
+
+var goTypeToRustTypeReplacer = strings.NewReplacer(
+	"byte", "u8",
+	"int", "i",
+	"uint", "u",
+	"float", "f",
+	"string", "String",
+)

--- a/fitgen/internal/profile/typedef/typedef.tmpl
+++ b/fitgen/internal/profile/typedef/typedef.tmpl
@@ -13,6 +13,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct {{ .TypeName }}(pub {{ .Base }});
 

--- a/rustyfit/src/profile/mesgdef/aviation_attitude.rs
+++ b/rustyfit/src/profile/mesgdef/aviation_attitude.rs
@@ -419,11 +419,8 @@ impl From<AviationAttitude> for Message {
                 num: 7,
                 profile_type: ProfileType::ATTITUDE_STAGE,
                 value: Value::VecUint8({
-                    let mut v = Vec::with_capacity(m.stage.len());
-                    for x in &m.stage {
-                        v.push(x.0)
-                    }
-                    v
+                    let (ptr, len, capacity) = m.stage.into_raw_parts();
+                    unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
             };
@@ -452,11 +449,8 @@ impl From<AviationAttitude> for Message {
                 num: 10,
                 profile_type: ProfileType::ATTITUDE_VALIDITY,
                 value: Value::VecUint16({
-                    let mut v = Vec::with_capacity(m.validity.len());
-                    for x in &m.validity {
-                        v.push(x.0)
-                    }
-                    v
+                    let (ptr, len, capacity) = m.validity.into_raw_parts();
+                    unsafe { Vec::from_raw_parts(ptr.cast::<u16>(), len, capacity) }
                 }),
                 is_expanded: false,
             };

--- a/rustyfit/src/profile/mesgdef/capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/capabilities.rs
@@ -121,11 +121,8 @@ impl From<Capabilities> for Message {
                 num: 1,
                 profile_type: ProfileType::SPORT_BITS_0,
                 value: Value::VecUint8({
-                    let mut v = Vec::with_capacity(m.sports.len());
-                    for x in &m.sports {
-                        v.push(x.0)
-                    }
-                    v
+                    let (ptr, len, capacity) = m.sports.into_raw_parts();
+                    unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
             };

--- a/rustyfit/src/profile/mesgdef/device_settings.rs
+++ b/rustyfit/src/profile/mesgdef/device_settings.rs
@@ -286,11 +286,8 @@ impl From<DeviceSettings> for Message {
                 num: 4,
                 profile_type: ProfileType::TIME_MODE,
                 value: Value::VecUint8({
-                    let mut v = Vec::with_capacity(m.time_mode.len());
-                    for x in &m.time_mode {
-                        v.push(x.0)
-                    }
-                    v
+                    let (ptr, len, capacity) = m.time_mode.into_raw_parts();
+                    unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
             };

--- a/rustyfit/src/profile/mesgdef/dive_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_alarm.rs
@@ -258,11 +258,8 @@ impl From<DiveAlarm> for Message {
                 num: 5,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::VecUint8({
-                    let mut v = Vec::with_capacity(m.dive_types.len());
-                    for x in &m.dive_types {
-                        v.push(x.0)
-                    }
-                    v
+                    let (ptr, len, capacity) = m.dive_types.into_raw_parts();
+                    unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
             };

--- a/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
@@ -258,11 +258,8 @@ impl From<DiveApneaAlarm> for Message {
                 num: 5,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::VecUint8({
-                    let mut v = Vec::with_capacity(m.dive_types.len());
-                    for x in &m.dive_types {
-                        v.push(x.0)
-                    }
-                    v
+                    let (ptr, len, capacity) = m.dive_types.into_raw_parts();
+                    unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
             };

--- a/rustyfit/src/profile/mesgdef/monitoring_info.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_info.rs
@@ -201,11 +201,8 @@ impl From<MonitoringInfo> for Message {
                 num: 1,
                 profile_type: ProfileType::ACTIVITY_TYPE,
                 value: Value::VecUint8({
-                    let mut v = Vec::with_capacity(m.activity_type.len());
-                    for x in &m.activity_type {
-                        v.push(x.0)
-                    }
-                    v
+                    let (ptr, len, capacity) = m.activity_type.into_raw_parts();
+                    unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
             };

--- a/rustyfit/src/profile/mesgdef/segment_file.rs
+++ b/rustyfit/src/profile/mesgdef/segment_file.rs
@@ -177,11 +177,8 @@ impl From<SegmentFile> for Message {
                 num: 7,
                 profile_type: ProfileType::SEGMENT_LEADERBOARD_TYPE,
                 value: Value::VecUint8({
-                    let mut v = Vec::with_capacity(m.leader_type.len());
-                    for x in &m.leader_type {
-                        v.push(x.0)
-                    }
-                    v
+                    let (ptr, len, capacity) = m.leader_type.into_raw_parts();
+                    unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
             };

--- a/rustyfit/src/profile/mesgdef/set.rs
+++ b/rustyfit/src/profile/mesgdef/set.rs
@@ -241,11 +241,8 @@ impl From<Set> for Message {
                 num: 7,
                 profile_type: ProfileType::EXERCISE_CATEGORY,
                 value: Value::VecUint16({
-                    let mut v = Vec::with_capacity(m.category.len());
-                    for x in &m.category {
-                        v.push(x.0)
-                    }
-                    v
+                    let (ptr, len, capacity) = m.category.into_raw_parts();
+                    unsafe { Vec::from_raw_parts(ptr.cast::<u16>(), len, capacity) }
                 }),
                 is_expanded: false,
             };

--- a/rustyfit/src/profile/typedef/activity.rs
+++ b/rustyfit/src/profile/typedef/activity.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Activity(pub u8);
 

--- a/rustyfit/src/profile/typedef/activity_class.rs
+++ b/rustyfit/src/profile/typedef/activity_class.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ActivityClass(pub u8);
 

--- a/rustyfit/src/profile/typedef/activity_level.rs
+++ b/rustyfit/src/profile/typedef/activity_level.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ActivityLevel(pub u8);
 

--- a/rustyfit/src/profile/typedef/activity_subtype.rs
+++ b/rustyfit/src/profile/typedef/activity_subtype.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ActivitySubtype(pub u8);
 

--- a/rustyfit/src/profile/typedef/activity_type.rs
+++ b/rustyfit/src/profile/typedef/activity_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ActivityType(pub u8);
 

--- a/rustyfit/src/profile/typedef/analog_watchface_layout.rs
+++ b/rustyfit/src/profile/typedef/analog_watchface_layout.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct AnalogWatchfaceLayout(pub u8);
 

--- a/rustyfit/src/profile/typedef/ant_channel_id.rs
+++ b/rustyfit/src/profile/typedef/ant_channel_id.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct AntChannelId(pub u32);
 

--- a/rustyfit/src/profile/typedef/ant_network.rs
+++ b/rustyfit/src/profile/typedef/ant_network.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct AntNetwork(pub u8);
 

--- a/rustyfit/src/profile/typedef/antplus_device_type.rs
+++ b/rustyfit/src/profile/typedef/antplus_device_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct AntplusDeviceType(pub u8);
 

--- a/rustyfit/src/profile/typedef/attitude_stage.rs
+++ b/rustyfit/src/profile/typedef/attitude_stage.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct AttitudeStage(pub u8);
 

--- a/rustyfit/src/profile/typedef/attitude_validity.rs
+++ b/rustyfit/src/profile/typedef/attitude_validity.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct AttitudeValidity(pub u16);
 

--- a/rustyfit/src/profile/typedef/auto_activity_detect.rs
+++ b/rustyfit/src/profile/typedef/auto_activity_detect.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct AutoActivityDetect(pub u32);
 

--- a/rustyfit/src/profile/typedef/auto_sync_frequency.rs
+++ b/rustyfit/src/profile/typedef/auto_sync_frequency.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct AutoSyncFrequency(pub u8);
 

--- a/rustyfit/src/profile/typedef/autolap_trigger.rs
+++ b/rustyfit/src/profile/typedef/autolap_trigger.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct AutolapTrigger(pub u8);
 

--- a/rustyfit/src/profile/typedef/autoscroll.rs
+++ b/rustyfit/src/profile/typedef/autoscroll.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Autoscroll(pub u8);
 

--- a/rustyfit/src/profile/typedef/backlight_mode.rs
+++ b/rustyfit/src/profile/typedef/backlight_mode.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BacklightMode(pub u8);
 

--- a/rustyfit/src/profile/typedef/backlight_timeout.rs
+++ b/rustyfit/src/profile/typedef/backlight_timeout.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BacklightTimeout(pub u8);
 

--- a/rustyfit/src/profile/typedef/banded_exercises_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/banded_exercises_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BandedExercisesExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/battery_status.rs
+++ b/rustyfit/src/profile/typedef/battery_status.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BatteryStatus(pub u8);
 

--- a/rustyfit/src/profile/typedef/battle_rope_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/battle_rope_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BattleRopeExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/bench_press_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/bench_press_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BenchPressExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/bike_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/bike_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BikeExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/bike_light_beam_angle_mode.rs
+++ b/rustyfit/src/profile/typedef/bike_light_beam_angle_mode.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BikeLightBeamAngleMode(pub u8);
 

--- a/rustyfit/src/profile/typedef/bike_light_network_config_type.rs
+++ b/rustyfit/src/profile/typedef/bike_light_network_config_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BikeLightNetworkConfigType(pub u8);
 

--- a/rustyfit/src/profile/typedef/bike_outdoor_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/bike_outdoor_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BikeOutdoorExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/ble_device_type.rs
+++ b/rustyfit/src/profile/typedef/ble_device_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BleDeviceType(pub u8);
 

--- a/rustyfit/src/profile/typedef/body_location.rs
+++ b/rustyfit/src/profile/typedef/body_location.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BodyLocation(pub u8);
 

--- a/rustyfit/src/profile/typedef/bool.rs
+++ b/rustyfit/src/profile/typedef/bool.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Bool(pub u8);
 

--- a/rustyfit/src/profile/typedef/bp_status.rs
+++ b/rustyfit/src/profile/typedef/bp_status.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct BpStatus(pub u8);
 

--- a/rustyfit/src/profile/typedef/calf_raise_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/calf_raise_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CalfRaiseExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/camera_event_type.rs
+++ b/rustyfit/src/profile/typedef/camera_event_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CameraEventType(pub u8);
 

--- a/rustyfit/src/profile/typedef/camera_orientation_type.rs
+++ b/rustyfit/src/profile/typedef/camera_orientation_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CameraOrientationType(pub u8);
 

--- a/rustyfit/src/profile/typedef/cardio_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/cardio_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CardioExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/carry_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/carry_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CarryExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/ccr_setpoint_switch_mode.rs
+++ b/rustyfit/src/profile/typedef/ccr_setpoint_switch_mode.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CcrSetpointSwitchMode(pub u8);
 

--- a/rustyfit/src/profile/typedef/checksum.rs
+++ b/rustyfit/src/profile/typedef/checksum.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Checksum(pub u8);
 

--- a/rustyfit/src/profile/typedef/chop_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/chop_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ChopExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/climb_pro_event.rs
+++ b/rustyfit/src/profile/typedef/climb_pro_event.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ClimbProEvent(pub u8);
 

--- a/rustyfit/src/profile/typedef/comm_timeout_type.rs
+++ b/rustyfit/src/profile/typedef/comm_timeout_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CommTimeoutType(pub u16);
 

--- a/rustyfit/src/profile/typedef/connectivity_capabilities.rs
+++ b/rustyfit/src/profile/typedef/connectivity_capabilities.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ConnectivityCapabilities(pub u32);
 

--- a/rustyfit/src/profile/typedef/core_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/core_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CoreExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/course_capabilities.rs
+++ b/rustyfit/src/profile/typedef/course_capabilities.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CourseCapabilities(pub u32);
 

--- a/rustyfit/src/profile/typedef/course_point.rs
+++ b/rustyfit/src/profile/typedef/course_point.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CoursePoint(pub u8);
 

--- a/rustyfit/src/profile/typedef/crunch_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/crunch_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CrunchExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/curl_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/curl_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct CurlExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/date_mode.rs
+++ b/rustyfit/src/profile/typedef/date_mode.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DateMode(pub u8);
 

--- a/rustyfit/src/profile/typedef/date_time.rs
+++ b/rustyfit/src/profile/typedef/date_time.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DateTime(pub u32);
 

--- a/rustyfit/src/profile/typedef/day_of_week.rs
+++ b/rustyfit/src/profile/typedef/day_of_week.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DayOfWeek(pub u8);
 

--- a/rustyfit/src/profile/typedef/deadlift_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/deadlift_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DeadliftExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/device_index.rs
+++ b/rustyfit/src/profile/typedef/device_index.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DeviceIndex(pub u8);
 

--- a/rustyfit/src/profile/typedef/digital_watchface_layout.rs
+++ b/rustyfit/src/profile/typedef/digital_watchface_layout.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DigitalWatchfaceLayout(pub u8);
 

--- a/rustyfit/src/profile/typedef/display_heart.rs
+++ b/rustyfit/src/profile/typedef/display_heart.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DisplayHeart(pub u8);
 

--- a/rustyfit/src/profile/typedef/display_measure.rs
+++ b/rustyfit/src/profile/typedef/display_measure.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DisplayMeasure(pub u8);
 

--- a/rustyfit/src/profile/typedef/display_orientation.rs
+++ b/rustyfit/src/profile/typedef/display_orientation.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DisplayOrientation(pub u8);
 

--- a/rustyfit/src/profile/typedef/display_position.rs
+++ b/rustyfit/src/profile/typedef/display_position.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DisplayPosition(pub u8);
 

--- a/rustyfit/src/profile/typedef/display_power.rs
+++ b/rustyfit/src/profile/typedef/display_power.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DisplayPower(pub u8);
 

--- a/rustyfit/src/profile/typedef/dive_alarm_type.rs
+++ b/rustyfit/src/profile/typedef/dive_alarm_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DiveAlarmType(pub u8);
 

--- a/rustyfit/src/profile/typedef/dive_alert.rs
+++ b/rustyfit/src/profile/typedef/dive_alert.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DiveAlert(pub u8);
 

--- a/rustyfit/src/profile/typedef/dive_backlight_mode.rs
+++ b/rustyfit/src/profile/typedef/dive_backlight_mode.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DiveBacklightMode(pub u8);
 

--- a/rustyfit/src/profile/typedef/dive_gas_mode.rs
+++ b/rustyfit/src/profile/typedef/dive_gas_mode.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DiveGasMode(pub u8);
 

--- a/rustyfit/src/profile/typedef/dive_gas_status.rs
+++ b/rustyfit/src/profile/typedef/dive_gas_status.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct DiveGasStatus(pub u8);
 

--- a/rustyfit/src/profile/typedef/elliptical_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/elliptical_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct EllipticalExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/event.rs
+++ b/rustyfit/src/profile/typedef/event.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Event(pub u8);
 

--- a/rustyfit/src/profile/typedef/event_type.rs
+++ b/rustyfit/src/profile/typedef/event_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct EventType(pub u8);
 

--- a/rustyfit/src/profile/typedef/exd_data_units.rs
+++ b/rustyfit/src/profile/typedef/exd_data_units.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ExdDataUnits(pub u8);
 

--- a/rustyfit/src/profile/typedef/exd_descriptors.rs
+++ b/rustyfit/src/profile/typedef/exd_descriptors.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ExdDescriptors(pub u8);
 

--- a/rustyfit/src/profile/typedef/exd_display_type.rs
+++ b/rustyfit/src/profile/typedef/exd_display_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ExdDisplayType(pub u8);
 

--- a/rustyfit/src/profile/typedef/exd_layout.rs
+++ b/rustyfit/src/profile/typedef/exd_layout.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ExdLayout(pub u8);
 

--- a/rustyfit/src/profile/typedef/exd_qualifiers.rs
+++ b/rustyfit/src/profile/typedef/exd_qualifiers.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ExdQualifiers(pub u8);
 

--- a/rustyfit/src/profile/typedef/exercise_category.rs
+++ b/rustyfit/src/profile/typedef/exercise_category.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ExerciseCategory(pub u16);
 

--- a/rustyfit/src/profile/typedef/favero_product.rs
+++ b/rustyfit/src/profile/typedef/favero_product.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct FaveroProduct(pub u16);
 

--- a/rustyfit/src/profile/typedef/file.rs
+++ b/rustyfit/src/profile/typedef/file.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct File(pub u8);
 

--- a/rustyfit/src/profile/typedef/file_flags.rs
+++ b/rustyfit/src/profile/typedef/file_flags.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct FileFlags(pub u8);
 

--- a/rustyfit/src/profile/typedef/fit_base_type.rs
+++ b/rustyfit/src/profile/typedef/fit_base_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct FitBaseType(pub u8);
 

--- a/rustyfit/src/profile/typedef/fit_base_unit.rs
+++ b/rustyfit/src/profile/typedef/fit_base_unit.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct FitBaseUnit(pub u16);
 

--- a/rustyfit/src/profile/typedef/fitness_equipment_state.rs
+++ b/rustyfit/src/profile/typedef/fitness_equipment_state.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct FitnessEquipmentState(pub u8);
 

--- a/rustyfit/src/profile/typedef/floor_climb_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/floor_climb_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct FloorClimbExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/flye_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/flye_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct FlyeExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/garmin_product.rs
+++ b/rustyfit/src/profile/typedef/garmin_product.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct GarminProduct(pub u16);
 

--- a/rustyfit/src/profile/typedef/gas_consumption_rate_type.rs
+++ b/rustyfit/src/profile/typedef/gas_consumption_rate_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct GasConsumptionRateType(pub u8);
 

--- a/rustyfit/src/profile/typedef/gender.rs
+++ b/rustyfit/src/profile/typedef/gender.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Gender(pub u8);
 

--- a/rustyfit/src/profile/typedef/goal.rs
+++ b/rustyfit/src/profile/typedef/goal.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Goal(pub u8);
 

--- a/rustyfit/src/profile/typedef/goal_recurrence.rs
+++ b/rustyfit/src/profile/typedef/goal_recurrence.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct GoalRecurrence(pub u8);
 

--- a/rustyfit/src/profile/typedef/goal_source.rs
+++ b/rustyfit/src/profile/typedef/goal_source.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct GoalSource(pub u8);
 

--- a/rustyfit/src/profile/typedef/hip_raise_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/hip_raise_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct HipRaiseExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/hip_stability_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/hip_stability_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct HipStabilityExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/hip_swing_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/hip_swing_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct HipSwingExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/hr_type.rs
+++ b/rustyfit/src/profile/typedef/hr_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct HrType(pub u8);
 

--- a/rustyfit/src/profile/typedef/hr_zone_calc.rs
+++ b/rustyfit/src/profile/typedef/hr_zone_calc.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct HrZoneCalc(pub u8);
 

--- a/rustyfit/src/profile/typedef/hrv_status.rs
+++ b/rustyfit/src/profile/typedef/hrv_status.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct HrvStatus(pub u8);
 

--- a/rustyfit/src/profile/typedef/hyperextension_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/hyperextension_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct HyperextensionExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/indoor_bike_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/indoor_bike_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct IndoorBikeExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/indoor_row_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/indoor_row_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct IndoorRowExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/intensity.rs
+++ b/rustyfit/src/profile/typedef/intensity.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Intensity(pub u8);
 

--- a/rustyfit/src/profile/typedef/ladder_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/ladder_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LadderExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/language.rs
+++ b/rustyfit/src/profile/typedef/language.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Language(pub u8);
 

--- a/rustyfit/src/profile/typedef/language_bits_0.rs
+++ b/rustyfit/src/profile/typedef/language_bits_0.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LanguageBits0(pub u8);
 

--- a/rustyfit/src/profile/typedef/language_bits_1.rs
+++ b/rustyfit/src/profile/typedef/language_bits_1.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LanguageBits1(pub u8);
 

--- a/rustyfit/src/profile/typedef/language_bits_2.rs
+++ b/rustyfit/src/profile/typedef/language_bits_2.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LanguageBits2(pub u8);
 

--- a/rustyfit/src/profile/typedef/language_bits_3.rs
+++ b/rustyfit/src/profile/typedef/language_bits_3.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LanguageBits3(pub u8);
 

--- a/rustyfit/src/profile/typedef/language_bits_4.rs
+++ b/rustyfit/src/profile/typedef/language_bits_4.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LanguageBits4(pub u8);
 

--- a/rustyfit/src/profile/typedef/lap_trigger.rs
+++ b/rustyfit/src/profile/typedef/lap_trigger.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LapTrigger(pub u8);
 

--- a/rustyfit/src/profile/typedef/lateral_raise_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/lateral_raise_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LateralRaiseExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/left_right_balance.rs
+++ b/rustyfit/src/profile/typedef/left_right_balance.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LeftRightBalance(pub u8);
 

--- a/rustyfit/src/profile/typedef/left_right_balance_100.rs
+++ b/rustyfit/src/profile/typedef/left_right_balance_100.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LeftRightBalance100(pub u16);
 

--- a/rustyfit/src/profile/typedef/leg_curl_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/leg_curl_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LegCurlExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/leg_raise_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/leg_raise_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LegRaiseExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/length_type.rs
+++ b/rustyfit/src/profile/typedef/length_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LengthType(pub u8);
 

--- a/rustyfit/src/profile/typedef/local_date_time.rs
+++ b/rustyfit/src/profile/typedef/local_date_time.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LocalDateTime(pub u32);
 

--- a/rustyfit/src/profile/typedef/local_device_type.rs
+++ b/rustyfit/src/profile/typedef/local_device_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LocalDeviceType(pub u8);
 

--- a/rustyfit/src/profile/typedef/localtime_into_day.rs
+++ b/rustyfit/src/profile/typedef/localtime_into_day.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LocaltimeIntoDay(pub u32);
 

--- a/rustyfit/src/profile/typedef/lunge_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/lunge_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct LungeExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/manufacturer.rs
+++ b/rustyfit/src/profile/typedef/manufacturer.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Manufacturer(pub u16);
 

--- a/rustyfit/src/profile/typedef/max_met_category.rs
+++ b/rustyfit/src/profile/typedef/max_met_category.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct MaxMetCategory(pub u8);
 

--- a/rustyfit/src/profile/typedef/max_met_heart_rate_source.rs
+++ b/rustyfit/src/profile/typedef/max_met_heart_rate_source.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct MaxMetHeartRateSource(pub u8);
 

--- a/rustyfit/src/profile/typedef/max_met_speed_source.rs
+++ b/rustyfit/src/profile/typedef/max_met_speed_source.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct MaxMetSpeedSource(pub u8);
 

--- a/rustyfit/src/profile/typedef/mesg_count.rs
+++ b/rustyfit/src/profile/typedef/mesg_count.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct MesgCount(pub u8);
 

--- a/rustyfit/src/profile/typedef/mesg_num.rs
+++ b/rustyfit/src/profile/typedef/mesg_num.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct MesgNum(pub u16);
 

--- a/rustyfit/src/profile/typedef/message_index.rs
+++ b/rustyfit/src/profile/typedef/message_index.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct MessageIndex(pub u16);
 

--- a/rustyfit/src/profile/typedef/move_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/move_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct MoveExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/nap_period_feedback.rs
+++ b/rustyfit/src/profile/typedef/nap_period_feedback.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct NapPeriodFeedback(pub u8);
 

--- a/rustyfit/src/profile/typedef/nap_source.rs
+++ b/rustyfit/src/profile/typedef/nap_source.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct NapSource(pub u8);
 

--- a/rustyfit/src/profile/typedef/no_fly_time_mode.rs
+++ b/rustyfit/src/profile/typedef/no_fly_time_mode.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct NoFlyTimeMode(pub u8);
 

--- a/rustyfit/src/profile/typedef/olympic_lift_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/olympic_lift_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct OlympicLiftExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/plank_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/plank_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct PlankExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/plyo_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/plyo_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct PlyoExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/pose_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/pose_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct PoseExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/power_phase_type.rs
+++ b/rustyfit/src/profile/typedef/power_phase_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct PowerPhaseType(pub u8);
 

--- a/rustyfit/src/profile/typedef/projectile_type.rs
+++ b/rustyfit/src/profile/typedef/projectile_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ProjectileType(pub u8);
 

--- a/rustyfit/src/profile/typedef/pull_up_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/pull_up_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct PullUpExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/push_up_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/push_up_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct PushUpExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/pwr_zone_calc.rs
+++ b/rustyfit/src/profile/typedef/pwr_zone_calc.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct PwrZoneCalc(pub u8);
 

--- a/rustyfit/src/profile/typedef/radar_threat_level_type.rs
+++ b/rustyfit/src/profile/typedef/radar_threat_level_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct RadarThreatLevelType(pub u8);
 

--- a/rustyfit/src/profile/typedef/rider_position_type.rs
+++ b/rustyfit/src/profile/typedef/rider_position_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct RiderPositionType(pub u8);
 

--- a/rustyfit/src/profile/typedef/row_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/row_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct RowExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/run_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/run_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct RunExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/run_indoor_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/run_indoor_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct RunIndoorExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/sandbag_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/sandbag_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SandbagExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/schedule.rs
+++ b/rustyfit/src/profile/typedef/schedule.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Schedule(pub u8);
 

--- a/rustyfit/src/profile/typedef/segment_delete_status.rs
+++ b/rustyfit/src/profile/typedef/segment_delete_status.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SegmentDeleteStatus(pub u8);
 

--- a/rustyfit/src/profile/typedef/segment_lap_status.rs
+++ b/rustyfit/src/profile/typedef/segment_lap_status.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SegmentLapStatus(pub u8);
 

--- a/rustyfit/src/profile/typedef/segment_leaderboard_type.rs
+++ b/rustyfit/src/profile/typedef/segment_leaderboard_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SegmentLeaderboardType(pub u8);
 

--- a/rustyfit/src/profile/typedef/segment_selection_type.rs
+++ b/rustyfit/src/profile/typedef/segment_selection_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SegmentSelectionType(pub u8);
 

--- a/rustyfit/src/profile/typedef/sensor_type.rs
+++ b/rustyfit/src/profile/typedef/sensor_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SensorType(pub u8);
 

--- a/rustyfit/src/profile/typedef/session_trigger.rs
+++ b/rustyfit/src/profile/typedef/session_trigger.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SessionTrigger(pub u8);
 

--- a/rustyfit/src/profile/typedef/set_type.rs
+++ b/rustyfit/src/profile/typedef/set_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SetType(pub u8);
 

--- a/rustyfit/src/profile/typedef/shoulder_press_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/shoulder_press_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ShoulderPressExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/shoulder_stability_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/shoulder_stability_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ShoulderStabilityExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/shrug_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/shrug_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct ShrugExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/side.rs
+++ b/rustyfit/src/profile/typedef/side.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Side(pub u8);
 

--- a/rustyfit/src/profile/typedef/sit_up_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/sit_up_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SitUpExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/sled_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/sled_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SledExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/sledge_hammer_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/sledge_hammer_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SledgeHammerExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/sleep_disruption_severity.rs
+++ b/rustyfit/src/profile/typedef/sleep_disruption_severity.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SleepDisruptionSeverity(pub u8);
 

--- a/rustyfit/src/profile/typedef/sleep_level.rs
+++ b/rustyfit/src/profile/typedef/sleep_level.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SleepLevel(pub u8);
 

--- a/rustyfit/src/profile/typedef/source_type.rs
+++ b/rustyfit/src/profile/typedef/source_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SourceType(pub u8);
 

--- a/rustyfit/src/profile/typedef/split_type.rs
+++ b/rustyfit/src/profile/typedef/split_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SplitType(pub u8);
 

--- a/rustyfit/src/profile/typedef/spo2_measurement_type.rs
+++ b/rustyfit/src/profile/typedef/spo2_measurement_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Spo2MeasurementType(pub u8);
 

--- a/rustyfit/src/profile/typedef/sport.rs
+++ b/rustyfit/src/profile/typedef/sport.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Sport(pub u8);
 

--- a/rustyfit/src/profile/typedef/sport_bits_0.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_0.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SportBits0(pub u8);
 

--- a/rustyfit/src/profile/typedef/sport_bits_1.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_1.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SportBits1(pub u8);
 

--- a/rustyfit/src/profile/typedef/sport_bits_2.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_2.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SportBits2(pub u8);
 

--- a/rustyfit/src/profile/typedef/sport_bits_3.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_3.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SportBits3(pub u8);
 

--- a/rustyfit/src/profile/typedef/sport_bits_4.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_4.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SportBits4(pub u8);
 

--- a/rustyfit/src/profile/typedef/sport_bits_5.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_5.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SportBits5(pub u8);
 

--- a/rustyfit/src/profile/typedef/sport_bits_6.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_6.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SportBits6(pub u8);
 

--- a/rustyfit/src/profile/typedef/sport_event.rs
+++ b/rustyfit/src/profile/typedef/sport_event.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SportEvent(pub u8);
 

--- a/rustyfit/src/profile/typedef/squat_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/squat_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SquatExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/stair_stepper_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/stair_stepper_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct StairStepperExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/stroke_type.rs
+++ b/rustyfit/src/profile/typedef/stroke_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct StrokeType(pub u8);
 

--- a/rustyfit/src/profile/typedef/sub_sport.rs
+++ b/rustyfit/src/profile/typedef/sub_sport.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SubSport(pub u8);
 

--- a/rustyfit/src/profile/typedef/supported_exd_screen_layouts.rs
+++ b/rustyfit/src/profile/typedef/supported_exd_screen_layouts.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SupportedExdScreenLayouts(pub u32);
 

--- a/rustyfit/src/profile/typedef/suspension_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/suspension_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SuspensionExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/swim_stroke.rs
+++ b/rustyfit/src/profile/typedef/swim_stroke.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SwimStroke(pub u8);
 

--- a/rustyfit/src/profile/typedef/switch.rs
+++ b/rustyfit/src/profile/typedef/switch.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Switch(pub u8);
 

--- a/rustyfit/src/profile/typedef/tap_sensitivity.rs
+++ b/rustyfit/src/profile/typedef/tap_sensitivity.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TapSensitivity(pub u8);
 

--- a/rustyfit/src/profile/typedef/time_into_day.rs
+++ b/rustyfit/src/profile/typedef/time_into_day.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TimeIntoDay(pub u32);
 

--- a/rustyfit/src/profile/typedef/time_mode.rs
+++ b/rustyfit/src/profile/typedef/time_mode.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TimeMode(pub u8);
 

--- a/rustyfit/src/profile/typedef/time_zone.rs
+++ b/rustyfit/src/profile/typedef/time_zone.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TimeZone(pub u8);
 

--- a/rustyfit/src/profile/typedef/timer_trigger.rs
+++ b/rustyfit/src/profile/typedef/timer_trigger.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TimerTrigger(pub u8);
 

--- a/rustyfit/src/profile/typedef/tire_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/tire_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TireExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/tissue_model_type.rs
+++ b/rustyfit/src/profile/typedef/tissue_model_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TissueModelType(pub u8);
 

--- a/rustyfit/src/profile/typedef/tone.rs
+++ b/rustyfit/src/profile/typedef/tone.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Tone(pub u8);
 

--- a/rustyfit/src/profile/typedef/total_body_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/total_body_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TotalBodyExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/triceps_extension_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/triceps_extension_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TricepsExtensionExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/turn_type.rs
+++ b/rustyfit/src/profile/typedef/turn_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TurnType(pub u8);
 

--- a/rustyfit/src/profile/typedef/user_local_id.rs
+++ b/rustyfit/src/profile/typedef/user_local_id.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct UserLocalId(pub u16);
 

--- a/rustyfit/src/profile/typedef/warm_up_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/warm_up_exercise_name.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WarmUpExerciseName(pub u16);
 

--- a/rustyfit/src/profile/typedef/watchface_mode.rs
+++ b/rustyfit/src/profile/typedef/watchface_mode.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WatchfaceMode(pub u8);
 

--- a/rustyfit/src/profile/typedef/water_type.rs
+++ b/rustyfit/src/profile/typedef/water_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WaterType(pub u8);
 

--- a/rustyfit/src/profile/typedef/weather_report.rs
+++ b/rustyfit/src/profile/typedef/weather_report.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WeatherReport(pub u8);
 

--- a/rustyfit/src/profile/typedef/weather_severe_type.rs
+++ b/rustyfit/src/profile/typedef/weather_severe_type.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WeatherSevereType(pub u8);
 

--- a/rustyfit/src/profile/typedef/weather_severity.rs
+++ b/rustyfit/src/profile/typedef/weather_severity.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WeatherSeverity(pub u8);
 

--- a/rustyfit/src/profile/typedef/weather_status.rs
+++ b/rustyfit/src/profile/typedef/weather_status.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WeatherStatus(pub u8);
 

--- a/rustyfit/src/profile/typedef/weight.rs
+++ b/rustyfit/src/profile/typedef/weight.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct Weight(pub u16);
 

--- a/rustyfit/src/profile/typedef/wkt_step_duration.rs
+++ b/rustyfit/src/profile/typedef/wkt_step_duration.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WktStepDuration(pub u8);
 

--- a/rustyfit/src/profile/typedef/wkt_step_target.rs
+++ b/rustyfit/src/profile/typedef/wkt_step_target.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WktStepTarget(pub u8);
 

--- a/rustyfit/src/profile/typedef/workout_capabilities.rs
+++ b/rustyfit/src/profile/typedef/workout_capabilities.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WorkoutCapabilities(pub u32);
 

--- a/rustyfit/src/profile/typedef/workout_equipment.rs
+++ b/rustyfit/src/profile/typedef/workout_equipment.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WorkoutEquipment(pub u8);
 

--- a/rustyfit/src/profile/typedef/workout_hr.rs
+++ b/rustyfit/src/profile/typedef/workout_hr.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WorkoutHr(pub u32);
 

--- a/rustyfit/src/profile/typedef/workout_power.rs
+++ b/rustyfit/src/profile/typedef/workout_power.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct WorkoutPower(pub u32);
 


### PR DESCRIPTION
Since converting mesgdef's struct into `proto::Message` is a move semantics, allocating another vector just for converting vector of the same underlying value is unnecessary (e.g. converting `Vec::<typedef::AttitudeStage>` into `Vec::<u8>`) . To ensure we safely transmute a vector into another vector we need to ensure the element of the vector shares the same memory layout. In this case, we need to make typedef's  structs `#[repr(transparent)]` and only then we can safely transmute the vector using `Vec::from_raw_parts`. UB otherwise.

Ref: 
- https://github.com/rust-lang/rust-clippy/issues/4484

- https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent
> #[repr(transparent)] can only be used on a struct or single-variant enum that has a single non-zero-sized field (there may be additional zero-sized fields). The effect is that the layout and ABI of the whole struct/enum is guaranteed to be the same as that one field.
>
> The goal is to make it possible to transmute between the single field and the struct/enum. An example of that is [UnsafeCell](https://doc.rust-lang.org/std/cell/struct.UnsafeCell.html), which can be transmuted into the type it wraps ([UnsafeCell](https://doc.rust-lang.org/std/cell/struct.UnsafeCell.html) also uses the unstable [no_niche](https://github.com/rust-lang/rust/pull/68491), so its ABI is not actually guaranteed to be the same when nested in other types).


- https://doc.rust-lang.org/std/mem/fn.transmute.html#alternatives
```rs
// This is the proper no-copy, unsafe way of "transmuting" a `Vec`, without relying on the
// data layout. Instead of literally calling `transmute`, we perform a pointer cast, but
// in terms of converting the original inner type (`&i32`) to the new one (`Option<&i32>`),
// this has all the same caveats. Besides the information provided above, also consult the
// [`from_raw_parts`] documentation.
let (ptr, len, capacity) = v_clone.into_raw_parts();
let v_from_raw = unsafe {
    Vec::from_raw_parts(ptr.cast::<*mut Option<&i32>>(), len, capacity)
};
```