### PR TITLE
chore: fix tests mod

### DIFF
--- a/rustyfit/src/crc16.rs
+++ b/rustyfit/src/crc16.rs
@@ -34,17 +34,21 @@ impl Crc16 {
 }
 
 #[cfg(test)]
-#[test]
-fn test_all() {
-    let b: [u8; 12] = [14, 32, 84, 8, 214, 204, 9, 0, 46, 70, 73, 84];
-    let expected: u16 = 12856;
+mod tests {
+    use crate::crc16::Crc16;
 
-    let mut c = Crc16::new();
-    c.write(&b);
+    #[test]
+    fn test_all() {
+        let b: [u8; 12] = [14, 32, 84, 8, 214, 204, 9, 0, 46, 70, 73, 84];
+        let expected: u16 = 12856;
 
-    assert_eq!(c.sum16(), expected);
+        let mut c = Crc16::new();
+        c.write(&b);
 
-    c.reset();
+        assert_eq!(c.sum16(), expected);
 
-    assert_eq!(c.sum16(), 0);
+        c.reset();
+
+        assert_eq!(c.sum16(), 0);
+    }
 }

--- a/rustyfit/src/decoder/accumulator.rs
+++ b/rustyfit/src/decoder/accumulator.rs
@@ -133,138 +133,147 @@ struct AccuValue {
     last: u64,
 }
 
-#[test]
-fn test_collect() {
-    let expected = vec![AccuValue {
-        mesg_num: MesgNum(1),
-        field_num: 1,
-        value: 2,
-        last: 2,
-    }];
+#[cfg(test)]
+mod tests {
+    use crate::{
+        decoder::{Accumulator, accumulator::AccuValue},
+        profile::typedef::MesgNum,
+        proto::Value,
+    };
 
-    let tt = [
-        Value::Int8(2),
-        Value::Uint8(2),
-        Value::Int16(2),
-        Value::Uint16(2),
-        Value::Int32(2),
-        Value::Uint32(2),
-        Value::Float32(2.0),
-        Value::Float64(2.0),
-        Value::Int64(2),
-        Value::Uint64(2),
-        Value::VecInt8(vec![1, 2]),
-        Value::VecUint8(vec![1, 2]),
-        Value::VecInt16(vec![1, 2]),
-        Value::VecUint16(vec![1, 2]),
-        Value::VecInt32(vec![1, 2]),
-        Value::VecUint32(vec![1, 2]),
-        Value::VecFloat32(vec![1.0, 2.0]),
-        Value::VecFloat64(vec![1.0, 2.0]),
-        Value::VecInt64(vec![1, 2]),
-        Value::VecUint64(vec![1, 2]),
-    ];
+    #[test]
+    fn test_collect() {
+        let expected = vec![AccuValue {
+            mesg_num: MesgNum(1),
+            field_num: 1,
+            value: 2,
+            last: 2,
+        }];
 
-    for tc in tt {
-        let mut accumu = Accumulator::new();
-        accumu.collect(MesgNum(1), 1, &tc);
-        assert_eq!(expected, accumu.values, "case: {:?}", tc);
+        let tt = [
+            Value::Int8(2),
+            Value::Uint8(2),
+            Value::Int16(2),
+            Value::Uint16(2),
+            Value::Int32(2),
+            Value::Uint32(2),
+            Value::Float32(2.0),
+            Value::Float64(2.0),
+            Value::Int64(2),
+            Value::Uint64(2),
+            Value::VecInt8(vec![1, 2]),
+            Value::VecUint8(vec![1, 2]),
+            Value::VecInt16(vec![1, 2]),
+            Value::VecUint16(vec![1, 2]),
+            Value::VecInt32(vec![1, 2]),
+            Value::VecUint32(vec![1, 2]),
+            Value::VecFloat32(vec![1.0, 2.0]),
+            Value::VecFloat64(vec![1.0, 2.0]),
+            Value::VecInt64(vec![1, 2]),
+            Value::VecUint64(vec![1, 2]),
+        ];
+
+        for tc in tt {
+            let mut accumu = Accumulator::new();
+            accumu.collect(MesgNum(1), 1, &tc);
+            assert_eq!(expected, accumu.values, "case: {:?}", tc);
+        }
+
+        let tt = [
+            Value::Invalid,
+            Value::String(String::new()),
+            Value::VecString(vec![]),
+        ];
+
+        for tc in tt {
+            let mut accumu = Accumulator::new();
+            accumu.collect(MesgNum(1), 1, &tc);
+            assert_eq!(Vec::<AccuValue>::new(), accumu.values, "case: {:?}", tc);
+        }
     }
 
-    let tt = [
-        Value::Invalid,
-        Value::String(String::new()),
-        Value::VecString(vec![]),
-    ];
-
-    for tc in tt {
+    #[test]
+    fn test_collect_64() {
         let mut accumu = Accumulator::new();
-        accumu.collect(MesgNum(1), 1, &tc);
-        assert_eq!(Vec::<AccuValue>::new(), accumu.values, "case: {:?}", tc);
-    }
-}
 
-#[test]
-fn test_collect_64() {
-    let mut accumu = Accumulator::new();
+        accumu.collect_u64(MesgNum(0), 0, 10);
+        assert_eq!(
+            vec![AccuValue {
+                mesg_num: MesgNum(0),
+                field_num: 0,
+                value: 10,
+                last: 10
+            }],
+            accumu.values,
+        );
 
-    accumu.collect_u64(MesgNum(0), 0, 10);
-    assert_eq!(
-        vec![AccuValue {
-            mesg_num: MesgNum(0),
-            field_num: 0,
-            value: 10,
-            last: 10
-        }],
-        accumu.values,
-    );
-
-    accumu.collect_u64(MesgNum(0), 0, 11);
-    assert_eq!(
-        vec![AccuValue {
-            mesg_num: MesgNum(0),
-            field_num: 0,
-            value: 11,
-            last: 11
-        }],
-        accumu.values,
-    );
-
-    accumu.collect_u64(MesgNum(0), 1, 11);
-    assert_eq!(
-        vec![
-            AccuValue {
+        accumu.collect_u64(MesgNum(0), 0, 11);
+        assert_eq!(
+            vec![AccuValue {
                 mesg_num: MesgNum(0),
                 field_num: 0,
                 value: 11,
                 last: 11
-            },
-            AccuValue {
-                mesg_num: MesgNum(0),
-                field_num: 1,
-                value: 11,
-                last: 11
-            }
-        ],
-        accumu.values,
-    );
-}
+            }],
+            accumu.values,
+        );
 
-#[test]
-fn test_accumulate() {
-    let mut accumu = Accumulator::new();
+        accumu.collect_u64(MesgNum(0), 1, 11);
+        assert_eq!(
+            vec![
+                AccuValue {
+                    mesg_num: MesgNum(0),
+                    field_num: 0,
+                    value: 11,
+                    last: 11
+                },
+                AccuValue {
+                    mesg_num: MesgNum(0),
+                    field_num: 1,
+                    value: 11,
+                    last: 11
+                }
+            ],
+            accumu.values,
+        );
+    }
 
-    accumu.collect_u64(MesgNum(1), 1, 1);
-    let val = accumu.accumulate(MesgNum(2), 2, 2, 8);
-    assert_eq!(2, val, "accumulate non-existing value");
+    #[test]
+    fn test_accumulate() {
+        let mut accumu = Accumulator::new();
 
-    let val = accumu.accumulate(MesgNum(1), 1, 10, 8);
-    assert_eq!(10, val, "accumulate first value");
-    assert_eq!(
-        vec![
-            AccuValue {
-                mesg_num: MesgNum(1),
-                field_num: 1,
-                value: 10,
-                last: 10,
-            },
-            AccuValue {
-                mesg_num: MesgNum(2),
-                field_num: 2,
-                value: 2,
-                last: 2,
-            }
-        ],
-        accumu.values,
-        "first value is updated, non-existing value is appended"
-    );
-}
+        accumu.collect_u64(MesgNum(1), 1, 1);
+        let val = accumu.accumulate(MesgNum(2), 2, 2, 8);
+        assert_eq!(2, val, "accumulate non-existing value");
 
-#[test]
-fn reset() {
-    let mut accumu = Accumulator::new();
-    accumu.collect_u64(MesgNum(1), 1, 1);
-    assert_eq!(1, accumu.values.len());
-    accumu.reset();
-    assert_eq!(0, accumu.values.len());
+        let val = accumu.accumulate(MesgNum(1), 1, 10, 8);
+        assert_eq!(10, val, "accumulate first value");
+        assert_eq!(
+            vec![
+                AccuValue {
+                    mesg_num: MesgNum(1),
+                    field_num: 1,
+                    value: 10,
+                    last: 10,
+                },
+                AccuValue {
+                    mesg_num: MesgNum(2),
+                    field_num: 2,
+                    value: 2,
+                    last: 2,
+                }
+            ],
+            accumu.values,
+            "first value is updated, non-existing value is appended"
+        );
+    }
+
+    #[test]
+    fn reset() {
+        let mut accumu = Accumulator::new();
+        accumu.collect_u64(MesgNum(1), 1, 1);
+        assert_eq!(1, accumu.values.len());
+        accumu.reset();
+        assert_eq!(0, accumu.values.len());
+    }
 }

--- a/rustyfit/src/decoder/bits.rs
+++ b/rustyfit/src/decoder/bits.rs
@@ -97,381 +97,388 @@ fn bits_from_slice<T: AsU64>(v: &mut Bits, s: &[T], bitsize: usize) {
 }
 
 #[cfg(test)]
-#[test]
-fn make_bits() {
-    struct TestCase {
-        value: Value,
-        expected: Option<Bits>,
-    }
+mod tests {
+    use crate::{
+        decoder::{Bits, bits::N},
+        proto::Value,
+    };
 
-    let tt = vec![
-        TestCase {
-            value: Value::Int8(10),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 8,
-            }),
-        },
-        TestCase {
-            value: Value::Uint8(10),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 8,
-            }),
-        },
-        TestCase {
-            value: Value::Int16(10),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 16,
-            }),
-        },
-        TestCase {
-            value: Value::Uint16(10),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 16,
-            }),
-        },
-        TestCase {
-            value: Value::Int32(10),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 32,
-            }),
-        },
-        TestCase {
-            value: Value::Uint32(10),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 32,
-            }),
-        },
-        TestCase {
-            value: Value::Float32(10.0),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 32,
-            }),
-        },
-        TestCase {
-            value: Value::Float64(10.0),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 64,
-            }),
-        },
-        TestCase {
-            value: Value::Int64(10),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 64,
-            }),
-        },
-        TestCase {
-            value: Value::Uint64(10),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 64,
-            }),
-        },
-        TestCase {
-            value: Value::VecInt8(vec![1, 2]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1 | (2 << 8);
-                    tmp
-                },
-                size: 16,
-            }),
-        },
-        TestCase {
-            value: Value::VecUint8(vec![1, 2]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1 | (2 << 8);
-                    tmp
-                },
-                size: 16,
-            }),
-        },
-        TestCase {
-            value: Value::VecInt16(vec![1, 2]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1 | (2 << 16);
-                    tmp
-                },
-                size: 32,
-            }),
-        },
-        TestCase {
-            value: Value::VecUint16(vec![1, 2]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1 | (2 << 16);
-                    tmp
-                },
-                size: 32,
-            }),
-        },
-        TestCase {
-            value: Value::VecInt32(vec![1, 2]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1 | (2 << 32);
-                    tmp
-                },
-                size: 64,
-            }),
-        },
-        TestCase {
-            value: Value::VecUint32(vec![1, 2]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1 | (2 << 32);
-                    tmp
-                },
-                size: 64,
-            }),
-        },
-        TestCase {
-            value: Value::VecFloat32(vec![1.0, 2.0]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1 | (2 << 32);
-                    tmp
-                },
-                size: 64,
-            }),
-        },
-        TestCase {
-            value: Value::VecFloat64(vec![1.0, 2.0]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1;
-                    tmp[1] = 2;
-                    tmp
-                },
-                size: 128,
-            }),
-        },
-        TestCase {
-            value: Value::VecInt64(vec![1, 2]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1;
-                    tmp[1] = 2;
-                    tmp
-                },
-                size: 128,
-            }),
-        },
-        TestCase {
-            value: Value::VecUint64(vec![1, 2]),
-            expected: Some(Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1;
-                    tmp[1] = 2;
-                    tmp
-                },
-                size: 128,
-            }),
-        },
-        TestCase {
-            value: Value::VecUint8(vec![0; 255]),
-            expected: Some(Bits {
-                store: [0u64; N],
-                size: 64 * (N as u64),
-            }),
-        },
-    ];
+    #[test]
+    fn make_bits() {
+        struct TestCase {
+            value: Value,
+            expected: Option<Bits>,
+        }
 
-    for tc in tt {
-        let vbits = Bits::new(&tc.value);
-        assert_eq!(tc.expected, vbits)
-    }
-}
-
-#[test]
-fn pull() {
-    struct Pull {
-        bits: u8,
-        value: Option<u64>,
-        vbits: Bits,
-    }
-
-    struct TestCase {
-        name: &'static str,
-        vbits: Bits,
-        pulls: Vec<Pull>,
-    }
-
-    let mut tt = vec![
-        TestCase {
-            name: "single value one pull",
-            vbits: Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 10;
-                    tmp
-                },
-                size: 8,
-            },
-            pulls: vec![Pull {
-                bits: 8,
-                value: Some(10),
-                vbits: Bits {
-                    store: [0u64; N],
-                    size: 0,
-                },
-            }],
-        },
-        TestCase {
-            name: "single value two pull",
-            vbits: Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 1 | 2 << 8;
-                    tmp
-                },
-                size: 16,
-            },
-            pulls: vec![
-                Pull {
-                    bits: 8,
-                    value: Some(1),
-                    vbits: Bits {
-                        store: {
-                            let mut tmp = [0u64; N];
-                            tmp[0] = 2;
-                            tmp
-                        },
-                        size: 8,
+        let tt = vec![
+            TestCase {
+                value: Value::Int8(10),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
                     },
+                    size: 8,
+                }),
+            },
+            TestCase {
+                value: Value::Uint8(10),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 8,
+                }),
+            },
+            TestCase {
+                value: Value::Int16(10),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 16,
+                }),
+            },
+            TestCase {
+                value: Value::Uint16(10),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 16,
+                }),
+            },
+            TestCase {
+                value: Value::Int32(10),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 32,
+                }),
+            },
+            TestCase {
+                value: Value::Uint32(10),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 32,
+                }),
+            },
+            TestCase {
+                value: Value::Float32(10.0),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 32,
+                }),
+            },
+            TestCase {
+                value: Value::Float64(10.0),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 64,
+                }),
+            },
+            TestCase {
+                value: Value::Int64(10),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 64,
+                }),
+            },
+            TestCase {
+                value: Value::Uint64(10),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 64,
+                }),
+            },
+            TestCase {
+                value: Value::VecInt8(vec![1, 2]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1 | (2 << 8);
+                        tmp
+                    },
+                    size: 16,
+                }),
+            },
+            TestCase {
+                value: Value::VecUint8(vec![1, 2]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1 | (2 << 8);
+                        tmp
+                    },
+                    size: 16,
+                }),
+            },
+            TestCase {
+                value: Value::VecInt16(vec![1, 2]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1 | (2 << 16);
+                        tmp
+                    },
+                    size: 32,
+                }),
+            },
+            TestCase {
+                value: Value::VecUint16(vec![1, 2]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1 | (2 << 16);
+                        tmp
+                    },
+                    size: 32,
+                }),
+            },
+            TestCase {
+                value: Value::VecInt32(vec![1, 2]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1 | (2 << 32);
+                        tmp
+                    },
+                    size: 64,
+                }),
+            },
+            TestCase {
+                value: Value::VecUint32(vec![1, 2]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1 | (2 << 32);
+                        tmp
+                    },
+                    size: 64,
+                }),
+            },
+            TestCase {
+                value: Value::VecFloat32(vec![1.0, 2.0]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1 | (2 << 32);
+                        tmp
+                    },
+                    size: 64,
+                }),
+            },
+            TestCase {
+                value: Value::VecFloat64(vec![1.0, 2.0]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1;
+                        tmp[1] = 2;
+                        tmp
+                    },
+                    size: 128,
+                }),
+            },
+            TestCase {
+                value: Value::VecInt64(vec![1, 2]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1;
+                        tmp[1] = 2;
+                        tmp
+                    },
+                    size: 128,
+                }),
+            },
+            TestCase {
+                value: Value::VecUint64(vec![1, 2]),
+                expected: Some(Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 1;
+                        tmp[1] = 2;
+                        tmp
+                    },
+                    size: 128,
+                }),
+            },
+            TestCase {
+                value: Value::VecUint8(vec![0; 255]),
+                expected: Some(Bits {
+                    store: [0u64; N],
+                    size: 64 * (N as u64),
+                }),
+            },
+        ];
+
+        for tc in tt {
+            let vbits = Bits::new(&tc.value);
+            assert_eq!(tc.expected, vbits)
+        }
+    }
+
+    #[test]
+    fn pull() {
+        struct Pull {
+            bits: u8,
+            value: Option<u64>,
+            vbits: Bits,
+        }
+
+        struct TestCase {
+            name: &'static str,
+            vbits: Bits,
+            pulls: Vec<Pull>,
+        }
+
+        let mut tt = vec![
+            TestCase {
+                name: "single value one pull",
+                vbits: Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 10;
+                        tmp
+                    },
+                    size: 8,
                 },
-                Pull {
+                pulls: vec![Pull {
                     bits: 8,
-                    value: Some(2),
+                    value: Some(10),
                     vbits: Bits {
                         store: [0u64; N],
                         size: 0,
                     },
-                },
-            ],
-        },
-        TestCase {
-            name: "multiple value one pull",
-            vbits: Bits {
-                store: {
-                    let mut tmp = [0u64; N];
-                    tmp[0] = 0x0000_0000_2701_0E08;
-                    tmp[1] = 0x0000_0000_0000_FFFF;
-                    tmp
-                },
-                size: 128,
+                }],
             },
-            pulls: vec![Pull {
-                bits: 8,
-                value: Some(0x08),
+            TestCase {
+                name: "single value two pull",
                 vbits: Bits {
                     store: {
                         let mut tmp = [0u64; N];
-                        tmp[0] = 0xFF00_0000_0027_010E;
-                        tmp[1] = 0x0000_0000_0000_00FF;
+                        tmp[0] = 1 | 2 << 8;
                         tmp
                     },
-                    size: 120,
+                    size: 16,
                 },
-            }],
-        },
-        TestCase {
-            name: "size is already zero",
-            vbits: Bits {
-                store: [0u64; N],
-                size: 0,
+                pulls: vec![
+                    Pull {
+                        bits: 8,
+                        value: Some(1),
+                        vbits: Bits {
+                            store: {
+                                let mut tmp = [0u64; N];
+                                tmp[0] = 2;
+                                tmp
+                            },
+                            size: 8,
+                        },
+                    },
+                    Pull {
+                        bits: 8,
+                        value: Some(2),
+                        vbits: Bits {
+                            store: [0u64; N],
+                            size: 0,
+                        },
+                    },
+                ],
             },
-            pulls: vec![Pull {
-                bits: 8,
-                value: None,
+            TestCase {
+                name: "multiple value one pull",
+                vbits: Bits {
+                    store: {
+                        let mut tmp = [0u64; N];
+                        tmp[0] = 0x0000_0000_2701_0E08;
+                        tmp[1] = 0x0000_0000_0000_FFFF;
+                        tmp
+                    },
+                    size: 128,
+                },
+                pulls: vec![Pull {
+                    bits: 8,
+                    value: Some(0x08),
+                    vbits: Bits {
+                        store: {
+                            let mut tmp = [0u64; N];
+                            tmp[0] = 0xFF00_0000_0027_010E;
+                            tmp[1] = 0x0000_0000_0000_00FF;
+                            tmp
+                        },
+                        size: 120,
+                    },
+                }],
+            },
+            TestCase {
+                name: "size is already zero",
                 vbits: Bits {
                     store: [0u64; N],
                     size: 0,
                 },
-            }],
-        },
-        TestCase {
-            name: "size 8 bits, pull 16 bits, return 8 bits",
-            vbits: Bits {
-                store: [0u64; N],
-                size: 8,
+                pulls: vec![Pull {
+                    bits: 8,
+                    value: None,
+                    vbits: Bits {
+                        store: [0u64; N],
+                        size: 0,
+                    },
+                }],
             },
-            pulls: vec![Pull {
-                bits: 16,
-                value: Some(0),
+            TestCase {
+                name: "size 8 bits, pull 16 bits, return 8 bits",
                 vbits: Bits {
                     store: [0u64; N],
-                    size: 0,
+                    size: 8,
                 },
-            }],
-        },
-    ];
+                pulls: vec![Pull {
+                    bits: 16,
+                    value: Some(0),
+                    vbits: Bits {
+                        store: [0u64; N],
+                        size: 0,
+                    },
+                }],
+            },
+        ];
 
-    for tc in &mut tt {
-        for (i, pull) in &mut tc.pulls.iter_mut().enumerate() {
-            let value = tc.vbits.pull(pull.bits);
-            assert_eq!(pull.value, value, "{}: pulls[{}]", tc.name, i);
-            assert_eq!(tc.vbits, pull.vbits, "{}: pills[{}]", tc.name, i);
+        for tc in &mut tt {
+            for (i, pull) in &mut tc.pulls.iter_mut().enumerate() {
+                let value = tc.vbits.pull(pull.bits);
+                assert_eq!(pull.value, value, "{}: pulls[{}]", tc.name, i);
+                assert_eq!(tc.vbits, pull.vbits, "{}: pills[{}]", tc.name, i);
+            }
         }
     }
 }

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -725,31 +725,36 @@ impl<R: Read> Builder<R> {
     }
 }
 
-#[test]
-fn test_convert_u64_to_value() {
-    let input = 1u64;
+#[cfg(test)]
+mod tests {
+    use crate::{decoder::convert_u64_to_value, profile::typedef::FitBaseType, proto::Value};
 
-    let tt = [
-        (FitBaseType::SINT8, Value::Int8(1)),
-        (FitBaseType::ENUM, Value::Uint8(1)),
-        (FitBaseType::BYTE, Value::Uint8(1)),
-        (FitBaseType::UINT8, Value::Uint8(1)),
-        (FitBaseType::UINT8Z, Value::Uint8(1)),
-        (FitBaseType::SINT16, Value::Int16(1)),
-        (FitBaseType::UINT16, Value::Uint16(1)),
-        (FitBaseType::UINT16Z, Value::Uint16(1)),
-        (FitBaseType::SINT32, Value::Int32(1)),
-        (FitBaseType::UINT32, Value::Uint32(1)),
-        (FitBaseType::UINT32Z, Value::Uint32(1)),
-        (FitBaseType::FLOAT32, Value::Float32(1.0)),
-        (FitBaseType::FLOAT64, Value::Float64(1.0)),
-        (FitBaseType::SINT64, Value::Int64(1)),
-        (FitBaseType::UINT64, Value::Uint64(1)),
-        (FitBaseType::UINT64Z, Value::Uint64(1)),
-    ];
+    #[test]
+    fn test_convert_u64_to_value() {
+        let input = 1u64;
 
-    for tc in tt {
-        let val = convert_u64_to_value(input, tc.0);
-        assert_eq!(tc.1, val, "input: {:?}", tc);
+        let tt = [
+            (FitBaseType::SINT8, Value::Int8(1)),
+            (FitBaseType::ENUM, Value::Uint8(1)),
+            (FitBaseType::BYTE, Value::Uint8(1)),
+            (FitBaseType::UINT8, Value::Uint8(1)),
+            (FitBaseType::UINT8Z, Value::Uint8(1)),
+            (FitBaseType::SINT16, Value::Int16(1)),
+            (FitBaseType::UINT16, Value::Uint16(1)),
+            (FitBaseType::UINT16Z, Value::Uint16(1)),
+            (FitBaseType::SINT32, Value::Int32(1)),
+            (FitBaseType::UINT32, Value::Uint32(1)),
+            (FitBaseType::UINT32Z, Value::Uint32(1)),
+            (FitBaseType::FLOAT32, Value::Float32(1.0)),
+            (FitBaseType::FLOAT64, Value::Float64(1.0)),
+            (FitBaseType::SINT64, Value::Int64(1)),
+            (FitBaseType::UINT64, Value::Uint64(1)),
+            (FitBaseType::UINT64Z, Value::Uint64(1)),
+        ];
+
+        for tc in tt {
+            let val = convert_u64_to_value(input, tc.0);
+            assert_eq!(tc.1, val, "input: {:?}", tc);
+        }
     }
 }

--- a/rustyfit/src/encoder/lru.rs
+++ b/rustyfit/src/encoder/lru.rs
@@ -61,40 +61,44 @@ impl Lru {
 }
 
 #[cfg(test)]
-#[test]
-fn test_lru() {
-    const SIZE: usize = 16;
-    let mut lru = Lru::new(SIZE);
+mod tests {
+    use crate::encoder::Lru;
 
-    assert_eq!(lru.bucket.len(), 0);
-    assert_eq!(lru.bucket.capacity(), SIZE);
-    assert_eq!(lru.items.len(), SIZE);
-    assert_eq!(lru.items.capacity(), SIZE);
+    #[test]
+    fn test_lru() {
+        const SIZE: usize = 16;
+        let mut lru = Lru::new(SIZE);
 
-    // place (size * 10) different items, the lru will be shifted in roundroubin order.
-    for i in 0..SIZE * 10 {
-        let mut b = vec![0u8; i + 1];
-        b[0] = i as u8;
-        let (local_mesg_num, is_new) = lru.put(&b);
-        assert_eq!(local_mesg_num, (i % SIZE) as u8);
-        assert!(is_new);
+        assert_eq!(lru.bucket.len(), 0);
+        assert_eq!(lru.bucket.capacity(), SIZE);
+        assert_eq!(lru.items.len(), SIZE);
+        assert_eq!(lru.items.capacity(), SIZE);
+
+        // place (size * 10) different items, the lru will be shifted in roundroubin order.
+        for i in 0..SIZE * 10 {
+            let mut b = vec![0u8; i + 1];
+            b[0] = i as u8;
+            let (local_mesg_num, is_new) = lru.put(&b);
+            assert_eq!(local_mesg_num, (i % SIZE) as u8);
+            assert!(is_new);
+        }
+
+        // put same items should shift the lru bucket
+        for i in 0..SIZE {
+            let item = lru.items[i].clone();
+            let (local_mesg_num, _) = lru.put(&item);
+            assert_eq!(local_mesg_num, i as u8);
+            assert_eq!(lru.bucket[SIZE - 1], i);
+        }
+
+        // check index exist
+        assert_eq!(lru.bucket_index(&lru.items[lru.bucket[1]]), Some(1));
+
+        // check index not exist
+        assert!(lru.bucket_index(&[255, 255]).is_none());
+
+        lru.reset();
+        assert_eq!(lru.bucket.len(), 0);
+        assert_eq!(lru.items.len(), SIZE);
     }
-
-    // put same items should shift the lru bucket
-    for i in 0..SIZE {
-        let item = lru.items[i].clone();
-        let (local_mesg_num, _) = lru.put(&item);
-        assert_eq!(local_mesg_num, i as u8);
-        assert_eq!(lru.bucket[SIZE - 1], i);
-    }
-
-    // check index exist
-    assert_eq!(lru.bucket_index(&lru.items[lru.bucket[1]]), Some(1));
-
-    // check index not exist
-    assert!(lru.bucket_index(&[255, 255]).is_none());
-
-    lru.reset();
-    assert_eq!(lru.bucket.len(), 0);
-    assert_eq!(lru.items.len(), SIZE);
 }

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -436,72 +436,79 @@ impl<W: Write + Seek> Builder<W> {
 }
 
 #[cfg(test)]
-#[test]
-fn compress_timestamp_into_header() {
-    use crate::profile::{mesgdef, typedef};
-    use std::io::Cursor;
+mod tests {
+    use crate::{
+        Encoder,
+        proto::{COMPRESSED_TIME_MASK, MESG_COMPRESSED_HEADER_MASK, Message},
+    };
 
-    let meter: u32 = 100;
+    #[test]
+    fn compress_timestamp_into_header() {
+        use crate::profile::{mesgdef, typedef};
+        use std::io::Cursor;
 
-    let mut mesgs = vec![
-        {
-            let mut file_id = mesgdef::FileId::new();
-            file_id.manufacturer = typedef::Manufacturer::DEVELOPMENT;
-            Message::from(file_id)
-        },
-        {
-            let mut rec = mesgdef::Record::new();
-            rec.timestamp = typedef::DateTime(0);
-            rec.distance = 100 * meter;
-            Message::from(rec)
-        },
-        {
-            let mut rec = mesgdef::Record::new();
-            rec.timestamp = DateTime(1062594924);
-            rec.distance = 200 * meter;
-            Message::from(rec)
-        },
-        {
-            let mut rec = mesgdef::Record::new();
-            rec.timestamp = DateTime(1062594925);
-            rec.distance = 300 * meter;
-            Message::from(rec)
-        },
-    ];
+        let meter: u32 = 100;
 
-    let expected = vec![
-        {
-            let mut file_id = mesgdef::FileId::new();
-            file_id.manufacturer = typedef::Manufacturer::DEVELOPMENT;
-            Message::from(file_id) // Nothing's changed since no timestamp
-        },
-        {
-            let mut rec = mesgdef::Record::new();
-            rec.timestamp = typedef::DateTime(0); // Keep since timestamp <= DateTime::MIN
-            rec.distance = 100 * meter;
-            Message::from(rec)
-        },
-        {
-            let mut rec = mesgdef::Record::new();
-            rec.timestamp = DateTime(1062594924); // Keep since first timestamp 
-            rec.distance = 200 * meter;
-            Message::from(rec)
-        },
-        {
-            let mut rec = mesgdef::Record::new();
-            // Timestamp is compressed into header since roll over < 32
-            rec.distance = 300 * meter;
-            let mut mesg = Message::from(rec);
-            mesg.header |=
-                MESG_COMPRESSED_HEADER_MASK | (1062594925 & COMPRESSED_TIME_MASK as u32) as u8;
-            mesg
-        },
-    ];
+        let mut mesgs = vec![
+            {
+                let mut file_id = mesgdef::FileId::new();
+                file_id.manufacturer = typedef::Manufacturer::DEVELOPMENT;
+                Message::from(file_id)
+            },
+            {
+                let mut rec = mesgdef::Record::new();
+                rec.timestamp = typedef::DateTime(0);
+                rec.distance = 100 * meter;
+                Message::from(rec)
+            },
+            {
+                let mut rec = mesgdef::Record::new();
+                rec.timestamp = typedef::DateTime(1062594924);
+                rec.distance = 200 * meter;
+                Message::from(rec)
+            },
+            {
+                let mut rec = mesgdef::Record::new();
+                rec.timestamp = typedef::DateTime(1062594925);
+                rec.distance = 300 * meter;
+                Message::from(rec)
+            },
+        ];
 
-    let mut enc = Encoder::new(Cursor::new(Vec::new()));
-    for mesg in mesgs.iter_mut() {
-        enc.compress_timestamp_into_header(mesg);
+        let expected = vec![
+            {
+                let mut file_id = mesgdef::FileId::new();
+                file_id.manufacturer = typedef::Manufacturer::DEVELOPMENT;
+                Message::from(file_id) // Nothing's changed since no timestamp
+            },
+            {
+                let mut rec = mesgdef::Record::new();
+                rec.timestamp = typedef::DateTime(0); // Keep since timestamp <= DateTime::MIN
+                rec.distance = 100 * meter;
+                Message::from(rec)
+            },
+            {
+                let mut rec = mesgdef::Record::new();
+                rec.timestamp = typedef::DateTime(1062594924); // Keep since first timestamp 
+                rec.distance = 200 * meter;
+                Message::from(rec)
+            },
+            {
+                let mut rec = mesgdef::Record::new();
+                // Timestamp is compressed into header since roll over < 32
+                rec.distance = 300 * meter;
+                let mut mesg = Message::from(rec);
+                mesg.header |=
+                    MESG_COMPRESSED_HEADER_MASK | (1062594925 & COMPRESSED_TIME_MASK as u32) as u8;
+                mesg
+            },
+        ];
+
+        let mut enc = Encoder::new(Cursor::new(Vec::new()));
+        for mesg in mesgs.iter_mut() {
+            enc.compress_timestamp_into_header(mesg);
+        }
+
+        assert_eq!(mesgs, expected);
     }
-
-    assert_eq!(mesgs, expected);
 }

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -1,22 +1,20 @@
-use std::{fs, io, path::PathBuf};
+use rustyfit::{Decoder, DecoderError, EncoderBuilder, Endianness};
+use std::error::Error;
+use std::{fs, path::PathBuf};
+use std::{
+    fs::File,
+    io::{BufReader, Cursor, Seek, SeekFrom},
+    path::Path,
+};
 
-#[cfg(test)]
 #[test]
 fn decode_encode_roundtrip() {
-    use std::{
-        fs::File,
-        io::{BufReader, Cursor, Seek, SeekFrom},
-        path::Path,
-    };
-
-    use rustyfit::{Decoder, DecoderError, EncoderBuilder, Endianness};
-
     let path = Path::new("tests/data").to_path_buf();
+    let mut buf = Vec::<u8>::with_capacity(5_000 >> 10); // 5 MB, large enough to avoid realloc.
 
-    let walk_fn = |path: &PathBuf| {
+    walk_path(&path, &mut |path: &PathBuf| {
         let file = File::open(path).unwrap();
         let br = BufReader::new(file);
-        let mut buf = Vec::<u8>::with_capacity(10_000 >> 10); // 10 MB, large enough to avoid realloc.
         let mut dec = Decoder::new(br);
 
         'decode: while let Some(fit) = &mut match dec.decode() {
@@ -33,36 +31,77 @@ fn decode_encode_roundtrip() {
                         }
                     }
                 }
-                panic!("decode: {:?}, err: {:?}", path, err);
+                return Err(format!("decode: {:?}", err).into());
             }
         } {
+            buf.clear();
             let mut cursor = Cursor::new(&mut buf);
 
             let mut enc = EncoderBuilder::new(&mut cursor)
                 .endianness(Endianness::BigEndian)
                 .build();
 
+            let expected_messages = fit.messages.clone(); // Must clone since encoder mutates the value.
+
             if let Err(err) = enc.encode(fit) {
-                panic!("encode: {:?}, err: {:?}", path, err);
+                return Err(format!("encode: {:?}", err).into());
             }
 
             cursor.seek(SeekFrom::Start(0)).unwrap();
 
             let mut dec = Decoder::new(&mut cursor);
-            if let Err(err) = dec.decode() {
-                panic!("re-decode the encoded file: {:?}, err: {:?}", path, err);
+            let result_fit = match dec.decode() {
+                Ok(result_fit) => result_fit,
+                Err(err) => {
+                    return Err(format!("re-decode the encoded file: {:?}", err).into());
+                }
+            };
+
+            let result_messages = result_fit.unwrap().messages;
+
+            if result_messages.len() == 0 || result_messages.len() != expected_messages.len() {
+                return Err(format!(
+                    "unexpected messages len, expected: {}, got: {}",
+                    expected_messages.len(),
+                    result_messages.len()
+                )
+                .into());
             }
 
-            buf.clear();
-        }
-    };
+            for (i, mesg) in expected_messages
+                .iter()
+                .zip(result_messages.iter())
+                .enumerate()
+            {
+                if mesg.0.num != mesg.1.num {
+                    return Err(format!(
+                        "mesg num mismatch for mesg index {}, expected: {}, got: {}",
+                        i, mesg.0.num, mesg.1.num
+                    )
+                    .into());
+                }
 
-    if let Err(err) = walk_path(&path, &walk_fn) {
-        panic!("walk_path: {}", err);
-    }
+                if mesg.0.fields.len() != mesg.1.fields.len() {
+                    return Err(format!(
+                        "fields len mismatch for mesg index {} num {}, expected: {}, got: {}",
+                        i,
+                        mesg.0.num,
+                        mesg.0.fields.len(),
+                        mesg.1.fields.len()
+                    )
+                    .into());
+                }
+            }
+        }
+        Ok(())
+    })
+    .unwrap()
 }
 
-fn walk_path<F: Fn(&PathBuf)>(path: &PathBuf, f: &F) -> Result<(), io::Error> {
+fn walk_path<F>(path: &PathBuf, f: &mut F) -> Result<(), Box<dyn Error>>
+where
+    F: FnMut(&PathBuf) -> Result<(), Box<dyn Error>>,
+{
     let dir = fs::read_dir(path)?;
 
     for entry in dir.flatten() {
@@ -72,7 +111,9 @@ fn walk_path<F: Fn(&PathBuf)>(path: &PathBuf, f: &F) -> Result<(), io::Error> {
             continue;
         }
         if path.extension().is_some_and(|ext| ext == "fit") {
-            f(&path);
+            if let Err(err) = f(&path) {
+                return Err(format!("path: {:?}, err: {:?}", path, err).into());
+            };
         }
     }
     Ok(())


### PR DESCRIPTION
- All unit tests should be wrapped under `mod tests` for compile optimization
  ```rs
  #[cfg(test)]
  mod tests { }
  ```
  Integration test under `./tests` folder does not need to define `#[cfg(test)]`
- Improve integration tests `roundtrip.rs` to also compare the resulting message len and its fields len with the original fit. The field's value may be different due to the decoder and encoder logic, but we ensure the result is partially identical by comparing the len.