### PR TITLE
refactor!: make this library #![no_std]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "embedded-io-adapters"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900a1c087f1f7d17cdc84a1290df91521cd90933efa76d68e568385d889f2f4"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +396,8 @@ name = "rustyfit"
 version = "0.5.0"
 dependencies = [
  "criterion",
+ "embedded-io",
+ "embedded-io-adapters",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # RustyFIT
 
 ![GitHub Workflow Status](https://github.com/muktihari/rustyfit/workflows/CI/badge.svg)
+[![docs.rs](https://img.shields.io/badge/docs.rs-rustyfit-gold?logo=docs.rs)](https://docs.rs/rustyfit)
 [![Crates.io Version](https://img.shields.io/crates/v/rustyfit.svg)](https://crates.io/crates/rustyfit)
 [![Crates.io Downloads](https://img.shields.io/crates/d/rustyfit.svg)](https://crates.io/crates/rustyfit)
 [![Profile Version](https://img.shields.io/badge/profile-v21.201-lightblue.svg?style=flat)](https://github.com/garmin/fit-sdk-tools/releases)
 
-Rewrite of [FIT SDK for Go](https://github.com/muktihari/fit) in Rust.
+This project hosts the `#![no_std]` Rust implementation for [The Flexible and Interoperable Data Transfer (FIT) Protocol](https://developer.garmin.com/fit), supporting both decoding and encoding
+
+This library is a rewrite of [FIT SDK for Go](https://github.com/muktihari/fit) and is designed to run on baremetal Rust.
 
 ## Current State
 
-This project serves as an exercise for me to learn Rust. I believe the fastest way to learn something new is by reinventing the wheel or rewriting something that already exists. Although this is a learning project, this library generally works, is usable, and quite fast.
-
-Missing features, test completeness, and more robust documentation may be added later through release iteration.
+At the moment, I can't make this library heapless without complicating the code. I have no elegant solution for pure baremetal without dynamic memory allocation. That being said, this library is efficient enough to work on resource-constrained environments. I've tested it on a `#![no_std]` `#![no_main]` program to decode a FIT file (statically embedded) and print some of its Session's fields to `stdout` with a custom global allocator having less than 50 KB heap size and it works like a charm.
 
 ## Usage
+
+For [#![no_std]](https://docs.rust-embedded.org/book/intro/no-std.html), you need to provide [#[global_allocator]](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute) since this library requires allocation.
+
+For [std](https://doc.rust-lang.org/std), you need to wrap `std::io`'s [Read](https://doc.rust-lang.org/std/io/trait.Read.html) or [Write](https://doc.rust-lang.org/std/io/trait.Write.html) with [embedded_io_adapters::std:FromStd](https://docs.rs/embedded-io-adapters/0.7.0/embedded_io_adapters/std/struct.FromStd.html). We will provide examples in `std` for a broad audience and simplicity.
 
 ### Decoding
 
@@ -25,6 +30,7 @@ NOTE: First call will return either Ok(Some(fit)) or Err(err), never Ok(None).
 On next call, it may return Ok(None) to indicate that no more FIT sequence in the file.
 
 ```rust
+use embedded_io_adapters::std::FromStd;
 use rustyfit::{Decoder, profile::{mesgdef, typedef}};
 use std::{error::Error, fs::File, io::BufReader};
 
@@ -32,7 +38,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let name = "Activity.fit";
     let f = File::open(name)?;
     let br = BufReader::new(f);
-    let mut dec = Decoder::new(br);
+    let mut dec = Decoder::new(FromStd::new(br));
 
     // SAFETY: First decode call is either Ok(Some(fit)) or Err(err), never Ok(None).
     let fit = dec.decode()?.unwrap(); 
@@ -77,14 +83,15 @@ Decoder's `decode_with` allow us to retrieve event data (FileHeader, MessageDefi
 This way, users can have fine-grained control on how to interact with the data.
 
 ```rust
-use rustyfit::{Decoder, DecoderEvent,profile::{mesgdef, typedef}};
+use embedded_io_adapters::std::FromStd;
+use rustyfit::{Decoder, DecoderEvent, profile::{mesgdef, typedef}};
 use std::{error::Error, fs::File, io::BufReader};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let name = "Activity.fit";
     let f = File::open(name)?;
     let br = BufReader::new(f);
-    let mut dec = Decoder::new(br);
+    let mut dec = Decoder::new(FromStd::new(br));
 
     dec.decode_with(|event| match event {
         DecoderEvent::FileHeader(_) => {},
@@ -147,14 +154,15 @@ let mut dec: Decoder = DecoderBuilder::new(br)
 Here is the example of manually encode FIT protocol using this library to give the idea how it works.
 
 ```rust
+use embedded_io_adapters::std::FromStd;
+use rustyfit::{Encoder, profile::{ProfileType, mesgdef, typedef}, proto::{FIT, Field, Message, Value}};
 use std::{error::Error, fs::File, io::{BufWriter, Write}};
-use rustyfit::{Encoder, profile::{ProfileType, mesgdef, typedef::{self}}, proto::{FIT, Field, Message, Value}};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let fout_name = "output.fit";
     let fout = File::create(fout_name)?;
     let mut bw = BufWriter::new(fout);
-    let mut enc = Encoder::new(&mut bw);
+    let mut enc = Encoder::new(FromStd::new(&mut bw));
 
     let mut fit = FIT {
         messages: vec![
@@ -222,14 +230,15 @@ fn main() -> Result<(), Box<dyn Error>> {
 Alternatively, users can create messages using the mesgdef module for convenience.
 
 ```rust
+use embedded_io_adapters::std::FromStd;
+use rustyfit::{Encoder, profile::{mesgdef, typedef}, proto::{FIT, Message}};
 use std::{error::Error, fs::File, io::{BufWriter, Write}};
-use rustyfit::{Encoder, profile::{mesgdef, typedef::{self}}, proto::{FIT, Message}};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let fout_name = "output.fit";
     let fout = File::create(fout_name)?;
     let mut bw = BufWriter::new(fout);
-    let mut enc = Encoder::new(&mut bw);
+    let mut enc = Encoder::new(FromStd::new(&mut bw));
 
     let mut fit = FIT {
         messages: vec![

--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -62,6 +62,7 @@ func (b *Builder) Build() ([]generator.Data, error) {
 
 	var maxLenFields int
 	for _, mesg := range b.messages {
+		imports := map[string]struct{}{}
 		canExpand, maxFieldExpandNum := b.componentExpansionAbility(&mesg)
 
 		if len(mesg.Fields) > maxLenFields {
@@ -131,6 +132,12 @@ func (b *Builder) Build() ([]generator.Data, error) {
 				FixedArraySize: fixedArraySize,
 				Units:          parserField.Units,
 			}
+			if strings.Contains(field.Type, "String") {
+				imports["alloc::string::String"] = struct{}{}
+				if fixedArraySize > 0 {
+					imports["alloc::borrow::ToOwned"] = struct{}{}
+				}
+			}
 
 			if _, ok := canExpand[parserField.Name]; ok {
 				field.CanExpand = true
@@ -173,6 +180,7 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			StateSize:         (maxFieldExpandNum + 8) / 8,
 			MaxFieldNum:       maxFieldNum + 1,
 			MaxFieldExpandNum: maxFieldExpandNum + 1,
+			Imports:           imports,
 		})
 	}
 

--- a/fitgen/internal/profile/mesgdef/data.go
+++ b/fitgen/internal/profile/mesgdef/data.go
@@ -23,6 +23,7 @@ type Message struct {
 	StateSize         byte
 	MaxFieldNum       byte
 	MaxFieldExpandNum byte
+	Imports           map[string]struct{}
 }
 
 type Field struct {

--- a/fitgen/internal/profile/mesgdef/mesgdef.tmpl
+++ b/fitgen/internal/profile/mesgdef/mesgdef.tmpl
@@ -14,6 +14,10 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
+{{- range $key, $val := .Imports -}}
+use {{ $key -}};
+{{ end }}
 
 {{ if gt .MaxFieldExpandNum 1 -}}
 fn is_expanded(state: &[u8], num: u8) -> bool {

--- a/fitgen/internal/profile/profiletype/profile_type.tmpl
+++ b/fitgen/internal/profile/profiletype/profile_type.tmpl
@@ -10,7 +10,7 @@
 {{ define "profile_type" }}
 {{ template "header" . }}
 use crate::profile::typedef::FitBaseType;
-use std::fmt;
+use core::fmt;
 
 pub const PROFILE_VERSION: u16 = {{ .VersionData.Version }};
 

--- a/fitgen/internal/profile/typedef/typedef.tmpl
+++ b/fitgen/internal/profile/typedef/typedef.tmpl
@@ -11,7 +11,7 @@
 {{ template "header" .}}
 #![allow(unused, clippy::match_single_binding)] 
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/Cargo.toml
+++ b/rustyfit/Cargo.toml
@@ -10,8 +10,12 @@ include = ["Cargo.toml", "src/**"]
 categories = ["encoding", "parser-implementations"]
 repository = "https://github.com/muktihari/rustyfit"
 
+[dependencies]
+embedded-io = { version = "0.7.1" }
+
 [dev-dependencies]
 criterion = { version = "0.8.2" }
+embedded-io-adapters = { version = "0.7.0", features = ["std"] }
 
 [[bench]]
 name = "bench_main"

--- a/rustyfit/benches/bench_main.rs
+++ b/rustyfit/benches/bench_main.rs
@@ -1,8 +1,8 @@
-use criterion::{Criterion, criterion_group, criterion_main};
-
 mod decoder;
 mod encoder;
 mod mesgdef;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 
 criterion_group! {
     name = benches;

--- a/rustyfit/benches/decoder.rs
+++ b/rustyfit/benches/decoder.rs
@@ -1,7 +1,7 @@
-use std::{hint::black_box, io::Cursor};
-
 use criterion::{Criterion, criterion_group, criterion_main};
+use embedded_io_adapters::std::FromStd;
 use rustyfit::{Decoder, DecoderBuilder};
+use std::{hint::black_box, io::Cursor};
 
 const TEST_FILE: &str = "tests/data/large.fit";
 
@@ -10,14 +10,14 @@ pub fn bench_decode(c: &mut Criterion) {
 
     c.bench_function("decode default", |b| {
         b.iter(|| {
-            let mut dec = Decoder::new(black_box(Cursor::new(&file_bytes)));
+            let mut dec = Decoder::new(black_box(FromStd::new(Cursor::new(&file_bytes))));
             dec.decode().unwrap();
         })
     });
 
     c.bench_function("decode no checksum no expand", |b| {
         b.iter(|| {
-            let mut dec = DecoderBuilder::new(black_box(Cursor::new(&file_bytes)))
+            let mut dec = DecoderBuilder::new(black_box(FromStd::new(Cursor::new(&file_bytes))))
                 .checksum(false)
                 .expand_components(false)
                 .build();
@@ -27,14 +27,14 @@ pub fn bench_decode(c: &mut Criterion) {
 
     c.bench_function("decode_with", |b| {
         b.iter(|| {
-            let mut dec = Decoder::new(black_box(Cursor::new(&file_bytes)));
+            let mut dec = Decoder::new(black_box(FromStd::new(Cursor::new(&file_bytes))));
             dec.decode_with(|_| {}).unwrap();
         })
     });
 
     c.bench_function("decode_with no checksum no expand", |b| {
         b.iter(|| {
-            let mut dec = DecoderBuilder::new(black_box(Cursor::new(&file_bytes)))
+            let mut dec = DecoderBuilder::new(black_box(FromStd::new(Cursor::new(&file_bytes))))
                 .checksum(false)
                 .expand_components(false)
                 .build();

--- a/rustyfit/benches/encoder.rs
+++ b/rustyfit/benches/encoder.rs
@@ -1,20 +1,20 @@
-use std::{hint::black_box, io::Cursor};
-
 use criterion::{Criterion, criterion_group, criterion_main};
+use embedded_io_adapters::std::FromStd;
 use rustyfit::{Decoder, Encoder, EncoderBuilder, HeaderOption};
+use std::{hint::black_box, io::Cursor};
 
 const TEST_FILE: &str = "tests/data/large.fit";
 
 pub fn bench_encode(c: &mut Criterion) {
     let file_bytes = std::fs::read(TEST_FILE).unwrap();
-    let mut dec = Decoder::new(Cursor::new(&file_bytes));
+    let mut dec = Decoder::new(FromStd::new(Cursor::new(&file_bytes)));
     let mut buf = Vec::<u8>::with_capacity(10_000 >> 10); // 10 MB, large enough to avoid realloc.
 
     while let Some(fit) = &mut dec.decode().unwrap() {
         c.bench_function("encode default", |b| {
             b.iter(|| {
                 let cur = Cursor::new(&mut buf);
-                let mut enc = Encoder::new(black_box(cur));
+                let mut enc = Encoder::new(black_box(FromStd::new(cur)));
                 enc.encode(fit).unwrap();
                 buf.clear();
             })
@@ -23,7 +23,7 @@ pub fn bench_encode(c: &mut Criterion) {
         c.bench_function("encode normal interleave 15", |b| {
             b.iter(|| {
                 let cur = Cursor::new(&mut buf);
-                let mut enc = EncoderBuilder::new(black_box(cur))
+                let mut enc = EncoderBuilder::new(black_box(FromStd::new(cur)))
                     .header_option(HeaderOption::Normal(15))
                     .build();
                 enc.encode(fit).unwrap();
@@ -34,7 +34,7 @@ pub fn bench_encode(c: &mut Criterion) {
         c.bench_function("encode compress interleave 3", |b| {
             b.iter(|| {
                 let cur = Cursor::new(&mut buf);
-                let mut enc = EncoderBuilder::new(black_box(cur))
+                let mut enc = EncoderBuilder::new(black_box(FromStd::new(cur)))
                     .header_option(HeaderOption::Compressed(3))
                     .build();
                 enc.encode(fit).unwrap();

--- a/rustyfit/benches/mesgdef.rs
+++ b/rustyfit/benches/mesgdef.rs
@@ -1,10 +1,9 @@
-use std::hint::black_box;
-
 use criterion::{Criterion, criterion_group, criterion_main};
 use rustyfit::{
     profile::{ProfileType, mesgdef::Record, typedef::MesgNum},
     proto::{Field, Message, Value},
 };
+use std::hint::black_box;
 
 pub fn bench_from(c: &mut Criterion) {
     const FIELD: Field = Field {

--- a/rustyfit/src/decoder/accumulator.rs
+++ b/rustyfit/src/decoder/accumulator.rs
@@ -1,4 +1,5 @@
 use crate::{profile::typedef::MesgNum, proto::Value};
+use alloc::vec::Vec;
 
 pub(super) struct Accumulator {
     values: Vec<AccuValue>,
@@ -140,6 +141,7 @@ mod tests {
         profile::typedef::MesgNum,
         proto::Value,
     };
+    use alloc::{string::String, vec, vec::Vec};
 
     #[test]
     fn test_collect() {

--- a/rustyfit/src/decoder/bits.rs
+++ b/rustyfit/src/decoder/bits.rs
@@ -102,6 +102,7 @@ mod tests {
         decoder::{Bits, bits::N},
         proto::Value,
     };
+    use alloc::{vec, vec::Vec};
 
     #[test]
     fn make_bits() {

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -5,27 +5,30 @@ mod bits;
 
 use crate::{
     crc16::Crc16,
+    decoder::accumulator::Accumulator,
+    decoder::bits::Bits,
     profile::{
         ProfileType, lookup, mesgdef,
         typedef::{FitBaseType, MesgNum},
     },
     proto::*,
 };
-use accumulator::Accumulator;
-use bits::Bits;
-use std::{
-    error, fmt,
-    io::{self, ErrorKind, Read},
-    mem,
-};
+use alloc::{vec, vec::Vec};
+use core::mem;
+use embedded_io::{Read, ReadExactError};
 
 /// Decoder Error
 #[derive(Debug)]
-pub enum Error {
+pub enum Error<E> {
     /// I/O related error when reading from the Reader.
     Io {
         /// I/O error
-        err: io::Error,
+        err: E,
+        /// Byte position
+        n: usize,
+    },
+    /// Unexpected EOF occurs during process.
+    UnexpectedEof {
         /// Byte position
         n: usize,
     },
@@ -45,10 +48,14 @@ pub enum Error {
     },
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<E> core::fmt::Display for Error<E>
+where
+    E: core::fmt::Display,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
-            Error::Io { err, n } => write!(f, "io error kind {} at byte pos {}", err, n),
+            Error::Io { err, n } => write!(f, "io error {} at byte pos {}", err, n),
+            Error::UnexpectedEof { n } => write!(f, "unexpected EOF at byte pos {}", n),
             Error::NotFITFile => write!(f, "not a FIT file"),
             Error::ChecksumMismatch { expected, got } => {
                 write!(f, "checksum mismatch, expected {} got {}", expected, got)
@@ -62,7 +69,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {}
+impl<E> core::error::Error for Error<E> where E: core::fmt::Debug + core::fmt::Display {}
 
 /// Event is FIT segments encountered by the Decoder.
 #[derive(Debug)]
@@ -108,7 +115,7 @@ impl<R: Read> Decoder<R> {
     /// Decode return a single FIT sequence. If it's a chained FIT file, call this method multiple times.
     /// First call will return either Ok(Some(fit)) or Err(err), never Ok(None).
     /// On next call, it may return Ok(None) to indicate that no more FIT sequence in the file.
-    pub fn decode(&mut self) -> Result<Option<FIT>, Error> {
+    pub fn decode(&mut self) -> Result<Option<FIT>, Error<R::Error>> {
         let file_header = match self.decode_file_header()? {
             Some(file_header) => file_header,
             None => return Ok(None),
@@ -131,7 +138,7 @@ impl<R: Read> Decoder<R> {
     }
 
     /// Similar to Decode but with a closure for retrieving DecoderEvent for the current FIT sequence.
-    pub fn decode_with<F>(&mut self, mut f: F) -> Result<bool, Error>
+    pub fn decode_with<F>(&mut self, mut f: F) -> Result<bool, Error<R::Error>>
     where
         F: FnMut(Event),
     {
@@ -147,13 +154,18 @@ impl<R: Read> Decoder<R> {
         Ok(true)
     }
 
-    fn decode_file_header(&mut self) -> Result<Option<FileHeader>, Error> {
+    fn decode_file_header(&mut self) -> Result<Option<FileHeader>, Error<R::Error>> {
         let mut arr = [0u8; 14];
         if let Err(err) = self.reader.read_exact(&mut arr[..1]) {
-            if self.n > 0 && err.kind() == ErrorKind::UnexpectedEof {
-                return Ok(None); // No chained FIT sequence
+            match err {
+                ReadExactError::UnexpectedEof => {
+                    if self.n > 0 {
+                        return Ok(None);
+                    }
+                    return Err(Error::UnexpectedEof { n: self.n });
+                }
+                ReadExactError::Other(err) => return Err(Error::Io { err, n: self.n }),
             }
-            return Err(Error::Io { err, n: self.n });
         };
         self.n += 1;
 
@@ -163,7 +175,10 @@ impl<R: Read> Decoder<R> {
         }
 
         if let Err(err) = self.reader.read_exact(&mut arr[1..n]) {
-            return Err(Error::Io { err, n: self.n });
+            return Err(match err {
+                ReadExactError::UnexpectedEof => Error::UnexpectedEof { n: self.n },
+                ReadExactError::Other(err) => Error::Io { err, n: self.n },
+            });
         }
         self.n += n - 1;
 
@@ -198,9 +213,12 @@ impl<R: Read> Decoder<R> {
     }
 
     /// Reads the exact number of bytes required to fill buf, increment n read bytes and calculate checksum.
-    fn read_exact_inc(&mut self, buf: &mut [u8]) -> Result<(), Error> {
+    fn read_exact_inc(&mut self, buf: &mut [u8]) -> Result<(), Error<R::Error>> {
         if let Err(err) = self.reader.read_exact(buf) {
-            return Err(Error::Io { err, n: self.n });
+            return Err(match err {
+                ReadExactError::UnexpectedEof => Error::UnexpectedEof { n: self.n },
+                ReadExactError::Other(err) => Error::Io { err, n: self.n },
+            });
         };
         self.n += buf.len();
         self.cur += buf.len() as u32;
@@ -210,7 +228,7 @@ impl<R: Read> Decoder<R> {
         Ok(())
     }
 
-    fn decode_message_with<F>(&mut self, data_size: u32, mut f: F) -> Result<(), Error>
+    fn decode_message_with<F>(&mut self, data_size: u32, mut f: F) -> Result<(), Error<R::Error>>
     where
         F: FnMut(Event),
     {
@@ -269,7 +287,10 @@ impl<R: Read> Decoder<R> {
         Ok(())
     }
 
-    fn decode_message_definition(&mut self, mesg_def: &mut MessageDefinition) -> Result<(), Error> {
+    fn decode_message_definition(
+        &mut self,
+        mesg_def: &mut MessageDefinition,
+    ) -> Result<(), Error<R::Error>> {
         let mut arr = [0u8; 765];
         self.read_exact_inc(&mut arr[..5])?;
 
@@ -319,7 +340,7 @@ impl<R: Read> Decoder<R> {
         &mut self,
         mesg: &mut Message,
         mesg_def: &MessageDefinition,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error<R::Error>> {
         if mesg.header & MESG_COMPRESSED_HEADER_MASK == MESG_COMPRESSED_HEADER_MASK {
             let time_offset = mesg.header & COMPRESSED_TIME_MASK;
             self.timestamp = self.timestamp.wrapping_add(
@@ -378,7 +399,7 @@ impl<R: Read> Decoder<R> {
         &mut self,
         mesg: &mut Message,
         mesg_def: &MessageDefinition,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error<R::Error>> {
         let mut arr = [0u8; 255];
 
         for field_def in &mesg_def.field_definitions {
@@ -516,7 +537,7 @@ impl<R: Read> Decoder<R> {
         &mut self,
         mesg: &mut Message,
         mesg_def: &MessageDefinition,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error<R::Error>> {
         let mut arr = [0u8; 255];
 
         for dev_field_def in &mesg_def.developer_field_definitions {
@@ -559,10 +580,13 @@ impl<R: Read> Decoder<R> {
         Ok(())
     }
 
-    fn decode_crc(&mut self) -> Result<u16, Error> {
+    fn decode_crc(&mut self) -> Result<u16, Error<R::Error>> {
         let mut arr = [0u8; 2];
         if let Err(err) = self.reader.read_exact(&mut arr) {
-            return Err(Error::Io { err, n: self.n });
+            return Err(match err {
+                ReadExactError::UnexpectedEof => Error::UnexpectedEof { n: self.n },
+                ReadExactError::Other(err) => Error::Io { err, n: self.n },
+            });
         };
         self.n += arr.len();
 

--- a/rustyfit/src/encoder/lru.rs
+++ b/rustyfit/src/encoder/lru.rs
@@ -1,3 +1,5 @@
+use alloc::{vec, vec::Vec};
+
 pub(super) struct Lru {
     items: Vec<Vec<u8>>,
     bucket: Vec<usize>,
@@ -63,6 +65,7 @@ impl Lru {
 #[cfg(test)]
 mod tests {
     use crate::encoder::Lru;
+    use alloc::vec;
 
     #[test]
     fn test_lru() {

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -5,28 +5,24 @@ mod validator;
 
 use crate::{
     crc16::Crc16,
-    encoder::validator::MessageValidatorError,
+    encoder::lru::Lru,
+    encoder::validator::{MessageValidator, MessageValidatorError},
     profile::{
         PROFILE_VERSION,
         typedef::{DateTime, MesgNum},
     },
     proto::{self, Error as ProtocolError, *},
 };
-use lru::Lru;
-use std::{
-    error,
-    fmt::{self},
-    io::{self, Seek, SeekFrom, Write},
-};
-use validator::MessageValidator;
+use alloc::vec::Vec;
+use embedded_io::{Seek, SeekFrom, Write};
 
 /// Encoder Error
 #[derive(Debug)]
-pub enum Error {
+pub enum Error<E> {
     /// I/O related error when writing to the Writer.
     Io {
         /// I/O error
-        err: io::Error,
+        err: E,
         /// Total written
         n: i64,
     },
@@ -52,13 +48,11 @@ pub enum Error {
     },
 }
 
-enum EncodeMessageError {
-    Io(io::Error),
-    Protocol(ProtocolError),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<E> core::fmt::Display for Error<E>
+where
+    E: core::fmt::Display,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
             Self::Io { err, n } => write!(f, "io: {}, n: {}", err, n),
             Self::EmptyMessages => write!(f, "messages is empty"),
@@ -77,7 +71,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {}
+impl<E> core::error::Error for Error<E> where E: core::fmt::Debug + core::fmt::Display {}
 
 /// HeaderOption to pick when encoding FIT file, this will optimize
 /// the size of the resulting FIT file.
@@ -133,7 +127,7 @@ impl<W: Write + Seek> Encoder<W> {
     }
 
     /// Encode the given `fit` to the writer.
-    pub fn encode(&mut self, fit: &mut FIT) -> Result<(), Error> {
+    pub fn encode(&mut self, fit: &mut FIT) -> Result<(), Error<W::Error>> {
         self.select_protocol_version(&mut fit.file_header);
         self.validate(fit)?;
 
@@ -156,7 +150,7 @@ impl<W: Write + Seek> Encoder<W> {
         }
     }
 
-    fn validate(&mut self, fit: &mut FIT) -> Result<(), Error> {
+    fn validate(&mut self, fit: &mut FIT) -> Result<(), Error<W::Error>> {
         if fit.messages.is_empty() {
             return Err(Error::EmptyMessages);
         }
@@ -182,7 +176,7 @@ impl<W: Write + Seek> Encoder<W> {
         Ok(())
     }
 
-    fn encode_file_header(&mut self, file_header: &mut FileHeader) -> Result<(), Error> {
+    fn encode_file_header(&mut self, file_header: &mut FileHeader) -> Result<(), Error<W::Error>> {
         self.last_file_header_pos = self.n;
 
         if file_header.size != 12 {
@@ -209,7 +203,7 @@ impl<W: Write + Seek> Encoder<W> {
         Ok(())
     }
 
-    fn update_file_header(&mut self, file_header: &mut FileHeader) -> Result<(), Error> {
+    fn update_file_header(&mut self, file_header: &mut FileHeader) -> Result<(), Error<W::Error>> {
         file_header.data_size = self.data_size;
 
         let buf = &mut self.buf;
@@ -240,25 +234,26 @@ impl<W: Write + Seek> Encoder<W> {
         Ok(())
     }
 
-    fn encode_messages(&mut self, messages: &mut [Message]) -> Result<(), Error> {
+    fn encode_messages(&mut self, messages: &mut [Message]) -> Result<(), Error<W::Error>> {
         for (i, mesg) in messages.iter_mut().enumerate() {
             if let Err(e) = self.encode_message(mesg) {
                 match e {
-                    EncodeMessageError::Io(err) => return Err(Error::Io { err, n: self.n }),
-                    EncodeMessageError::Protocol(err) => {
+                    Error::Io { err, .. } => return Err(Error::Io { err, n: self.n }),
+                    Error::Protocol { err, .. } => {
                         return Err(Error::Protocol {
                             mesg_index: i,
                             mesg_num: mesg.num,
                             err,
                         });
                     }
+                    _ => return Err(e),
                 }
             }
         }
         Ok(())
     }
 
-    fn encode_message(&mut self, mesg: &mut Message) -> Result<(), EncodeMessageError> {
+    fn encode_message(&mut self, mesg: &mut Message) -> Result<(), Error<W::Error>> {
         mesg.header = MESG_NORMAL_HEADER_MASK;
 
         if let HeaderOption::Compressed(_) = self.options.header_option {
@@ -280,7 +275,7 @@ impl<W: Write + Seek> Encoder<W> {
 
         if is_new_mesg_def {
             if let Err(err) = self.writer.write_all(buf) {
-                return Err(EncodeMessageError::Io(err));
+                return Err(Error::Io { err, n: self.n });
             }
             self.n += buf.len() as i64;
             self.data_size += buf.len() as u32;
@@ -289,11 +284,15 @@ impl<W: Write + Seek> Encoder<W> {
 
         buf.clear();
         if let Err(err) = mesg.marshal_append(buf, self.options.endianness as u8) {
-            return Err(EncodeMessageError::Protocol(err));
+            return Err(Error::Protocol {
+                mesg_index: 0,
+                mesg_num: MesgNum(0),
+                err,
+            });
         }
 
         if let Err(err) = self.writer.write_all(buf) {
-            return Err(EncodeMessageError::Io(err));
+            return Err(Error::Io { err, n: self.n });
         }
         self.n += buf.len() as i64;
         self.data_size += buf.len() as u32;
@@ -324,7 +323,7 @@ impl<W: Write + Seek> Encoder<W> {
         mesg.fields.retain(|field| field.num != FIELD_NUM_TIMESTAMP);
     }
 
-    fn encode_crc(&mut self) -> Result<(), Error> {
+    fn encode_crc(&mut self) -> Result<(), Error<W::Error>> {
         let crc = self.crc16.sum16().to_le_bytes();
         if let Err(err) = self.writer.write_all(&crc) {
             return Err(Error::Io { err, n: self.n });
@@ -440,14 +439,35 @@ impl<W: Write + Seek> Builder<W> {
 mod tests {
     use crate::{
         Encoder,
+        profile::{mesgdef, typedef},
         proto::{COMPRESSED_TIME_MASK, MESG_COMPRESSED_HEADER_MASK, Message},
     };
+    use alloc::vec;
+    use embedded_io::{ErrorKind, ErrorType, Seek, Write};
+
+    struct Sink;
+
+    impl ErrorType for Sink {
+        type Error = ErrorKind;
+    }
+
+    impl Write for Sink {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl Seek for Sink {
+        fn seek(&mut self, _: embedded_io::SeekFrom) -> Result<u64, Self::Error> {
+            Ok(0)
+        }
+    }
 
     #[test]
     fn compress_timestamp_into_header() {
-        use crate::profile::{mesgdef, typedef};
-        use std::io::Cursor;
-
         let meter: u32 = 100;
 
         let mut mesgs = vec![
@@ -505,7 +525,7 @@ mod tests {
             },
         ];
 
-        let mut enc = Encoder::new(Cursor::new(Vec::new()));
+        let mut enc = Encoder::new(Sink {});
         for mesg in mesgs.iter_mut() {
             enc.compress_timestamp_into_header(mesg);
         }

--- a/rustyfit/src/encoder/validator.rs
+++ b/rustyfit/src/encoder/validator.rs
@@ -1,7 +1,5 @@
 #![warn(missing_docs)]
 
-use std::fmt;
-
 use crate::{
     profile::{
         mesgdef,
@@ -9,6 +7,7 @@ use crate::{
     },
     proto::{Message, Value},
 };
+use alloc::{string::String, vec::Vec};
 
 #[derive(Debug)]
 pub enum MessageValidatorError {
@@ -30,8 +29,8 @@ pub enum MessageValidatorError {
     MissingFieldDescription { developer_field_index: usize },
 }
 
-impl fmt::Display for MessageValidatorError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Display for MessageValidatorError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
             Self::NoFields => write!(f, "no fields"),
             Self::FieldValueIntegrity { field_index, err } => write!(
@@ -78,8 +77,8 @@ pub enum IntegrityError {
     ValueSizeExceedLimit,
 }
 
-impl fmt::Display for IntegrityError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Display for IntegrityError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
             Self::ValueBaseTypeNotAlign { value, base_type } => {
                 write!(
@@ -225,13 +224,13 @@ impl MessageValidator {
 
         match value {
             Value::String(v) => {
-                if std::str::from_utf8(v.as_bytes()).is_err() {
+                if core::str::from_utf8(v.as_bytes()).is_err() {
                     return Err(IntegrityError::InvalidUTF8String(v.clone()));
                 }
             }
             Value::VecString(v) => {
                 for x in v.iter() {
-                    if std::str::from_utf8(x.as_bytes()).is_err() {
+                    if core::str::from_utf8(x.as_bytes()).is_err() {
                         return Err(IntegrityError::InvalidUTF8String(x.clone()));
                     }
                 }

--- a/rustyfit/src/lib.rs
+++ b/rustyfit/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 pub use decoder::{
     Builder as DecoderBuilder, Decoder, Error as DecoderError, Event as DecoderEvent,
 };

--- a/rustyfit/src/profile/mesgdef/aad_accel_features.rs
+++ b/rustyfit/src/profile/mesgdef/aad_accel_features.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// AadAccelFeatures is a AadAccelFeatures message.

--- a/rustyfit/src/profile/mesgdef/accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/accelerometer_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// AccelerometerData is a AccelerometerData message.

--- a/rustyfit/src/profile/mesgdef/activity.rs
+++ b/rustyfit/src/profile/mesgdef/activity.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Activity is a Activity message.

--- a/rustyfit/src/profile/mesgdef/ant_channel_id.rs
+++ b/rustyfit/src/profile/mesgdef/ant_channel_id.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// AntChannelId is a AntChannelId message.

--- a/rustyfit/src/profile/mesgdef/ant_rx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_rx.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/ant_tx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_tx.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/aviation_attitude.rs
+++ b/rustyfit/src/profile/mesgdef/aviation_attitude.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// AviationAttitude is a AviationAttitude message.

--- a/rustyfit/src/profile/mesgdef/barometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/barometer_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// BarometerData is a BarometerData message.

--- a/rustyfit/src/profile/mesgdef/beat_intervals.rs
+++ b/rustyfit/src/profile/mesgdef/beat_intervals.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// BeatIntervals is a BeatIntervals message.

--- a/rustyfit/src/profile/mesgdef/bike_profile.rs
+++ b/rustyfit/src/profile/mesgdef/bike_profile.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// BikeProfile is a BikeProfile message.

--- a/rustyfit/src/profile/mesgdef/blood_pressure.rs
+++ b/rustyfit/src/profile/mesgdef/blood_pressure.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// BloodPressure is a BloodPressure message.

--- a/rustyfit/src/profile/mesgdef/cadence_zone.rs
+++ b/rustyfit/src/profile/mesgdef/cadence_zone.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// CadenceZone is a CadenceZone message.

--- a/rustyfit/src/profile/mesgdef/camera_event.rs
+++ b/rustyfit/src/profile/mesgdef/camera_event.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// CameraEvent is a CameraEvent message.

--- a/rustyfit/src/profile/mesgdef/capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/capabilities.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Capabilities is a Capabilities message.

--- a/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// ChronoShotData is a ChronoShotData message.

--- a/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// ChronoShotSession is a ChronoShotSession message.

--- a/rustyfit/src/profile/mesgdef/climb_pro.rs
+++ b/rustyfit/src/profile/mesgdef/climb_pro.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// ClimbPro is a ClimbPro message.

--- a/rustyfit/src/profile/mesgdef/connectivity.rs
+++ b/rustyfit/src/profile/mesgdef/connectivity.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Connectivity is a Connectivity message.

--- a/rustyfit/src/profile/mesgdef/course.rs
+++ b/rustyfit/src/profile/mesgdef/course.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Course is a Course message.

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// CoursePoint is a CoursePoint message.

--- a/rustyfit/src/profile/mesgdef/developer_data_id.rs
+++ b/rustyfit/src/profile/mesgdef/developer_data_id.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// DeveloperDataId is a DeveloperDataId message.

--- a/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// DeviceAuxBatteryInfo is a DeviceAuxBatteryInfo message.

--- a/rustyfit/src/profile/mesgdef/device_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_info.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// DeviceInfo is a DeviceInfo message.

--- a/rustyfit/src/profile/mesgdef/device_settings.rs
+++ b/rustyfit/src/profile/mesgdef/device_settings.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// DeviceSettings is a DeviceSettings message.

--- a/rustyfit/src/profile/mesgdef/dive_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_alarm.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// DiveAlarm is a DiveAlarm message.

--- a/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// DiveApneaAlarm is a DiveApneaAlarm message.

--- a/rustyfit/src/profile/mesgdef/dive_gas.rs
+++ b/rustyfit/src/profile/mesgdef/dive_gas.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// DiveGas is a DiveGas message.

--- a/rustyfit/src/profile/mesgdef/dive_settings.rs
+++ b/rustyfit/src/profile/mesgdef/dive_settings.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// DiveSettings is a DiveSettings message.

--- a/rustyfit/src/profile/mesgdef/dive_summary.rs
+++ b/rustyfit/src/profile/mesgdef/dive_summary.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// DiveSummary is a DiveSummary message.

--- a/rustyfit/src/profile/mesgdef/event.rs
+++ b/rustyfit/src/profile/mesgdef/event.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
@@ -8,6 +8,9 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// ExdScreenConfiguration is a ExdScreenConfiguration message.

--- a/rustyfit/src/profile/mesgdef/exercise_title.rs
+++ b/rustyfit/src/profile/mesgdef/exercise_title.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// ExerciseTitle is a ExerciseTitle message.

--- a/rustyfit/src/profile/mesgdef/field_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/field_capabilities.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// FieldCapabilities is a FieldCapabilities message.

--- a/rustyfit/src/profile/mesgdef/field_description.rs
+++ b/rustyfit/src/profile/mesgdef/field_description.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// FieldDescription is a FieldDescription message.

--- a/rustyfit/src/profile/mesgdef/file_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/file_capabilities.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// FileCapabilities is a FileCapabilities message.

--- a/rustyfit/src/profile/mesgdef/file_creator.rs
+++ b/rustyfit/src/profile/mesgdef/file_creator.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// FileCreator is a FileCreator message.

--- a/rustyfit/src/profile/mesgdef/file_id.rs
+++ b/rustyfit/src/profile/mesgdef/file_id.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// FileId is a FileId message.

--- a/rustyfit/src/profile/mesgdef/goal.rs
+++ b/rustyfit/src/profile/mesgdef/goal.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Goal is a Goal message.

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// GpsMetadata is a GpsMetadata message.

--- a/rustyfit/src/profile/mesgdef/gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/gyroscope_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// GyroscopeData is a GyroscopeData message.

--- a/rustyfit/src/profile/mesgdef/hr.rs
+++ b/rustyfit/src/profile/mesgdef/hr.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/hr_zone.rs
+++ b/rustyfit/src/profile/mesgdef/hr_zone.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HrZone is a HrZone message.

--- a/rustyfit/src/profile/mesgdef/hrm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/hrm_profile.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HrmProfile is a HrmProfile message.

--- a/rustyfit/src/profile/mesgdef/hrv.rs
+++ b/rustyfit/src/profile/mesgdef/hrv.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Hrv is a Hrv message.

--- a/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HrvStatusSummary is a HrvStatusSummary message.

--- a/rustyfit/src/profile/mesgdef/hrv_value.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_value.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HrvValue is a HrvValue message.

--- a/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaAccelerometerData is a HsaAccelerometerData message.

--- a/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaBodyBatteryData is a HsaBodyBatteryData message.

--- a/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaConfigurationData is a HsaConfigurationData message.

--- a/rustyfit/src/profile/mesgdef/hsa_event.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_event.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaEvent is a HsaEvent message.

--- a/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaGyroscopeData is a HsaGyroscopeData message.

--- a/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaHeartRateData is a HsaHeartRateData message.

--- a/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaRespirationData is a HsaRespirationData message.

--- a/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaSpo2Data is a HsaSpo2Data message.

--- a/rustyfit/src/profile/mesgdef/hsa_step_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_step_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaStepData is a HsaStepData message.

--- a/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaStressData is a HsaStressData message.

--- a/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// HsaWristTemperatureData is a HsaWristTemperatureData message.

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/length.rs
+++ b/rustyfit/src/profile/mesgdef/length.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/magnetometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/magnetometer_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// MagnetometerData is a MagnetometerData message.

--- a/rustyfit/src/profile/mesgdef/max_met_data.rs
+++ b/rustyfit/src/profile/mesgdef/max_met_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// MaxMetData is a MaxMetData message.

--- a/rustyfit/src/profile/mesgdef/memo_glob.rs
+++ b/rustyfit/src/profile/mesgdef/memo_glob.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// MemoGlob is a MemoGlob message.

--- a/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// MesgCapabilities is a MesgCapabilities message.

--- a/rustyfit/src/profile/mesgdef/met_zone.rs
+++ b/rustyfit/src/profile/mesgdef/met_zone.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// MetZone is a MetZone message.

--- a/rustyfit/src/profile/mesgdef/monitoring.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// MonitoringHrData is a MonitoringHrData message.

--- a/rustyfit/src/profile/mesgdef/monitoring_info.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_info.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// MonitoringInfo is a MonitoringInfo message.

--- a/rustyfit/src/profile/mesgdef/nap_event.rs
+++ b/rustyfit/src/profile/mesgdef/nap_event.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// NapEvent is a NapEvent message.

--- a/rustyfit/src/profile/mesgdef/nmea_sentence.rs
+++ b/rustyfit/src/profile/mesgdef/nmea_sentence.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// NmeaSentence is a NmeaSentence message.

--- a/rustyfit/src/profile/mesgdef/obdii_data.rs
+++ b/rustyfit/src/profile/mesgdef/obdii_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// ObdiiData is a ObdiiData message.

--- a/rustyfit/src/profile/mesgdef/ohr_settings.rs
+++ b/rustyfit/src/profile/mesgdef/ohr_settings.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// OhrSettings is a OhrSettings message.

--- a/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// OneDSensorCalibration is a OneDSensorCalibration message.

--- a/rustyfit/src/profile/mesgdef/power_zone.rs
+++ b/rustyfit/src/profile/mesgdef/power_zone.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// PowerZone is a PowerZone message.

--- a/rustyfit/src/profile/mesgdef/raw_bbi.rs
+++ b/rustyfit/src/profile/mesgdef/raw_bbi.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/respiration_rate.rs
+++ b/rustyfit/src/profile/mesgdef/respiration_rate.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// RespirationRate is a RespirationRate message.

--- a/rustyfit/src/profile/mesgdef/schedule.rs
+++ b/rustyfit/src/profile/mesgdef/schedule.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Schedule is a Schedule message.

--- a/rustyfit/src/profile/mesgdef/sdm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/sdm_profile.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SdmProfile is a SdmProfile message.

--- a/rustyfit/src/profile/mesgdef/segment_file.rs
+++ b/rustyfit/src/profile/mesgdef/segment_file.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SegmentFile is a SegmentFile message.

--- a/rustyfit/src/profile/mesgdef/segment_id.rs
+++ b/rustyfit/src/profile/mesgdef/segment_id.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SegmentId is a SegmentId message.

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
+++ b/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SegmentLeaderboardEntry is a SegmentLeaderboardEntry message.

--- a/rustyfit/src/profile/mesgdef/segment_point.rs
+++ b/rustyfit/src/profile/mesgdef/segment_point.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
     match num {

--- a/rustyfit/src/profile/mesgdef/set.rs
+++ b/rustyfit/src/profile/mesgdef/set.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Set is a Set message.

--- a/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
+++ b/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SkinTempOvernight is a SkinTempOvernight message.

--- a/rustyfit/src/profile/mesgdef/slave_device.rs
+++ b/rustyfit/src/profile/mesgdef/slave_device.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SlaveDevice is a SlaveDevice message.

--- a/rustyfit/src/profile/mesgdef/sleep_assessment.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_assessment.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SleepAssessment is a SleepAssessment message.

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SleepDisruptionOvernightSeverity is a SleepDisruptionOvernightSeverity message.

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SleepDisruptionSeverityPeriod is a SleepDisruptionSeverityPeriod message.

--- a/rustyfit/src/profile/mesgdef/sleep_level.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_level.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SleepLevel is a SleepLevel message.

--- a/rustyfit/src/profile/mesgdef/software.rs
+++ b/rustyfit/src/profile/mesgdef/software.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Software is a Software message.

--- a/rustyfit/src/profile/mesgdef/speed_zone.rs
+++ b/rustyfit/src/profile/mesgdef/speed_zone.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SpeedZone is a SpeedZone message.

--- a/rustyfit/src/profile/mesgdef/split.rs
+++ b/rustyfit/src/profile/mesgdef/split.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Split is a Split message.

--- a/rustyfit/src/profile/mesgdef/split_summary.rs
+++ b/rustyfit/src/profile/mesgdef/split_summary.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// SplitSummary is a SplitSummary message.

--- a/rustyfit/src/profile/mesgdef/spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/spo2_data.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Spo2Data is a Spo2Data message.

--- a/rustyfit/src/profile/mesgdef/sport.rs
+++ b/rustyfit/src/profile/mesgdef/sport.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Sport is a Sport message.

--- a/rustyfit/src/profile/mesgdef/stress_level.rs
+++ b/rustyfit/src/profile/mesgdef/stress_level.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// StressLevel is a StressLevel message.

--- a/rustyfit/src/profile/mesgdef/tank_summary.rs
+++ b/rustyfit/src/profile/mesgdef/tank_summary.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// TankSummary is a TankSummary message.

--- a/rustyfit/src/profile/mesgdef/tank_update.rs
+++ b/rustyfit/src/profile/mesgdef/tank_update.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// TankUpdate is a TankUpdate message.

--- a/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// ThreeDSensorCalibration is a ThreeDSensorCalibration message.

--- a/rustyfit/src/profile/mesgdef/time_in_zone.rs
+++ b/rustyfit/src/profile/mesgdef/time_in_zone.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// TimeInZone is a TimeInZone message.

--- a/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
+++ b/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// TimestampCorrelation is a TimestampCorrelation message.

--- a/rustyfit/src/profile/mesgdef/totals.rs
+++ b/rustyfit/src/profile/mesgdef/totals.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Totals is a Totals message.

--- a/rustyfit/src/profile/mesgdef/training_file.rs
+++ b/rustyfit/src/profile/mesgdef/training_file.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// TrainingFile is a TrainingFile message.

--- a/rustyfit/src/profile/mesgdef/training_settings.rs
+++ b/rustyfit/src/profile/mesgdef/training_settings.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// TrainingSettings is a TrainingSettings message.

--- a/rustyfit/src/profile/mesgdef/user_profile.rs
+++ b/rustyfit/src/profile/mesgdef/user_profile.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// UserProfile is a UserProfile message.

--- a/rustyfit/src/profile/mesgdef/video.rs
+++ b/rustyfit/src/profile/mesgdef/video.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Video is a Video message.

--- a/rustyfit/src/profile/mesgdef/video_clip.rs
+++ b/rustyfit/src/profile/mesgdef/video_clip.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// VideoClip is a VideoClip message.

--- a/rustyfit/src/profile/mesgdef/video_description.rs
+++ b/rustyfit/src/profile/mesgdef/video_description.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// VideoDescription is a VideoDescription message.

--- a/rustyfit/src/profile/mesgdef/video_frame.rs
+++ b/rustyfit/src/profile/mesgdef/video_frame.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// VideoFrame is a VideoFrame message.

--- a/rustyfit/src/profile/mesgdef/video_title.rs
+++ b/rustyfit/src/profile/mesgdef/video_title.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// VideoTitle is a VideoTitle message.

--- a/rustyfit/src/profile/mesgdef/watchface_settings.rs
+++ b/rustyfit/src/profile/mesgdef/watchface_settings.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// WatchfaceSettings is a WatchfaceSettings message.

--- a/rustyfit/src/profile/mesgdef/weather_alert.rs
+++ b/rustyfit/src/profile/mesgdef/weather_alert.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// WeatherAlert is a WeatherAlert message.

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// WeatherConditions is a WeatherConditions message.

--- a/rustyfit/src/profile/mesgdef/weight_scale.rs
+++ b/rustyfit/src/profile/mesgdef/weight_scale.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// WeightScale is a WeightScale message.

--- a/rustyfit/src/profile/mesgdef/workout.rs
+++ b/rustyfit/src/profile/mesgdef/workout.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// Workout is a Workout message.

--- a/rustyfit/src/profile/mesgdef/workout_session.rs
+++ b/rustyfit/src/profile/mesgdef/workout_session.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// WorkoutSession is a WorkoutSession message.

--- a/rustyfit/src/profile/mesgdef/workout_step.rs
+++ b/rustyfit/src/profile/mesgdef/workout_step.rs
@@ -8,6 +8,8 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// WorkoutStep is a WorkoutStep message.

--- a/rustyfit/src/profile/mesgdef/zones_target.rs
+++ b/rustyfit/src/profile/mesgdef/zones_target.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 /// ZonesTarget is a ZonesTarget message.

--- a/rustyfit/src/profile/profile_type.rs
+++ b/rustyfit/src/profile/profile_type.rs
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file.
 
 use crate::profile::typedef::FitBaseType;
-use std::fmt;
+use core::fmt;
 
 pub const PROFILE_VERSION: u16 = 21201;
 

--- a/rustyfit/src/profile/typedef/activity.rs
+++ b/rustyfit/src/profile/typedef/activity.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/activity_class.rs
+++ b/rustyfit/src/profile/typedef/activity_class.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/activity_level.rs
+++ b/rustyfit/src/profile/typedef/activity_level.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/activity_subtype.rs
+++ b/rustyfit/src/profile/typedef/activity_subtype.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/activity_type.rs
+++ b/rustyfit/src/profile/typedef/activity_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/analog_watchface_layout.rs
+++ b/rustyfit/src/profile/typedef/analog_watchface_layout.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/ant_channel_id.rs
+++ b/rustyfit/src/profile/typedef/ant_channel_id.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/ant_network.rs
+++ b/rustyfit/src/profile/typedef/ant_network.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/antplus_device_type.rs
+++ b/rustyfit/src/profile/typedef/antplus_device_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/attitude_stage.rs
+++ b/rustyfit/src/profile/typedef/attitude_stage.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/attitude_validity.rs
+++ b/rustyfit/src/profile/typedef/attitude_validity.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/auto_activity_detect.rs
+++ b/rustyfit/src/profile/typedef/auto_activity_detect.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/auto_sync_frequency.rs
+++ b/rustyfit/src/profile/typedef/auto_sync_frequency.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/autolap_trigger.rs
+++ b/rustyfit/src/profile/typedef/autolap_trigger.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/autoscroll.rs
+++ b/rustyfit/src/profile/typedef/autoscroll.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/backlight_mode.rs
+++ b/rustyfit/src/profile/typedef/backlight_mode.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/backlight_timeout.rs
+++ b/rustyfit/src/profile/typedef/backlight_timeout.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/banded_exercises_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/banded_exercises_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/battery_status.rs
+++ b/rustyfit/src/profile/typedef/battery_status.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/battle_rope_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/battle_rope_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/bench_press_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/bench_press_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/bike_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/bike_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/bike_light_beam_angle_mode.rs
+++ b/rustyfit/src/profile/typedef/bike_light_beam_angle_mode.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/bike_light_network_config_type.rs
+++ b/rustyfit/src/profile/typedef/bike_light_network_config_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/bike_outdoor_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/bike_outdoor_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/ble_device_type.rs
+++ b/rustyfit/src/profile/typedef/ble_device_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/body_location.rs
+++ b/rustyfit/src/profile/typedef/body_location.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/bool.rs
+++ b/rustyfit/src/profile/typedef/bool.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/bp_status.rs
+++ b/rustyfit/src/profile/typedef/bp_status.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/calf_raise_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/calf_raise_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/camera_event_type.rs
+++ b/rustyfit/src/profile/typedef/camera_event_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/camera_orientation_type.rs
+++ b/rustyfit/src/profile/typedef/camera_orientation_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/cardio_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/cardio_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/carry_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/carry_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/ccr_setpoint_switch_mode.rs
+++ b/rustyfit/src/profile/typedef/ccr_setpoint_switch_mode.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/checksum.rs
+++ b/rustyfit/src/profile/typedef/checksum.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/chop_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/chop_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/climb_pro_event.rs
+++ b/rustyfit/src/profile/typedef/climb_pro_event.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/comm_timeout_type.rs
+++ b/rustyfit/src/profile/typedef/comm_timeout_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/connectivity_capabilities.rs
+++ b/rustyfit/src/profile/typedef/connectivity_capabilities.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/core_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/core_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/course_capabilities.rs
+++ b/rustyfit/src/profile/typedef/course_capabilities.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/course_point.rs
+++ b/rustyfit/src/profile/typedef/course_point.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/crunch_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/crunch_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/curl_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/curl_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/date_mode.rs
+++ b/rustyfit/src/profile/typedef/date_mode.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/date_time.rs
+++ b/rustyfit/src/profile/typedef/date_time.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/day_of_week.rs
+++ b/rustyfit/src/profile/typedef/day_of_week.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/deadlift_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/deadlift_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/device_index.rs
+++ b/rustyfit/src/profile/typedef/device_index.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/digital_watchface_layout.rs
+++ b/rustyfit/src/profile/typedef/digital_watchface_layout.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/display_heart.rs
+++ b/rustyfit/src/profile/typedef/display_heart.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/display_measure.rs
+++ b/rustyfit/src/profile/typedef/display_measure.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/display_orientation.rs
+++ b/rustyfit/src/profile/typedef/display_orientation.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/display_position.rs
+++ b/rustyfit/src/profile/typedef/display_position.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/display_power.rs
+++ b/rustyfit/src/profile/typedef/display_power.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/dive_alarm_type.rs
+++ b/rustyfit/src/profile/typedef/dive_alarm_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/dive_alert.rs
+++ b/rustyfit/src/profile/typedef/dive_alert.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/dive_backlight_mode.rs
+++ b/rustyfit/src/profile/typedef/dive_backlight_mode.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/dive_gas_mode.rs
+++ b/rustyfit/src/profile/typedef/dive_gas_mode.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/dive_gas_status.rs
+++ b/rustyfit/src/profile/typedef/dive_gas_status.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/elliptical_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/elliptical_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/event.rs
+++ b/rustyfit/src/profile/typedef/event.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/event_type.rs
+++ b/rustyfit/src/profile/typedef/event_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/exd_data_units.rs
+++ b/rustyfit/src/profile/typedef/exd_data_units.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/exd_descriptors.rs
+++ b/rustyfit/src/profile/typedef/exd_descriptors.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/exd_display_type.rs
+++ b/rustyfit/src/profile/typedef/exd_display_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/exd_layout.rs
+++ b/rustyfit/src/profile/typedef/exd_layout.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/exd_qualifiers.rs
+++ b/rustyfit/src/profile/typedef/exd_qualifiers.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/exercise_category.rs
+++ b/rustyfit/src/profile/typedef/exercise_category.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/favero_product.rs
+++ b/rustyfit/src/profile/typedef/favero_product.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/file.rs
+++ b/rustyfit/src/profile/typedef/file.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/file_flags.rs
+++ b/rustyfit/src/profile/typedef/file_flags.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/fit_base_type.rs
+++ b/rustyfit/src/profile/typedef/fit_base_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/fit_base_unit.rs
+++ b/rustyfit/src/profile/typedef/fit_base_unit.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/fitness_equipment_state.rs
+++ b/rustyfit/src/profile/typedef/fitness_equipment_state.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/floor_climb_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/floor_climb_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/flye_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/flye_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/garmin_product.rs
+++ b/rustyfit/src/profile/typedef/garmin_product.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/gas_consumption_rate_type.rs
+++ b/rustyfit/src/profile/typedef/gas_consumption_rate_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/gender.rs
+++ b/rustyfit/src/profile/typedef/gender.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/goal.rs
+++ b/rustyfit/src/profile/typedef/goal.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/goal_recurrence.rs
+++ b/rustyfit/src/profile/typedef/goal_recurrence.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/goal_source.rs
+++ b/rustyfit/src/profile/typedef/goal_source.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/hip_raise_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/hip_raise_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/hip_stability_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/hip_stability_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/hip_swing_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/hip_swing_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/hr_type.rs
+++ b/rustyfit/src/profile/typedef/hr_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/hr_zone_calc.rs
+++ b/rustyfit/src/profile/typedef/hr_zone_calc.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/hrv_status.rs
+++ b/rustyfit/src/profile/typedef/hrv_status.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/hyperextension_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/hyperextension_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/indoor_bike_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/indoor_bike_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/indoor_row_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/indoor_row_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/intensity.rs
+++ b/rustyfit/src/profile/typedef/intensity.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/ladder_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/ladder_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/language.rs
+++ b/rustyfit/src/profile/typedef/language.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/language_bits_0.rs
+++ b/rustyfit/src/profile/typedef/language_bits_0.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/language_bits_1.rs
+++ b/rustyfit/src/profile/typedef/language_bits_1.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/language_bits_2.rs
+++ b/rustyfit/src/profile/typedef/language_bits_2.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/language_bits_3.rs
+++ b/rustyfit/src/profile/typedef/language_bits_3.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/language_bits_4.rs
+++ b/rustyfit/src/profile/typedef/language_bits_4.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/lap_trigger.rs
+++ b/rustyfit/src/profile/typedef/lap_trigger.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/lateral_raise_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/lateral_raise_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/left_right_balance.rs
+++ b/rustyfit/src/profile/typedef/left_right_balance.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/left_right_balance_100.rs
+++ b/rustyfit/src/profile/typedef/left_right_balance_100.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/leg_curl_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/leg_curl_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/leg_raise_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/leg_raise_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/length_type.rs
+++ b/rustyfit/src/profile/typedef/length_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/local_date_time.rs
+++ b/rustyfit/src/profile/typedef/local_date_time.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/local_device_type.rs
+++ b/rustyfit/src/profile/typedef/local_device_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/localtime_into_day.rs
+++ b/rustyfit/src/profile/typedef/localtime_into_day.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/lunge_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/lunge_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/manufacturer.rs
+++ b/rustyfit/src/profile/typedef/manufacturer.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/max_met_category.rs
+++ b/rustyfit/src/profile/typedef/max_met_category.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/max_met_heart_rate_source.rs
+++ b/rustyfit/src/profile/typedef/max_met_heart_rate_source.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/max_met_speed_source.rs
+++ b/rustyfit/src/profile/typedef/max_met_speed_source.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/mesg_count.rs
+++ b/rustyfit/src/profile/typedef/mesg_count.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/mesg_num.rs
+++ b/rustyfit/src/profile/typedef/mesg_num.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/message_index.rs
+++ b/rustyfit/src/profile/typedef/message_index.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/move_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/move_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/nap_period_feedback.rs
+++ b/rustyfit/src/profile/typedef/nap_period_feedback.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/nap_source.rs
+++ b/rustyfit/src/profile/typedef/nap_source.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/no_fly_time_mode.rs
+++ b/rustyfit/src/profile/typedef/no_fly_time_mode.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/olympic_lift_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/olympic_lift_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/plank_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/plank_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/plyo_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/plyo_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/pose_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/pose_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/power_phase_type.rs
+++ b/rustyfit/src/profile/typedef/power_phase_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/projectile_type.rs
+++ b/rustyfit/src/profile/typedef/projectile_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/pull_up_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/pull_up_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/push_up_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/push_up_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/pwr_zone_calc.rs
+++ b/rustyfit/src/profile/typedef/pwr_zone_calc.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/radar_threat_level_type.rs
+++ b/rustyfit/src/profile/typedef/radar_threat_level_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/rider_position_type.rs
+++ b/rustyfit/src/profile/typedef/rider_position_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/row_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/row_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/run_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/run_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/run_indoor_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/run_indoor_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sandbag_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/sandbag_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/schedule.rs
+++ b/rustyfit/src/profile/typedef/schedule.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/segment_delete_status.rs
+++ b/rustyfit/src/profile/typedef/segment_delete_status.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/segment_lap_status.rs
+++ b/rustyfit/src/profile/typedef/segment_lap_status.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/segment_leaderboard_type.rs
+++ b/rustyfit/src/profile/typedef/segment_leaderboard_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/segment_selection_type.rs
+++ b/rustyfit/src/profile/typedef/segment_selection_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sensor_type.rs
+++ b/rustyfit/src/profile/typedef/sensor_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/session_trigger.rs
+++ b/rustyfit/src/profile/typedef/session_trigger.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/set_type.rs
+++ b/rustyfit/src/profile/typedef/set_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/shoulder_press_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/shoulder_press_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/shoulder_stability_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/shoulder_stability_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/shrug_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/shrug_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/side.rs
+++ b/rustyfit/src/profile/typedef/side.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sit_up_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/sit_up_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sled_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/sled_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sledge_hammer_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/sledge_hammer_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sleep_disruption_severity.rs
+++ b/rustyfit/src/profile/typedef/sleep_disruption_severity.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sleep_level.rs
+++ b/rustyfit/src/profile/typedef/sleep_level.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/source_type.rs
+++ b/rustyfit/src/profile/typedef/source_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/split_type.rs
+++ b/rustyfit/src/profile/typedef/split_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/spo2_measurement_type.rs
+++ b/rustyfit/src/profile/typedef/spo2_measurement_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sport.rs
+++ b/rustyfit/src/profile/typedef/sport.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sport_bits_0.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_0.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sport_bits_1.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_1.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sport_bits_2.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_2.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sport_bits_3.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_3.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sport_bits_4.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_4.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sport_bits_5.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_5.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sport_bits_6.rs
+++ b/rustyfit/src/profile/typedef/sport_bits_6.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sport_event.rs
+++ b/rustyfit/src/profile/typedef/sport_event.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/squat_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/squat_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/stair_stepper_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/stair_stepper_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/stroke_type.rs
+++ b/rustyfit/src/profile/typedef/stroke_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/sub_sport.rs
+++ b/rustyfit/src/profile/typedef/sub_sport.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/supported_exd_screen_layouts.rs
+++ b/rustyfit/src/profile/typedef/supported_exd_screen_layouts.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/suspension_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/suspension_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/swim_stroke.rs
+++ b/rustyfit/src/profile/typedef/swim_stroke.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/switch.rs
+++ b/rustyfit/src/profile/typedef/switch.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/tap_sensitivity.rs
+++ b/rustyfit/src/profile/typedef/tap_sensitivity.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/time_into_day.rs
+++ b/rustyfit/src/profile/typedef/time_into_day.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/time_mode.rs
+++ b/rustyfit/src/profile/typedef/time_mode.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/time_zone.rs
+++ b/rustyfit/src/profile/typedef/time_zone.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/timer_trigger.rs
+++ b/rustyfit/src/profile/typedef/timer_trigger.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/tire_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/tire_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/tissue_model_type.rs
+++ b/rustyfit/src/profile/typedef/tissue_model_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/tone.rs
+++ b/rustyfit/src/profile/typedef/tone.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/total_body_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/total_body_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/triceps_extension_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/triceps_extension_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/turn_type.rs
+++ b/rustyfit/src/profile/typedef/turn_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/user_local_id.rs
+++ b/rustyfit/src/profile/typedef/user_local_id.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/warm_up_exercise_name.rs
+++ b/rustyfit/src/profile/typedef/warm_up_exercise_name.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/watchface_mode.rs
+++ b/rustyfit/src/profile/typedef/watchface_mode.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/water_type.rs
+++ b/rustyfit/src/profile/typedef/water_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/weather_report.rs
+++ b/rustyfit/src/profile/typedef/weather_report.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/weather_severe_type.rs
+++ b/rustyfit/src/profile/typedef/weather_severe_type.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/weather_severity.rs
+++ b/rustyfit/src/profile/typedef/weather_severity.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/weather_status.rs
+++ b/rustyfit/src/profile/typedef/weather_status.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/weight.rs
+++ b/rustyfit/src/profile/typedef/weight.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/wkt_step_duration.rs
+++ b/rustyfit/src/profile/typedef/wkt_step_duration.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/wkt_step_target.rs
+++ b/rustyfit/src/profile/typedef/wkt_step_target.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/workout_capabilities.rs
+++ b/rustyfit/src/profile/typedef/workout_capabilities.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/workout_equipment.rs
+++ b/rustyfit/src/profile/typedef/workout_equipment.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/workout_hr.rs
+++ b/rustyfit/src/profile/typedef/workout_hr.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/profile/typedef/workout_power.rs
+++ b/rustyfit/src/profile/typedef/workout_power.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused, clippy::match_single_binding)]
 
-use std::fmt;
+use core::fmt;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -1,11 +1,10 @@
 #![warn(missing_docs)]
 
-use std::{error, fmt};
-
 use crate::profile::{
     ProfileType,
     typedef::{FitBaseType, MesgNum},
 };
+use alloc::{string::String, vec::Vec};
 
 /// Mask for determining if the message type is a message definition.
 pub(crate) const MESG_DEFINITION_MASK: u8 = 0b01000000;
@@ -57,8 +56,8 @@ pub enum Error {
     InvalidValue,
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match *self {
             Error::ProtocolViolationDeveloperData => {
                 write!(f, "protocol version 1.0 do not support developer data")
@@ -71,7 +70,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {}
+impl core::error::Error for Error {}
 
 /// FIT is FIT protocol data representative.
 #[derive(Debug, Default)]
@@ -469,7 +468,7 @@ impl Value {
                     String::from_utf8_lossy(
                         &buf[0..buf.iter().position(|&v| v == 0).unwrap_or(buf.len())],
                     )
-                    .to_string(),
+                    .into_owned(),
                 ),
             },
             FitBaseType::FLOAT32 => match array {
@@ -1094,6 +1093,7 @@ mod tests {
         profile::typedef::FitBaseType,
         proto::{Error, Value, strcount},
     };
+    use alloc::{borrow::ToOwned, string::String, vec, vec::Vec};
 
     #[test]
     fn test_strcount() {
@@ -1286,17 +1286,17 @@ mod tests {
                 is_valid: true,
             },
             Case {
-                value: Value::String("rustyfit".to_string()),
+                value: Value::String("rustyfit".to_owned()),
                 base_type: FitBaseType::STRING,
                 is_valid: true,
             },
             Case {
-                value: Value::String("".to_string()),
+                value: Value::String("".to_owned()),
                 base_type: FitBaseType::STRING,
                 is_valid: false,
             },
             Case {
-                value: Value::String("\x00".to_string()),
+                value: Value::String("\x00".to_owned()),
                 base_type: FitBaseType::STRING,
                 is_valid: false,
             },
@@ -1441,12 +1441,12 @@ mod tests {
                 is_valid: false,
             },
             Case {
-                value: Value::VecString(vec!["rustyfit".to_string(), "rustyfit".to_string()]),
+                value: Value::VecString(vec!["rustyfit".to_owned(), "rustyfit".to_owned()]),
                 base_type: FitBaseType::STRING,
                 is_valid: true,
             },
             Case {
-                value: Value::VecString(vec!["\x00".to_string(), "\x00".to_string()]),
+                value: Value::VecString(vec!["\x00".to_owned(), "\x00".to_owned()]),
                 base_type: FitBaseType::STRING,
                 is_valid: false,
             },

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -1,10 +1,10 @@
+use embedded_io_adapters::std::FromStd;
 use rustyfit::{Decoder, DecoderError, EncoderBuilder, Endianness, HeaderOption};
-use std::error::Error;
-use std::{fs, path::PathBuf};
 use std::{
-    fs::File,
+    error::Error,
+    fs::{self, File},
     io::{BufReader, Cursor, Seek, SeekFrom},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 #[test]
@@ -73,7 +73,7 @@ fn do_roudtrip_with_encoder_options(
 ) -> Result<(), Box<dyn Error>> {
     let file = File::open(path).unwrap();
     let br = BufReader::new(file);
-    let mut dec = Decoder::new(br);
+    let mut dec = Decoder::new(FromStd::new(br));
     let buf = Vec::<u8>::with_capacity(5_000 >> 10); // 5 MB, large enough to avoid realloc.
     let mut cursor = Cursor::new(buf);
 
@@ -96,7 +96,7 @@ fn do_roudtrip_with_encoder_options(
     } {
         cursor.seek(SeekFrom::Start(0)).unwrap();
 
-        let mut enc = EncoderBuilder::new(&mut cursor)
+        let mut enc = EncoderBuilder::new(FromStd::new(&mut cursor))
             .endianness(encoder_options.endianness)
             .header_option(encoder_options.header_option)
             .build();
@@ -109,7 +109,7 @@ fn do_roudtrip_with_encoder_options(
 
         cursor.seek(SeekFrom::Start(0)).unwrap();
 
-        let mut dec = Decoder::new(&mut cursor);
+        let mut dec = Decoder::new(FromStd::new(&mut cursor));
         let result_fit = match dec.decode() {
             Ok(result_fit) => result_fit,
             Err(err) => {


### PR DESCRIPTION
After learning more about Rust, I realized that all imports that we use from `std` is actually available on `core` and `alloc`. Without depending on `std`, we can push this library forward to support `#![no_std]`, making it available in a broader range of environments such as microcontrollers or WebAssembly. This movement is make sense since FIT format is commonly produced by wearable devices.

At the moment, I can't make this library heapless without complicating the code. I have no elegant solution for pure baremetal without dynamic memory allocation. That being said, this library is efficient enough to work on resource-constrained environments. I've tested it on a `#![no_std]` `#![no_main]` program to decode a FIT file (statically embedded) and print some of its Session's fields to `stdout` with a custom global allocator having less than 50 KB heap size and it works like a charm.

By supporting `#![no_std]`, users using `std` now must use adapter for `std::io::Read` and `std::io::Write`, since we now use `embedded_io::Read` and `embedded_io::Write`, but I believe this is a minor ergonomics change, other than that, the library can be used as usual.