### PR TITLE
fix: handling compressed timestamp

### DIFF
--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -65,6 +65,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {}
 
 /// Event is FIT segments encountered by the Decoder.
+#[derive(Debug)]
 pub enum Event<'a> {
     /// Returned when the Decoder encounter FileHeader.
     FileHeader(&'a FileHeader),
@@ -233,8 +234,8 @@ impl<R: Read> Decoder<R> {
                 continue;
             }
 
-            let local_mesg_num = match header & COMPRESSED_TIME_MASK {
-                COMPRESSED_TIME_MASK => {
+            let local_mesg_num = match header & MESG_COMPRESSED_HEADER_MASK {
+                MESG_COMPRESSED_HEADER_MASK => {
                     (header & COMPRESSED_LOCAL_MESG_NUM_MASK) >> COMPRESSED_BIT_SHIFT
                 }
                 _ => header,
@@ -321,7 +322,9 @@ impl<R: Read> Decoder<R> {
     ) -> Result<(), Error> {
         if mesg.header & MESG_COMPRESSED_HEADER_MASK == MESG_COMPRESSED_HEADER_MASK {
             let time_offset = mesg.header & COMPRESSED_TIME_MASK;
-            self.timestamp += ((time_offset - self.last_time_offset) & COMPRESSED_TIME_MASK) as u32;
+            self.timestamp = self.timestamp.wrapping_add(
+                (time_offset.wrapping_sub(self.last_time_offset) & COMPRESSED_TIME_MASK) as u32,
+            );
             self.last_time_offset = time_offset;
 
             mesg.fields.push(Field {

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -85,6 +85,7 @@ impl error::Error for Error {}
 /// Available options: Normal(0-15), Compressed(0-3).
 ///
 /// Default: Normal(0)
+#[derive(Clone, Copy)]
 pub enum HeaderOption {
     /// Set Normal Header with the number of maximum message definition interleave allowed.
     /// Valid value: 0-15;

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -313,7 +313,7 @@ impl<W: Write + Seek> Encoder<W> {
             return;
         }
 
-        if (timestamp - self.timestamp_reference) as u8 > COMPRESSED_TIME_MASK {
+        if timestamp.wrapping_sub(self.timestamp_reference) as u8 > COMPRESSED_TIME_MASK {
             self.timestamp_reference = timestamp;
             return;
         }

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -1,4 +1,4 @@
-use rustyfit::{Decoder, DecoderError, EncoderBuilder, Endianness};
+use rustyfit::{Decoder, DecoderError, EncoderBuilder, Endianness, HeaderOption};
 use std::error::Error;
 use std::{fs, path::PathBuf};
 use std::{
@@ -91,6 +91,71 @@ fn decode_encode_roundtrip() {
                     )
                     .into());
                 }
+            }
+        }
+        Ok(())
+    })
+    .unwrap()
+}
+
+#[test]
+fn decode_encode_roundtrip_compressed() {
+    let path = Path::new("tests/data").to_path_buf();
+    let mut buf = Vec::<u8>::with_capacity(5_000 >> 10); // 5 MB, large enough to avoid realloc.
+
+    walk_path(&path, &mut |path: &PathBuf| {
+        let file = File::open(path).unwrap();
+        let br = BufReader::new(file);
+        let mut dec = Decoder::new(br);
+
+        'decode: while let Some(fit) = &mut match dec.decode() {
+            Ok(fit) => fit,
+            Err(err) => {
+                if let DecoderError::ChecksumMismatch { .. } = err {
+                    if let Some(file_name) = path.file_name() {
+                        // NOTE: Doubts exist regarding the integrity of these files.
+                        if ["WeightScaleMultiUser.fit", "Settings.fit"]
+                            .iter()
+                            .any(|x| *x == file_name)
+                        {
+                            continue 'decode;
+                        }
+                    }
+                }
+                return Err(format!("decode: {:?}", err).into());
+            }
+        } {
+            buf.clear();
+            let mut cursor = Cursor::new(&mut buf);
+
+            let mut enc = EncoderBuilder::new(&mut cursor)
+                .header_option(HeaderOption::Compressed(3))
+                .build();
+
+            if let Err(err) = enc.encode(fit) {
+                return Err(format!("encode: {:?}", err).into());
+            }
+
+            cursor.seek(SeekFrom::Start(0)).unwrap();
+
+            let mut dec = Decoder::new(&mut cursor);
+            let result_fit = match dec.decode() {
+                Ok(result_fit) => result_fit,
+                Err(err) => {
+                    return Err(format!("re-decode the encoded file: {:?}", err).into());
+                }
+            };
+
+            let result_messages = result_fit.unwrap().messages;
+
+            // Do not need to clone fit.messages since we only compare the messages len
+            if result_messages.len() == 0 || result_messages.len() != fit.messages.len() {
+                return Err(format!(
+                    "unexpected messages len, expected: {}, got: {}",
+                    fit.messages.len(),
+                    result_messages.len()
+                )
+                .into());
             }
         }
         Ok(())

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -9,158 +9,41 @@ use std::{
 
 #[test]
 fn decode_encode_roundtrip() {
-    let path = Path::new("tests/data").to_path_buf();
-    let mut buf = Vec::<u8>::with_capacity(5_000 >> 10); // 5 MB, large enough to avoid realloc.
-
-    walk_path(&path, &mut |path: &PathBuf| {
-        let file = File::open(path).unwrap();
-        let br = BufReader::new(file);
-        let mut dec = Decoder::new(br);
-
-        'decode: while let Some(fit) = &mut match dec.decode() {
-            Ok(fit) => fit,
-            Err(err) => {
-                if let DecoderError::ChecksumMismatch { .. } = err {
-                    if let Some(file_name) = path.file_name() {
-                        // NOTE: Doubts exist regarding the integrity of these files.
-                        if ["WeightScaleMultiUser.fit", "Settings.fit"]
-                            .iter()
-                            .any(|x| *x == file_name)
-                        {
-                            continue 'decode;
-                        }
-                    }
-                }
-                return Err(format!("decode: {:?}", err).into());
-            }
-        } {
-            buf.clear();
-            let mut cursor = Cursor::new(&mut buf);
-
-            let mut enc = EncoderBuilder::new(&mut cursor)
-                .endianness(Endianness::BigEndian)
-                .build();
-
-            let expected_messages = fit.messages.clone(); // Must clone since encoder mutates the value.
-
-            if let Err(err) = enc.encode(fit) {
-                return Err(format!("encode: {:?}", err).into());
-            }
-
-            cursor.seek(SeekFrom::Start(0)).unwrap();
-
-            let mut dec = Decoder::new(&mut cursor);
-            let result_fit = match dec.decode() {
-                Ok(result_fit) => result_fit,
-                Err(err) => {
-                    return Err(format!("re-decode the encoded file: {:?}", err).into());
-                }
-            };
-
-            let result_messages = result_fit.unwrap().messages;
-
-            if result_messages.len() == 0 || result_messages.len() != expected_messages.len() {
-                return Err(format!(
-                    "unexpected messages len, expected: {}, got: {}",
-                    expected_messages.len(),
-                    result_messages.len()
-                )
-                .into());
-            }
-
-            for (i, mesg) in expected_messages
-                .iter()
-                .zip(result_messages.iter())
-                .enumerate()
-            {
-                if mesg.0.num != mesg.1.num {
-                    return Err(format!(
-                        "mesg num mismatch for mesg index {}, expected: {}, got: {}",
-                        i, mesg.0.num, mesg.1.num
-                    )
-                    .into());
-                }
-
-                if mesg.0.fields.len() != mesg.1.fields.len() {
-                    return Err(format!(
-                        "fields len mismatch for mesg index {} num {}, expected: {}, got: {}",
-                        i,
-                        mesg.0.num,
-                        mesg.0.fields.len(),
-                        mesg.1.fields.len()
-                    )
-                    .into());
-                }
-            }
-        }
-        Ok(())
-    })
-    .unwrap()
+    walk_path(
+        &Path::new("tests/data").to_path_buf(),
+        &mut |path: &PathBuf| {
+            do_roudtrip_with_encoder_options(
+                path,
+                EncoderOptions {
+                    endianness: Endianness::LittleEndian,
+                    header_option: HeaderOption::Normal(0),
+                },
+            )
+        },
+    )
+    .unwrap();
 }
 
 #[test]
 fn decode_encode_roundtrip_compressed() {
-    let path = Path::new("tests/data").to_path_buf();
-    let mut buf = Vec::<u8>::with_capacity(5_000 >> 10); // 5 MB, large enough to avoid realloc.
+    walk_path(
+        &Path::new("tests/data").to_path_buf(),
+        &mut |path: &PathBuf| {
+            do_roudtrip_with_encoder_options(
+                path,
+                EncoderOptions {
+                    endianness: Endianness::BigEndian,
+                    header_option: HeaderOption::Compressed(3),
+                },
+            )
+        },
+    )
+    .unwrap();
+}
 
-    walk_path(&path, &mut |path: &PathBuf| {
-        let file = File::open(path).unwrap();
-        let br = BufReader::new(file);
-        let mut dec = Decoder::new(br);
-
-        'decode: while let Some(fit) = &mut match dec.decode() {
-            Ok(fit) => fit,
-            Err(err) => {
-                if let DecoderError::ChecksumMismatch { .. } = err {
-                    if let Some(file_name) = path.file_name() {
-                        // NOTE: Doubts exist regarding the integrity of these files.
-                        if ["WeightScaleMultiUser.fit", "Settings.fit"]
-                            .iter()
-                            .any(|x| *x == file_name)
-                        {
-                            continue 'decode;
-                        }
-                    }
-                }
-                return Err(format!("decode: {:?}", err).into());
-            }
-        } {
-            buf.clear();
-            let mut cursor = Cursor::new(&mut buf);
-
-            let mut enc = EncoderBuilder::new(&mut cursor)
-                .header_option(HeaderOption::Compressed(3))
-                .build();
-
-            if let Err(err) = enc.encode(fit) {
-                return Err(format!("encode: {:?}", err).into());
-            }
-
-            cursor.seek(SeekFrom::Start(0)).unwrap();
-
-            let mut dec = Decoder::new(&mut cursor);
-            let result_fit = match dec.decode() {
-                Ok(result_fit) => result_fit,
-                Err(err) => {
-                    return Err(format!("re-decode the encoded file: {:?}", err).into());
-                }
-            };
-
-            let result_messages = result_fit.unwrap().messages;
-
-            // Do not need to clone fit.messages since we only compare the messages len
-            if result_messages.len() == 0 || result_messages.len() != fit.messages.len() {
-                return Err(format!(
-                    "unexpected messages len, expected: {}, got: {}",
-                    fit.messages.len(),
-                    result_messages.len()
-                )
-                .into());
-            }
-        }
-        Ok(())
-    })
-    .unwrap()
+struct EncoderOptions {
+    endianness: Endianness,
+    header_option: HeaderOption,
 }
 
 fn walk_path<F>(path: &PathBuf, f: &mut F) -> Result<(), Box<dyn Error>>
@@ -179,6 +62,95 @@ where
             if let Err(err) = f(&path) {
                 return Err(format!("path: {:?}, err: {:?}", path, err).into());
             };
+        }
+    }
+    Ok(())
+}
+
+fn do_roudtrip_with_encoder_options(
+    path: &PathBuf,
+    encoder_options: EncoderOptions,
+) -> Result<(), Box<dyn Error>> {
+    let file = File::open(path).unwrap();
+    let br = BufReader::new(file);
+    let mut dec = Decoder::new(br);
+    let buf = Vec::<u8>::with_capacity(5_000 >> 10); // 5 MB, large enough to avoid realloc.
+    let mut cursor = Cursor::new(buf);
+
+    'decode: while let Some(fit) = &mut match dec.decode() {
+        Ok(fit) => fit,
+        Err(err) => {
+            if let DecoderError::ChecksumMismatch { .. } = err {
+                if let Some(file_name) = path.file_name() {
+                    // NOTE: Doubts exist regarding the integrity of these files.
+                    if ["WeightScaleMultiUser.fit", "Settings.fit"]
+                        .iter()
+                        .any(|x| *x == file_name)
+                    {
+                        continue 'decode;
+                    }
+                }
+            }
+            return Err(format!("decode: {:?}", err).into());
+        }
+    } {
+        cursor.seek(SeekFrom::Start(0)).unwrap();
+
+        let mut enc = EncoderBuilder::new(&mut cursor)
+            .endianness(encoder_options.endianness)
+            .header_option(encoder_options.header_option)
+            .build();
+
+        let expected_messages = fit.messages.clone(); // Must clone since encoder mutates the value.
+
+        if let Err(err) = enc.encode(fit) {
+            return Err(format!("encode: {:?}", err).into());
+        }
+
+        cursor.seek(SeekFrom::Start(0)).unwrap();
+
+        let mut dec = Decoder::new(&mut cursor);
+        let result_fit = match dec.decode() {
+            Ok(result_fit) => result_fit,
+            Err(err) => {
+                return Err(format!("re-decode the encoded file: {:?}", err).into());
+            }
+        };
+
+        let result_messages = result_fit.unwrap().messages;
+
+        if result_messages.len() == 0 || result_messages.len() != expected_messages.len() {
+            return Err(format!(
+                "unexpected messages len, expected: {}, got: {}",
+                expected_messages.len(),
+                result_messages.len()
+            )
+            .into());
+        }
+
+        for (i, mesg) in expected_messages
+            .iter()
+            .zip(result_messages.iter())
+            .enumerate()
+        {
+            if mesg.0.num != mesg.1.num {
+                return Err(format!(
+                    "mesg num mismatch for mesg index {}, expected: {}, got: {}",
+                    i, mesg.0.num, mesg.1.num
+                )
+                .into());
+            }
+
+            if mesg.0.fields.len() != mesg.1.fields.len() {
+                return Err(format!(
+                    "fields len mismatch for mesg index {} num {}, expected: {}, got: {}",
+                    i,
+                    mesg.0.num,
+                    mesg.0.fields.len(),
+                    mesg.1.fields.len()
+                )
+                .into());
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
- Fix decoder incorrect parsing `local_mesg_num` it was using wrong constant to check, it should be `MESG_COMPRESSED_HEADER_MASK` instead of `COMPRESSED_TIME_MASK`.
- Use `wrapping_add` and `wrapping_sub` when underflow or overflow is ok, avoid panic when run with unoptimized compile. I didn't know that it will only show panic during runtime when the code is invoked.
- Add derive Debug for DecoderEvent,  and derive Clone Copy for HeaderOption for easier debug and do integration tests.
- Refactor integration tests and add roundtrip test for compressed timestamp FIT to ensure correctness.