### PR TITLE
chore: move constants into its associated item

### DIFF
--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -182,7 +182,7 @@ impl<R: Read> Decoder<R> {
         }
         self.n += n - 1;
 
-        if &arr[8..12] != DATA_TYPE.as_bytes() {
+        if &arr[8..12] != FileHeader::DATA_TYPE.as_bytes() {
             return Err(Error::NotFITFile);
         }
 
@@ -207,7 +207,7 @@ impl<R: Read> Decoder<R> {
             protocol_version: ProtocolVersion(arr[1]),
             profile_version: u16::from_le_bytes([arr[12], arr[13]]),
             data_size: u32::from_le_bytes(arr[4..8].try_into().unwrap()),
-            data_type: DATA_TYPE,
+            data_type: FileHeader::DATA_TYPE,
             crc,
         }))
     }
@@ -239,8 +239,8 @@ impl<R: Read> Decoder<R> {
 
             let header = arr[0];
 
-            if header & MESG_HEADER_MASK == MESG_DEFINITION_MASK {
-                let local_mesg_num = (header & LOCAL_MESG_NUM_MASK) as usize;
+            if header & Message::HEADER_MASK == Message::DEFINITION_MASK {
+                let local_mesg_num = (header & Message::LOCAL_NUM_MASK) as usize;
                 let mut mesg_def = mem::take(&mut self.mesg_definitions[local_mesg_num]);
                 mesg_def.header = header;
 
@@ -252,12 +252,12 @@ impl<R: Read> Decoder<R> {
                 continue;
             }
 
-            let local_mesg_num = match header & MESG_COMPRESSED_HEADER_MASK {
-                MESG_COMPRESSED_HEADER_MASK => {
-                    (header & COMPRESSED_LOCAL_MESG_NUM_MASK) >> COMPRESSED_BIT_SHIFT
+            let local_mesg_num = match header & Message::COMPRESSED_HEADER_MASK {
+                Message::COMPRESSED_HEADER_MASK => {
+                    (header & Message::COMPRESSED_LOCAL_NUM_MASK) >> Message::COMPRESSED_BIT_SHIFT
                 }
                 _ => header,
-            } & LOCAL_MESG_NUM_MASK;
+            } & Message::LOCAL_NUM_MASK;
 
             let mesg_def = mem::take(&mut self.mesg_definitions[local_mesg_num as usize]);
             if mesg_def.header == 0 {
@@ -316,7 +316,7 @@ impl<R: Read> Decoder<R> {
                 base_type: FitBaseType(b[2]),
             }));
 
-        if mesg_def.header & DEV_DATA_MASK == DEV_DATA_MASK {
+        if mesg_def.header & Message::DEV_DATA_MASK == Message::DEV_DATA_MASK {
             self.read_exact_inc(&mut arr[..1])?;
 
             let n = arr[0] as usize * 3;
@@ -341,15 +341,16 @@ impl<R: Read> Decoder<R> {
         mesg: &mut Message,
         mesg_def: &MessageDefinition,
     ) -> Result<(), Error<R::Error>> {
-        if mesg.header & MESG_COMPRESSED_HEADER_MASK == MESG_COMPRESSED_HEADER_MASK {
-            let time_offset = mesg.header & COMPRESSED_TIME_MASK;
+        if mesg.header & Message::COMPRESSED_HEADER_MASK == Message::COMPRESSED_HEADER_MASK {
+            let time_offset = mesg.header & Message::COMPRESSED_TIME_MASK;
             self.timestamp = self.timestamp.wrapping_add(
-                (time_offset.wrapping_sub(self.last_time_offset) & COMPRESSED_TIME_MASK) as u32,
+                (time_offset.wrapping_sub(self.last_time_offset) & Message::COMPRESSED_TIME_MASK)
+                    as u32,
             );
             self.last_time_offset = time_offset;
 
             mesg.fields.push(Field {
-                num: FIELD_NUM_TIMESTAMP,
+                num: Field::TIMESTAMP,
                 profile_type: ProfileType::DATE_TIME,
                 is_expanded: false,
                 value: Value::Uint32(self.timestamp),
@@ -444,10 +445,10 @@ impl<R: Read> Decoder<R> {
 
             let value = Value::unmarshal(buf, array, base_type, mesg_def.arch);
 
-            if num == FIELD_NUM_TIMESTAMP && base_type == FitBaseType::UINT32 {
+            if num == Field::TIMESTAMP && base_type == FitBaseType::UINT32 {
                 if let Value::Uint32(v) = value {
                     self.timestamp = v;
-                    self.last_time_offset = v as u8 & COMPRESSED_TIME_MASK;
+                    self.last_time_offset = v as u8 & Message::COMPRESSED_TIME_MASK;
                 }
             }
 

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -188,7 +188,7 @@ impl<W: Write + Seek> Encoder<W> {
             file_header.profile_version = PROFILE_VERSION;
         }
 
-        file_header.data_type = DATA_TYPE;
+        file_header.data_type = FileHeader::DATA_TYPE;
         file_header.crc = 0; // recalculated
 
         let buf = &mut self.buf;
@@ -252,7 +252,7 @@ impl<W: Write + Seek> Encoder<W> {
     }
 
     fn encode_message(&mut self, mesg: &mut Message) -> Result<(), Error<W::Error>> {
-        mesg.header = MESG_NORMAL_HEADER_MASK;
+        mesg.header = Message::NORMAL_HEADER_MASK;
 
         if let HeaderOption::Compressed(_) = self.options.header_option {
             self.compress_timestamp_into_header(mesg);
@@ -265,8 +265,8 @@ impl<W: Write + Seek> Encoder<W> {
         let (local_mesg_num, is_new_mesg_def) = self.lru.put(&buf);
 
         buf[0] |= local_mesg_num;
-        if mesg.header & MESG_COMPRESSED_HEADER_MASK == MESG_COMPRESSED_HEADER_MASK {
-            mesg.header |= local_mesg_num << COMPRESSED_BIT_SHIFT;
+        if mesg.header & Message::COMPRESSED_HEADER_MASK == Message::COMPRESSED_HEADER_MASK {
+            mesg.header |= local_mesg_num << Message::COMPRESSED_BIT_SHIFT;
         } else {
             mesg.header |= local_mesg_num;
         }
@@ -303,7 +303,7 @@ impl<W: Write + Seek> Encoder<W> {
         let timestamp = mesg
             .fields
             .iter()
-            .find(|field| field.num == FIELD_NUM_TIMESTAMP)
+            .find(|field| field.num == Field::TIMESTAMP)
             .map(|field| field.value.as_u32())
             .unwrap_or(u32::MAX);
 
@@ -311,14 +311,14 @@ impl<W: Write + Seek> Encoder<W> {
             return;
         }
 
-        if timestamp.wrapping_sub(self.timestamp_reference) as u8 > COMPRESSED_TIME_MASK {
+        if timestamp.wrapping_sub(self.timestamp_reference) as u8 > Message::COMPRESSED_TIME_MASK {
             self.timestamp_reference = timestamp;
             return;
         }
 
-        let time_offset = (timestamp & COMPRESSED_TIME_MASK as u32) as u8;
-        mesg.header = MESG_COMPRESSED_HEADER_MASK | time_offset;
-        mesg.fields.retain(|field| field.num != FIELD_NUM_TIMESTAMP);
+        let time_offset = (timestamp & Message::COMPRESSED_TIME_MASK as u32) as u8;
+        mesg.header = Message::COMPRESSED_HEADER_MASK | time_offset;
+        mesg.fields.retain(|field| field.num != Field::TIMESTAMP);
     }
 
     fn encode_crc(&mut self) -> Result<(), Error<W::Error>> {
@@ -341,9 +341,9 @@ impl<W: Write + Seek> Encoder<W> {
 
 fn marshal_append_message_definition(buf: &mut Vec<u8>, mesg: &Message, arch: u8) {
     buf.extend_from_slice(&[
-        MESG_DEFINITION_MASK, // header
-        0,                    // reserved
-        arch,                 // architecture
+        Message::DEFINITION_MASK, // header
+        0,                        // reserved
+        arch,                     // architecture
     ]);
 
     buf.extend_from_slice(&match arch {
@@ -362,7 +362,7 @@ fn marshal_append_message_definition(buf: &mut Vec<u8>, mesg: &Message, arch: u8
         return;
     }
 
-    buf[0] |= DEV_DATA_MASK;
+    buf[0] |= Message::DEV_DATA_MASK;
     buf.push(mesg.developer_fields.len() as u8);
     for developer_field in &mesg.developer_fields {
         buf.push(developer_field.num);
@@ -443,7 +443,7 @@ mod tests {
     use crate::{
         Encoder,
         profile::{mesgdef, typedef},
-        proto::{COMPRESSED_TIME_MASK, MESG_COMPRESSED_HEADER_MASK, Message},
+        proto::Message,
     };
     use alloc::vec;
     use embedded_io::{ErrorKind, ErrorType, Seek, Write};
@@ -522,8 +522,8 @@ mod tests {
                 // Timestamp is compressed into header since roll over < 32
                 rec.distance = 300 * meter;
                 let mut mesg = Message::from(rec);
-                mesg.header |=
-                    MESG_COMPRESSED_HEADER_MASK | (1062594925 & COMPRESSED_TIME_MASK as u32) as u8;
+                mesg.header |= Message::COMPRESSED_HEADER_MASK
+                    | (1062594925 & Message::COMPRESSED_TIME_MASK as u32) as u8;
                 mesg
             },
         ];

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -6,44 +6,6 @@ use crate::profile::{
 };
 use alloc::{string::String, vec::Vec};
 
-/// Mask for determining if the message type is a message definition.
-pub(crate) const MESG_DEFINITION_MASK: u8 = 0b01000000;
-
-/// Mask for determining if the message type is a normal message data .
-pub(crate) const MESG_NORMAL_HEADER_MASK: u8 = 0b00000000;
-
-/// Mask for determining if the message type is a compressed timestamp message data.
-pub(crate) const MESG_COMPRESSED_HEADER_MASK: u8 = 0b10000000;
-
-/// Mask for determining if the message's header is a message definition or is it
-/// actually a message data with compressed timestamp and multiple local message type.
-///
-/// For compressed timestamp, message data's header bit 5-6 is the local message type.
-/// Bit 6 overlap with MESG_DEFINITION_MASK, it's a message definition only if Bit 7 is zero.
-pub(crate) const MESG_HEADER_MASK: u8 = MESG_COMPRESSED_HEADER_MASK | MESG_DEFINITION_MASK;
-
-/// Mask for mapping normal message data to the message definition.
-pub(crate) const LOCAL_MESG_NUM_MASK: u8 = 0b00001111;
-
-/// Mask for mapping compressed timestamp message data to the message definition. Used with CompressedBitShift.
-pub(crate) const COMPRESSED_LOCAL_MESG_NUM_MASK: u8 = 0b01100000;
-
-/// Mask for measuring time offset value from header. Compressed timestamp is using 5 least significant bits (lsb) of header
-pub(crate) const COMPRESSED_TIME_MASK: u8 = 0b00011111;
-
-/// Mask for determining if a message contains developer fields.
-pub(crate) const DEV_DATA_MASK: u8 = 0b00100000;
-
-/// Used for right-shifting the 5 least significant bits (lsb) of compressed time.
-pub(crate) const COMPRESSED_BIT_SHIFT: u8 = 5;
-
-/// Field's number for timestamp across all defined messages in the profile.
-/// Exception: Course Point and Set message.
-pub(crate) const FIELD_NUM_TIMESTAMP: u8 = 253;
-
-/// FileHeader's data_type.
-pub(crate) static DATA_TYPE: &str = ".FIT";
-
 /// Defined errors returned from proto module.
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug)]
@@ -95,7 +57,7 @@ pub struct FileHeader {
     pub profile_version: u16,
     /// The size of the messages in bytes (this field will be automatically updated by the encoder)
     pub data_size: u32,
-    /// ".FIT" (an immutable string constant)
+    /// String marker `.FIT`. Any user-provided value is automatically overwritten with `FileHeader::DATA_TYPE` during encoding.
     pub data_type: &'static str,
     /// Cyclic Redundancy Check 16-bit value to ensure the integrity of the file header.
     /// (this field will be automatically updated by the encoder)
@@ -103,12 +65,14 @@ pub struct FileHeader {
 }
 
 impl FileHeader {
+    pub(crate) const DATA_TYPE: &str = ".FIT";
+
     pub(crate) fn marshal_append(&self, vec: &mut Vec<u8>) {
         vec.push(self.size);
         vec.push(self.protocol_version.0);
         vec.extend_from_slice(&self.profile_version.to_le_bytes());
         vec.extend_from_slice(&self.data_size.to_le_bytes());
-        vec.extend_from_slice(DATA_TYPE.as_bytes());
+        vec.extend_from_slice(Self::DATA_TYPE.as_bytes());
         if self.size >= 14 {
             vec.extend_from_slice(&self.crc.to_le_bytes());
         }
@@ -170,6 +134,29 @@ pub struct Message {
 }
 
 impl Message {
+    /// Mask for determining if the message type is a message definition.
+    pub(crate) const DEFINITION_MASK: u8 = 0b01000000;
+    /// Mask for determining if the message type is a normal message data .
+    pub(crate) const NORMAL_HEADER_MASK: u8 = 0b00000000;
+    /// Mask for determining if the message type is a compressed timestamp message data.
+    pub(crate) const COMPRESSED_HEADER_MASK: u8 = 0b10000000;
+    /// Mask for determining if the message's header is a message definition or is it
+    /// actually a message data with compressed timestamp and multiple local message type.
+    ///
+    /// For compressed timestamp, message data's header bit 5-6 is the local message type.
+    /// Bit 6 overlap with MESG_DEFINITION_MASK, it's a message definition only if Bit 7 is zero.
+    pub(crate) const HEADER_MASK: u8 = Self::COMPRESSED_HEADER_MASK | Self::DEFINITION_MASK;
+    /// Mask for mapping normal message data to the message definition.
+    pub(crate) const LOCAL_NUM_MASK: u8 = 0b00001111;
+    /// Mask for mapping compressed timestamp message data to the message definition. Used with CompressedBitShift.
+    pub(crate) const COMPRESSED_LOCAL_NUM_MASK: u8 = 0b01100000;
+    /// Mask for measuring time offset value from header. Compressed timestamp is using 5 least significant bits (lsb) of header
+    pub(crate) const COMPRESSED_TIME_MASK: u8 = 0b00011111;
+    /// Mask for determining if a message contains developer fields.
+    pub(crate) const DEV_DATA_MASK: u8 = 0b00100000;
+    /// Used for right-shifting the 5 least significant bits (lsb) of compressed time.
+    pub(crate) const COMPRESSED_BIT_SHIFT: u8 = 5;
+
     /// SubFieldSubstitution returns any sub-field that can substitute
     /// the properties interpretation of the parent Field (Dynamic Field).
     pub fn sub_field_substitution<'a>(
@@ -216,6 +203,12 @@ pub struct Field {
     pub value: Value,
     /// A flag to detect whether this field is generated through component expansion.
     pub is_expanded: bool,
+}
+
+impl Field {
+    /// Field's number for timestamp across all defined messages in the profile.
+    /// Exception: `CoursePoint` (1) and `Set` message (254).
+    pub(crate) const TIMESTAMP: u8 = 253;
 }
 
 /// FieldReference acts as a representation of a field as defined in the Global FIT Profile.


### PR DESCRIPTION
Associated constants are more easier to navigate that free global constants. This reduce the mental load for understanding the code such as "where this constant is used for" into "this constant is only used when we dealing this item".