### PR TITLE
feat: mesgdef add degrees method

### DIFF
--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -138,6 +138,9 @@ func (b *Builder) Build() ([]generator.Data, error) {
 					imports["alloc::borrow::ToOwned"] = struct{}{}
 				}
 			}
+			if field.Units == "semicircles" {
+				imports["crate::semconv"] = struct{}{}
+			}
 
 			if _, ok := canExpand[parserField.Name]; ok {
 				field.CanExpand = true

--- a/fitgen/internal/profile/mesgdef/mesgdef.tmpl
+++ b/fitgen/internal/profile/mesgdef/mesgdef.tmpl
@@ -81,6 +81,15 @@ impl {{ .Name }} {
     }
 
     {{ range .Fields -}}
+    {{ if eq .Units "semicircles" }}
+        /// Returns `{{ .Name }}` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+        pub fn {{ .Name }}_degrees(&self) -> f64 {
+            semconv::to_degrees(self.{{ .Name }})
+        }
+    {{ end }}
+    {{ end }}
+
+    {{ range .Fields -}}
     {{ if not (and (eq .Scale 1.0) (eq .Offset 0.0)) -}}
         /// Returns `{{ .Name }}` in its scaled value. It returns invalid f64 when value is valid.
         {{ if not .Array -}}

--- a/fitgen/main.go
+++ b/fitgen/main.go
@@ -61,6 +61,10 @@ func main() {
 		fatalf("could no parse message: %v\n", err)
 	}
 
+	if filepath.Base(*generatePath) != "src" {
+		*generatePath = filepath.Join(*generatePath, "src")
+	}
+
 	path := abspath(*generatePath)
 	lookup := lookup.New(parsedtypes, parsedmesgs)
 	var (

--- a/rustyfit/src/profile/mesgdef/climb_pro.rs
+++ b/rustyfit/src/profile/mesgdef/climb_pro.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
@@ -59,6 +60,16 @@ impl ClimbPro {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_lat)
+    }
+
+    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_long)
     }
 }
 

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -63,6 +64,16 @@ impl CoursePoint {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_lat)
+    }
+
+    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_long)
     }
 
     /// Returns `distance` in its scaled value. It returns invalid f64 when value is valid.

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
@@ -72,6 +73,16 @@ impl GpsMetadata {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_lat)
+    }
+
+    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_long)
     }
 
     /// Returns `enhanced_altitude` in its scaled value. It returns invalid f64 when value is valid.

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -85,6 +86,16 @@ impl Jump {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_lat)
+    }
+
+    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_long)
     }
 
     /// Returns `speed` in its scaled value. It returns invalid f64 when value is valid.

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -637,6 +638,26 @@ impl Lap {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `start_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn start_position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.start_position_lat)
+    }
+
+    /// Returns `start_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn start_position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.start_position_long)
+    }
+
+    /// Returns `end_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn end_position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.end_position_lat)
+    }
+
+    /// Returns `end_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn end_position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.end_position_long)
     }
 
     /// Returns `total_elapsed_time` in its scaled value. It returns invalid f64 when value is valid.

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -451,6 +452,16 @@ impl Record {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_lat)
+    }
+
+    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_long)
     }
 
     /// Returns `altitude` in its scaled value. It returns invalid f64 when value is valid.

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -496,6 +497,46 @@ impl SegmentLap {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `start_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn start_position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.start_position_lat)
+    }
+
+    /// Returns `start_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn start_position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.start_position_long)
+    }
+
+    /// Returns `end_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn end_position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.end_position_lat)
+    }
+
+    /// Returns `end_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn end_position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.end_position_long)
+    }
+
+    /// Returns `nec_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn nec_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.nec_lat)
+    }
+
+    /// Returns `nec_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn nec_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.nec_long)
+    }
+
+    /// Returns `swc_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn swc_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.swc_lat)
+    }
+
+    /// Returns `swc_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn swc_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.swc_long)
     }
 
     /// Returns `total_elapsed_time` in its scaled value. It returns invalid f64 when value is valid.

--- a/rustyfit/src/profile/mesgdef/segment_point.rs
+++ b/rustyfit/src/profile/mesgdef/segment_point.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::vec::Vec;
 
 fn is_expanded(state: &[u8], num: u8) -> bool {
@@ -70,6 +71,16 @@ impl SegmentPoint {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_lat)
+    }
+
+    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.position_long)
     }
 
     /// Returns `distance` in its scaled value. It returns invalid f64 when value is valid.

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -810,6 +811,46 @@ impl Session {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `start_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn start_position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.start_position_lat)
+    }
+
+    /// Returns `start_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn start_position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.start_position_long)
+    }
+
+    /// Returns `nec_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn nec_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.nec_lat)
+    }
+
+    /// Returns `nec_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn nec_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.nec_long)
+    }
+
+    /// Returns `swc_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn swc_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.swc_lat)
+    }
+
+    /// Returns `swc_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn swc_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.swc_long)
+    }
+
+    /// Returns `end_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn end_position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.end_position_lat)
+    }
+
+    /// Returns `end_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn end_position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.end_position_long)
     }
 
     /// Returns `total_elapsed_time` in its scaled value. It returns invalid f64 when value is valid.

--- a/rustyfit/src/profile/mesgdef/split.rs
+++ b/rustyfit/src/profile/mesgdef/split.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
@@ -123,6 +124,26 @@ impl Split {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `start_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn start_position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.start_position_lat)
+    }
+
+    /// Returns `start_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn start_position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.start_position_long)
+    }
+
+    /// Returns `end_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn end_position_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.end_position_lat)
+    }
+
+    /// Returns `end_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn end_position_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.end_position_long)
     }
 
     /// Returns `total_elapsed_time` in its scaled value. It returns invalid f64 when value is valid.

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use crate::semconv;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -105,6 +106,16 @@ impl WeatherConditions {
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
+    }
+
+    /// Returns `observed_location_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn observed_location_lat_degrees(&self) -> f64 {
+        semconv::to_degrees(self.observed_location_lat)
+    }
+
+    /// Returns `observed_location_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
+    pub fn observed_location_long_degrees(&self) -> f64 {
+        semconv::to_degrees(self.observed_location_long)
     }
 
     /// Returns `wind_speed` in its scaled value. It returns invalid f64 when value is valid.


### PR DESCRIPTION
Degrees is the standard type to represent GPS position, adding degrees method on mesgdef struct for conversion adds convenience on accessing the data.