### PR TITLE
perf: reduce storage for field description

### DIFF
--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -5,10 +5,9 @@ mod bits;
 
 use crate::{
     crc16::Crc16,
-    decoder::accumulator::Accumulator,
-    decoder::bits::Bits,
+    decoder::{accumulator::Accumulator, bits::Bits},
     profile::{
-        ProfileType, lookup, mesgdef,
+        ProfileType, lookup,
         typedef::{FitBaseType, MesgNum},
     },
     proto::*,
@@ -102,7 +101,7 @@ pub struct Decoder<R> {
     last_time_offset: u8,
     buf_fields: Vec<Field>,
     buf_developer_fields: Vec<DeveloperField>,
-    field_descriptions: Vec<mesgdef::FieldDescription>,
+    field_descriptions: Vec<LocalFieldDescription>,
     options: Options,
 }
 
@@ -364,7 +363,7 @@ impl<R: Read> Decoder<R> {
         // Developer Data Lookup, currently we allow missing developer_data_id
         if mesg.num == MesgNum::FIELD_DESCRIPTION {
             self.field_descriptions
-                .push(mesgdef::FieldDescription::from(&*mesg));
+                .push(LocalFieldDescription::from(&*mesg));
         }
 
         if !self.options.expand_components {

--- a/rustyfit/src/encoder/validator.rs
+++ b/rustyfit/src/encoder/validator.rs
@@ -5,7 +5,7 @@ use crate::{
         mesgdef,
         typedef::{FitBaseType, MesgNum},
     },
-    proto::{Message, Value},
+    proto::{LocalFieldDescription, Message, Value},
 };
 use alloc::{string::String, vec::Vec};
 
@@ -95,7 +95,7 @@ impl core::fmt::Display for IntegrityError {
 
 pub(super) struct MessageValidator {
     developer_data_index_seen: [u64; 4],
-    field_descriptions: Vec<mesgdef::FieldDescription>,
+    field_descriptions: Vec<LocalFieldDescription>,
 }
 
 impl MessageValidator {
@@ -154,7 +154,7 @@ impl MessageValidator {
             }
             MesgNum::FIELD_DESCRIPTION => self
                 .field_descriptions
-                .push(mesgdef::FieldDescription::from(mesg as &Message)),
+                .push(LocalFieldDescription::from(&*mesg)),
             _ => {}
         };
 

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -1065,6 +1065,35 @@ pub(crate) fn validate_message(
     Ok(())
 }
 
+/// Simplified version of `FieldDescription` message.
+///
+/// We only need these fields to process developer data.
+#[derive(Clone, Copy)]
+pub(crate) struct LocalFieldDescription {
+    pub(crate) developer_data_index: u8,
+    pub(crate) field_definition_number: u8,
+    pub(crate) fit_base_type_id: FitBaseType,
+}
+
+impl From<&Message> for LocalFieldDescription {
+    fn from(mesg: &Message) -> Self {
+        let mut s = Self {
+            developer_data_index: u8::MAX,
+            field_definition_number: u8::MAX,
+            fit_base_type_id: FitBaseType(u8::MAX),
+        };
+        for field in &mesg.fields {
+            match field.num {
+                0 => s.developer_data_index = field.value.as_u8(),
+                1 => s.field_definition_number = field.value.as_u8(),
+                2 => s.fit_base_type_id = FitBaseType(field.value.as_u8()),
+                _ => {}
+            };
+        }
+        return s;
+    }
+}
+
 /// Counts how many valid utf-8 string in s.
 pub(crate) fn strcount(s: &[u8]) -> u8 {
     let mut last = 0usize;


### PR DESCRIPTION
Sizeof `mesgdef::FieldDescription` is 160 bytes (exclude unknown fields), while we only need 3 bytes of it to process developer data. We waste 157 bytes per instance. And a single FIT file may have a few more of them and it's heap allocated. This will reduce presure to global allocator especially  on baremetal.