### PR TITLE
refactor!: change builder signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ The `decode_with` method can be invoked multiple times to decode chained FIT fil
 
 #### DecoderBuilder
 
-Create `Decoder` instance with options using `DecoderBuilder`.
+Create `Decoder` instance with options using `Decoder::builder()` or `DecoderBuilder::new()`.
 
 ```rust
-let mut dec: Decoder = DecoderBuilder::new(br)
+let mut dec = Decoder::builder()
         .checksum(false)
         .expand_components(false)
-        .build();
+        .build(reader);
 ```
 
 ### Encoding
@@ -269,12 +269,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 #### EncoderBuilder
 
-Create `Encoder` instance with options using `EncoderBuilder`.
+Create `Encoder` instance with options using `Encoder::builder()` or `EncoderBuilder::new()`.
 
 ```rust
-let mut enc: Encoder = EncoderBuilder::new(&mut bw)
+let mut enc = Encoder::builder()
         .endianness(Endianness::BigEndian)
         .protocol_version(ProtocolVersion::V2)
         .header_option(HeaderOption::Compressed(3))
-        .build();
+        .build(writer);
 ```

--- a/rustyfit/benches/decoder.rs
+++ b/rustyfit/benches/decoder.rs
@@ -1,6 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use embedded_io_adapters::std::FromStd;
-use rustyfit::{Decoder, DecoderBuilder};
+use rustyfit::Decoder;
 use std::{hint::black_box, io::Cursor};
 
 const TEST_FILE: &str = "tests/data/large.fit";
@@ -17,10 +17,10 @@ pub fn bench_decode(c: &mut Criterion) {
 
     c.bench_function("decode no checksum no expand", |b| {
         b.iter(|| {
-            let mut dec = DecoderBuilder::new(black_box(FromStd::new(Cursor::new(&file_bytes))))
+            let mut dec = Decoder::builder()
                 .checksum(false)
                 .expand_components(false)
-                .build();
+                .build(black_box(FromStd::new(Cursor::new(&file_bytes))));
             dec.decode().unwrap();
         })
     });
@@ -34,10 +34,10 @@ pub fn bench_decode(c: &mut Criterion) {
 
     c.bench_function("decode_with no checksum no expand", |b| {
         b.iter(|| {
-            let mut dec = DecoderBuilder::new(black_box(FromStd::new(Cursor::new(&file_bytes))))
+            let mut dec = Decoder::builder()
                 .checksum(false)
                 .expand_components(false)
-                .build();
+                .build(black_box(FromStd::new(Cursor::new(&file_bytes))));
             dec.decode_with(|_| {}).unwrap();
         })
     });

--- a/rustyfit/benches/encoder.rs
+++ b/rustyfit/benches/encoder.rs
@@ -1,6 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use embedded_io_adapters::std::FromStd;
-use rustyfit::{Decoder, Encoder, EncoderBuilder, HeaderOption};
+use rustyfit::{Decoder, Encoder, HeaderOption};
 use std::{hint::black_box, io::Cursor};
 
 const TEST_FILE: &str = "tests/data/large.fit";
@@ -8,7 +8,7 @@ const TEST_FILE: &str = "tests/data/large.fit";
 pub fn bench_encode(c: &mut Criterion) {
     let file_bytes = std::fs::read(TEST_FILE).unwrap();
     let mut dec = Decoder::new(FromStd::new(Cursor::new(&file_bytes)));
-    let mut buf = Vec::<u8>::with_capacity(10_000 >> 10); // 10 MB, large enough to avoid realloc.
+    let mut buf = Vec::<u8>::with_capacity(5000 * 1024); // 5 MB, large enough to avoid realloc.
 
     while let Some(fit) = &mut dec.decode().unwrap() {
         c.bench_function("encode default", |b| {
@@ -23,9 +23,9 @@ pub fn bench_encode(c: &mut Criterion) {
         c.bench_function("encode normal interleave 15", |b| {
             b.iter(|| {
                 let cur = Cursor::new(&mut buf);
-                let mut enc = EncoderBuilder::new(black_box(FromStd::new(cur)))
+                let mut enc = Encoder::builder()
                     .header_option(HeaderOption::Normal(15))
-                    .build();
+                    .build(black_box(FromStd::new(cur)));
                 enc.encode(fit).unwrap();
                 buf.clear();
             })
@@ -34,9 +34,9 @@ pub fn bench_encode(c: &mut Criterion) {
         c.bench_function("encode compress interleave 3", |b| {
             b.iter(|| {
                 let cur = Cursor::new(&mut buf);
-                let mut enc = EncoderBuilder::new(black_box(FromStd::new(cur)))
+                let mut enc = Encoder::builder()
                     .header_option(HeaderOption::Compressed(3))
-                    .build();
+                    .build(black_box(FromStd::new(cur)));
                 enc.encode(fit).unwrap();
                 buf.clear();
             })

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -84,13 +84,14 @@ pub enum Event<'a> {
     Crc(&'a u16),
 }
 
+#[derive(Clone, Copy)]
 struct Options {
     checksum: bool,
     expand_components: bool,
 }
 
 /// Decoder for decoding FIT file.
-pub struct Decoder<R: Read> {
+pub struct Decoder<R> {
     reader: R,
     n: usize,
     cur: u32,
@@ -107,9 +108,9 @@ pub struct Decoder<R: Read> {
 
 impl<R: Read> Decoder<R> {
     /// Create new Decoder for decoding FIT file.
-    /// For more options, use DecoderBuilder to build the Decoder.
+    /// For more options, use `Decoder::builder()` to build the Decoder.
     pub fn new(reader: R) -> Self {
-        Builder::new(reader).build()
+        Builder::new().build(reader)
     }
 
     /// Decode return a single FIT sequence. If it's a chained FIT file, call this method multiple times.
@@ -693,17 +694,22 @@ fn push_value_to_vec(vec_value: &mut Value, value: &Value) {
     }
 }
 
+impl Decoder<()> {
+    /// Create new Decoder with options for decoding FIT file.
+    pub const fn builder() -> Builder {
+        Builder::new()
+    }
+}
+
 /// Build Decoder with some options.
-pub struct Builder<R: Read> {
-    reader: R,
+pub struct Builder {
     options: Options,
 }
 
-impl<R: Read> Builder<R> {
+impl Builder {
     /// Create new DecoderBuilder.
-    pub const fn new(reader: R) -> Self {
+    pub const fn new() -> Self {
         Self {
-            reader,
             options: Options {
                 checksum: true,
                 expand_components: true,
@@ -725,9 +731,9 @@ impl<R: Read> Builder<R> {
     }
 
     /// Build Decoder based on given options (if any).
-    pub fn build(self) -> Decoder<R> {
+    pub fn build<R: Read>(&self, reader: R) -> Decoder<R> {
         Decoder {
-            reader: self.reader,
+            reader: reader,
             n: 0,
             cur: 0,
             crc16: Crc16::new(),

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -99,6 +99,7 @@ pub enum Endianness {
     BigEndian = 1,
 }
 
+#[derive(Clone, Copy)]
 struct Options {
     protocol_version: ProtocolVersion,
     endianness: Endianness,
@@ -106,7 +107,7 @@ struct Options {
 }
 
 /// Encoder for encoding FIT file.
-pub struct Encoder<W: Write + Seek> {
+pub struct Encoder<W> {
     writer: W,
     n: i64,
     last_file_header_pos: i64,
@@ -121,9 +122,9 @@ pub struct Encoder<W: Write + Seek> {
 
 impl<W: Write + Seek> Encoder<W> {
     /// Create new Encoder for encoding FIT file.
-    /// For more options, use EncoderBuilder to build the Encoder.
+    /// For more options, use `Encoder::builder()` to build the Encoder.
     pub fn new(writer: W) -> Encoder<W> {
-        Builder::new(writer).build()
+        Builder::new().build(writer)
     }
 
     /// Encode the given `fit` to the writer.
@@ -373,17 +374,22 @@ fn marshal_append_message_definition(buf: &mut Vec<u8>, mesg: &Message, arch: u8
     }
 }
 
+impl Encoder<()> {
+    /// Create new Encoder with options for encoding FIT file.
+    pub const fn builder() -> Builder {
+        Builder::new()
+    }
+}
+
 /// Build Encoder with some options.
-pub struct Builder<W: Write + Seek> {
-    writer: W,
+pub struct Builder {
     options: Options,
 }
 
-impl<W: Write + Seek> Builder<W> {
+impl Builder {
     /// Create new DecoderBuilder.
-    pub const fn new(writer: W) -> Builder<W> {
+    pub const fn new() -> Builder {
         Self {
-            writer,
             options: Options {
                 protocol_version: ProtocolVersion(0),
                 endianness: Endianness::LittleEndian,
@@ -414,9 +420,9 @@ impl<W: Write + Seek> Builder<W> {
     }
 
     /// Build Encoder based on given options (if any).
-    pub fn build(self) -> Encoder<W> {
+    pub fn build<W: Write + Seek>(&self, writer: W) -> Encoder<W> {
         Encoder {
-            writer: self.writer,
+            writer: writer,
             n: 0,
             last_file_header_pos: 0,
             data_size: 0,

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -14,10 +14,9 @@ fn decode_encode_roundtrip() {
         &mut |path: &PathBuf| {
             do_roudtrip_with_encoder_options(
                 path,
-                EncoderOptions {
-                    endianness: Endianness::LittleEndian,
-                    header_option: HeaderOption::Normal(0),
-                },
+                EncoderBuilder::new()
+                    .endianness(Endianness::LittleEndian)
+                    .header_option(HeaderOption::Normal(0)),
             )
         },
     )
@@ -31,19 +30,13 @@ fn decode_encode_roundtrip_compressed() {
         &mut |path: &PathBuf| {
             do_roudtrip_with_encoder_options(
                 path,
-                EncoderOptions {
-                    endianness: Endianness::BigEndian,
-                    header_option: HeaderOption::Compressed(3),
-                },
+                EncoderBuilder::new()
+                    .endianness(Endianness::BigEndian)
+                    .header_option(HeaderOption::Compressed(3)),
             )
         },
     )
     .unwrap();
-}
-
-struct EncoderOptions {
-    endianness: Endianness,
-    header_option: HeaderOption,
 }
 
 fn walk_path<F>(path: &PathBuf, f: &mut F) -> Result<(), Box<dyn Error>>
@@ -69,12 +62,12 @@ where
 
 fn do_roudtrip_with_encoder_options(
     path: &PathBuf,
-    encoder_options: EncoderOptions,
+    encoder_builder: EncoderBuilder,
 ) -> Result<(), Box<dyn Error>> {
     let file = File::open(path).unwrap();
     let br = BufReader::new(file);
     let mut dec = Decoder::new(FromStd::new(br));
-    let buf = Vec::<u8>::with_capacity(5_000 >> 10); // 5 MB, large enough to avoid realloc.
+    let buf = Vec::<u8>::with_capacity(5000 * 1024); // 5 MB, large enough to avoid realloc.
     let mut cursor = Cursor::new(buf);
 
     'decode: while let Some(fit) = &mut match dec.decode() {
@@ -96,10 +89,7 @@ fn do_roudtrip_with_encoder_options(
     } {
         cursor.seek(SeekFrom::Start(0)).unwrap();
 
-        let mut enc = EncoderBuilder::new(FromStd::new(&mut cursor))
-            .endianness(encoder_options.endianness)
-            .header_option(encoder_options.header_option)
-            .build();
+        let mut enc = encoder_builder.build(FromStd::new(&mut cursor));
 
         let expected_messages = fit.messages.clone(); // Must clone since encoder mutates the value.
 


### PR DESCRIPTION
Builders signature are changed, `build` method new accept value instead of `new` to make it reusable. The builder itself only need the value at the end when calling `build`. The builder itself no longer need to be generic,  only the build method.
- `DecoderBuilder::new(reader).build()` is now changed into `DecoderBuilder::new().build(reader)` 
- `EncoderBuilder::new(writer).build()` is now changed into `EncoderBuilder::new().build(writer)` 

The `build` method is now `&self` since it's more like an intermediate representation and we don't need it to `move`.

Add associated method `builder` for both `Decoder` and `Encoder` for easier feature discovery that they can be instantiated using options without users have to know about the builder struct itself.

- `Decoder::builder().checksum(false).build(reader)`
- `Encoder::builder().protocol_version(ProtocolVersion::V2).build(writer)`