### PR TITLE
chore: simplify code

### DIFF
--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -54,13 +54,13 @@ where
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
-            Error::Io { err, n } => write!(f, "io error {} at byte pos {}", err, n),
-            Error::UnexpectedEof { n } => write!(f, "unexpected EOF at byte pos {}", n),
-            Error::NotFITFile => write!(f, "not a FIT file"),
-            Error::ChecksumMismatch { expected, got } => {
+            Self::Io { err, n } => write!(f, "io error: {} at byte pos: {}", err, n),
+            Self::UnexpectedEof { n } => write!(f, "unexpected EOF at byte pos: {}", n),
+            Self::NotFITFile => write!(f, "not a FIT file"),
+            Self::ChecksumMismatch { expected, got } => {
                 write!(f, "checksum mismatch, expected {} got {}", expected, got)
             }
-            Error::MissingMessageDefinition { local_mesg_num } => write!(
+            Self::MissingMessageDefinition { local_mesg_num } => write!(
                 f,
                 "missing message definition for local message number {}",
                 local_mesg_num

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -54,7 +54,7 @@ where
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
-            Self::Io { err, n } => write!(f, "io: {}, n: {}", err, n),
+            Self::Io { err, n } => write!(f, "io error: {} at byte pos: {}", err, n),
             Self::EmptyMessages => write!(f, "messages is empty"),
             Self::Protocol {
                 mesg_index,

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -238,17 +238,14 @@ impl<W: Write + Seek> Encoder<W> {
     fn encode_messages(&mut self, messages: &mut [Message]) -> Result<(), Error<W::Error>> {
         for (i, mesg) in messages.iter_mut().enumerate() {
             if let Err(e) = self.encode_message(mesg) {
-                match e {
-                    Error::Io { err, .. } => return Err(Error::Io { err, n: self.n }),
-                    Error::Protocol { err, .. } => {
-                        return Err(Error::Protocol {
-                            mesg_index: i,
-                            mesg_num: mesg.num,
-                            err,
-                        });
-                    }
-                    _ => return Err(e),
+                if let Error::Protocol { err, .. } = e {
+                    return Err(Error::Protocol {
+                        mesg_index: i,
+                        mesg_num: mesg.num,
+                        err,
+                    });
                 }
+                return Err(e);
             }
         }
         Ok(())

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -59,13 +59,13 @@ pub enum Error {
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match *self {
-            Error::ProtocolViolationDeveloperData => {
+            Self::ProtocolViolationDeveloperData => {
                 write!(f, "protocol version 1.0 do not support developer data")
             }
-            Error::ProtocolViolationUnsupportedBaseType(base_type) => {
+            Self::ProtocolViolationUnsupportedBaseType(base_type) => {
                 write!(f, "protocol version 1.0 do not support type {}", base_type)
             }
-            Error::InvalidValue => write!(f, "invalid proto::Value"),
+            Self::InvalidValue => write!(f, "invalid proto::Value"),
         }
     }
 }


### PR DESCRIPTION
- use `Self::` rather than its actual name such as `Error::` 
- simplify encoder error handling, no need to match error io since we already correctly construct it.