### PR TITLE
refactor!: change proto value helper methods to private

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ On next call, it may return Ok(None) to indicate that no more FIT sequence in th
 
 ```rust
 use embedded_io_adapters::std::FromStd;
-use rustyfit::{Decoder, profile::{mesgdef, typedef}};
+use rustyfit::{Decoder, profile::{mesgdef, typedef}, proto::Value};
 use std::{error::Error, fs::File, io::BufReader};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -48,7 +48,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     for field in &fit.messages[0].fields {
         // first message: file_id
         if field.num == mesgdef::FileId::TYPE {
-            println!("file type: {}", typedef::File(field.value.as_u8()));
+            if let Value::Uint8(v) = field.value {
+                println!("file type: {}", typedef::File(v));
+            }
         }
     }
     
@@ -71,7 +73,9 @@ We can decode chained FIT file using `while let`, e.g:
         for field in &fit.messages[0].fields {
             // first message: file_id
             if field.num == mesgdef::FileId::TYPE {
-                println!("file type: {}", typedef::File(field.value.as_u8()));
+                if let Value::Uint8(v) = field.value {
+                    println!("file type: {}", typedef::File(v));
+                }
             }
         }
     }

--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -150,6 +150,13 @@ func (b *Builder) Build() ([]generator.Data, error) {
 				field.InvalidValue += fmt.Sprintf("&& %s != \"\"", field.ComparableValue)
 			}
 
+			field.IfSelfEqualInvalid = fmt.Sprintf("self.%s == %s", field.Name, field.InvalidValue)
+			field.IfNotEqualInvalid = fmt.Sprintf("m.%s != %s", field.Name, field.InvalidValue)
+			if parserField.Array == "[N]" {
+				field.IfSelfEqualInvalid = fmt.Sprintf("self.%s.is_empty()", field.Name)
+				field.IfNotEqualInvalid = fmt.Sprintf("!m.%s.is_empty()", field.Name)
+			}
+
 			// Scale and offset do not apply for field that has more than one components
 			if len(parserField.Components) > 1 {
 				field.Scale, field.Offset = 1, 0
@@ -406,9 +413,13 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 
 	var value string
 	if array == "" {
-		value = fmt.Sprintf(`vals[%d].as_%s()`, num, rustAsType)
+		if rustAsType == "string" {
+			value = fmt.Sprintf(`vals[%d].to_string()`, num)
+		} else {
+			value = fmt.Sprintf(`vals[%d].as_%s()`, num, rustAsType)
+		}
 	} else if fixedArraySize == 0 { // vector
-		value = fmt.Sprintf(`vals[%d].as_vec_%s()`, num, strings.TrimSuffix(rustAsType, "z"))
+		value = fmt.Sprintf(`vals[%d].to_vec_%s()`, num, strings.TrimSuffix(rustAsType, "z"))
 	} else { // array
 		rustType := baseTypeToRustTypeReplacer.Replace(baseType)
 		arrayValue := fmt.Sprintf("[%s::MAX; %d]", rustType, fixedArraySize)
@@ -450,9 +461,7 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 	return fmt.Sprintf(`match &vals[%d] {
 		Value::Vec%s(v) => {
 			let mut vs = Vec::with_capacity(v.len());
-			for x in v {
-				vs.push(%s(*x))
-			}
+			vs.extend(v.iter().map(|&x|%s(x)));
 			vs
 		},
 		_ => Vec::new(),
@@ -476,13 +485,7 @@ func (b *Builder) invalidValueOf(fieldType, array string, fixedArraySize byte) s
 
 	if array != "" {
 		if fixedArraySize == 0 { // Slice
-			if baseType == "string" {
-				return "Vec::<String>::new()"
-			}
-			if baseType != fieldType {
-				return fmt.Sprintf("Vec::<typedef::%s>::new()", strutil.ToTitle(fieldType))
-			}
-			return fmt.Sprintf("Vec::<%s>::new()", rustType)
+			return "Vec::new()"
 		}
 		if baseType == "string" {
 			invalid = fmt.Sprintf("const { %s }", invalid)

--- a/fitgen/internal/profile/mesgdef/data.go
+++ b/fitgen/internal/profile/mesgdef/data.go
@@ -27,30 +27,32 @@ type Message struct {
 }
 
 type Field struct {
-	Num              byte
-	Name             string
-	Name0            string // Name but with .0 if it's typedef
-	NameUpperCase    string
-	String           string
-	ProfileType      string
-	BaseType         string
-	BaseType0        string // Underlying base_type, typedef::Weight -> u16
-	BaseType0Invalid string // Invalid value of the underlying base type.
-	MaxValue         string // Only if numeric
-	Size             byte
-	Type             string
-	TypedValue       string
-	PrimitiveValue   string
-	ProtoValue       string
-	IsValidValue     string
-	ComparableValue  string
-	InvalidValue     string
-	Comment          string
-	Units            string
-	Scale            float64
-	Offset           float64
-	Array            bool
-	CanExpand        bool
+	Num                byte
+	Name               string
+	Name0              string // Name but with .0 if it's typedef
+	NameUpperCase      string
+	String             string
+	ProfileType        string
+	BaseType           string
+	BaseType0          string // Underlying base_type, typedef::Weight -> u16
+	BaseType0Invalid   string // Invalid value of the underlying base type.
+	MaxValue           string // Only if numeric
+	Size               byte
+	Type               string
+	TypedValue         string
+	PrimitiveValue     string
+	ProtoValue         string
+	IsValidValue       string
+	ComparableValue    string
+	InvalidValue       string
+	Comment            string
+	Units              string
+	Scale              float64
+	Offset             float64
+	Array              bool
+	CanExpand          bool
+	IfSelfEqualInvalid string
+	IfNotEqualInvalid  string
 
 	FixedArraySize          byte
 	InvalidArrayValueScaled string

--- a/fitgen/internal/profile/mesgdef/mesgdef.tmpl
+++ b/fitgen/internal/profile/mesgdef/mesgdef.tmpl
@@ -10,7 +10,7 @@
 {{ define "mesgdef" -}}
 {{ template "header" . -}}
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -101,7 +101,7 @@ impl {{ .Name }} {
         }
         {{ else if eq .FixedArraySize 0 -}}
         pub fn {{ .Name }}_scaled(&self) -> Vec<f64> {
-            if self.{{ .Name }} == {{ .InvalidValue }} {
+            if {{ .IfSelfEqualInvalid }} {
                 return Vec::new();
             }
             let mut v = Vec::with_capacity(self.{{ .Name }}.len());
@@ -200,7 +200,7 @@ impl Default for {{ .Name }} {
 impl From<&Message> for {{ .Name }} {
     /// from creates new {{ .Name }} struct based on given mesg. 
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; {{ .MaxFieldNum }}] = [const { &Value::Invalid }; {{ .MaxFieldNum }}];
+        let mut vals = [const { &Value::Invalid }; {{ .MaxFieldNum }}];
         {{ if gt .MaxFieldExpandNum 1 -}}
 		let mut state = [0u8; {{ .StateSize }}];
 		{{ end }}
@@ -211,7 +211,7 @@ impl From<&Message> for {{ .Name }} {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize>>6]>>(field.num&63))&1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize>>6]>>(field.num&63))&1 == 0 {
@@ -255,7 +255,7 @@ impl From<{{ .Name }}> for Message {
         {{ if gt .MaxFieldExpandNum 1 -}} let state = m.state; {{ end }}
 
         {{ range .Fields -}}
-        if m.{{ .Name }} != {{ .InvalidValue }} {
+        if {{ .IfNotEqualInvalid }} {
             arr[len] = Field {
                 num: {{ .Num }},
                 profile_type: {{ .ProfileType }},
@@ -266,11 +266,11 @@ impl From<{{ .Name }}> for Message {
         }
         {{- end }}
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::{{ .Num }},
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/aad_accel_features.rs
+++ b/rustyfit/src/profile/mesgdef/aad_accel_features.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -87,14 +87,14 @@ impl Default for AadAccelFeatures {
 impl From<&Message> for AadAccelFeatures {
     /// from creates new AadAccelFeatures struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -184,11 +184,11 @@ impl From<AadAccelFeatures> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::AAD_ACCEL_FEATURES,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/accelerometer_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -74,16 +74,16 @@ impl AccelerometerData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
-            sample_time_offset: Vec::<u16>::new(),
-            accel_x: Vec::<u16>::new(),
-            accel_y: Vec::<u16>::new(),
-            accel_z: Vec::<u16>::new(),
-            calibrated_accel_x: Vec::<f32>::new(),
-            calibrated_accel_y: Vec::<f32>::new(),
-            calibrated_accel_z: Vec::<f32>::new(),
-            compressed_calibrated_accel_x: Vec::<i16>::new(),
-            compressed_calibrated_accel_y: Vec::<i16>::new(),
-            compressed_calibrated_accel_z: Vec::<i16>::new(),
+            sample_time_offset: Vec::new(),
+            accel_x: Vec::new(),
+            accel_y: Vec::new(),
+            accel_z: Vec::new(),
+            calibrated_accel_x: Vec::new(),
+            calibrated_accel_y: Vec::new(),
+            calibrated_accel_z: Vec::new(),
+            compressed_calibrated_accel_x: Vec::new(),
+            compressed_calibrated_accel_y: Vec::new(),
+            compressed_calibrated_accel_z: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -99,14 +99,14 @@ impl Default for AccelerometerData {
 impl From<&Message> for AccelerometerData {
     /// from creates new AccelerometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [2047, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -119,16 +119,16 @@ impl From<&Message> for AccelerometerData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            sample_time_offset: vals[1].as_vec_u16(),
-            accel_x: vals[2].as_vec_u16(),
-            accel_y: vals[3].as_vec_u16(),
-            accel_z: vals[4].as_vec_u16(),
-            calibrated_accel_x: vals[5].as_vec_f32(),
-            calibrated_accel_y: vals[6].as_vec_f32(),
-            calibrated_accel_z: vals[7].as_vec_f32(),
-            compressed_calibrated_accel_x: vals[8].as_vec_i16(),
-            compressed_calibrated_accel_y: vals[9].as_vec_i16(),
-            compressed_calibrated_accel_z: vals[10].as_vec_i16(),
+            sample_time_offset: vals[1].to_vec_u16(),
+            accel_x: vals[2].to_vec_u16(),
+            accel_y: vals[3].to_vec_u16(),
+            accel_z: vals[4].to_vec_u16(),
+            calibrated_accel_x: vals[5].to_vec_f32(),
+            calibrated_accel_y: vals[6].to_vec_f32(),
+            calibrated_accel_z: vals[7].to_vec_f32(),
+            compressed_calibrated_accel_x: vals[8].to_vec_i16(),
+            compressed_calibrated_accel_y: vals[9].to_vec_i16(),
+            compressed_calibrated_accel_z: vals[10].to_vec_i16(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -165,7 +165,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.sample_time_offset != Vec::<u16>::new() {
+        if !m.sample_time_offset.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
@@ -174,7 +174,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.accel_x != Vec::<u16>::new() {
+        if !m.accel_x.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
@@ -183,7 +183,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.accel_y != Vec::<u16>::new() {
+        if !m.accel_y.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
@@ -192,7 +192,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.accel_z != Vec::<u16>::new() {
+        if !m.accel_z.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
@@ -201,7 +201,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.calibrated_accel_x != Vec::<f32>::new() {
+        if !m.calibrated_accel_x.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,
@@ -210,7 +210,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.calibrated_accel_y != Vec::<f32>::new() {
+        if !m.calibrated_accel_y.is_empty() {
             arr[len] = Field {
                 num: 6,
                 profile_type: ProfileType::FLOAT32,
@@ -219,7 +219,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.calibrated_accel_z != Vec::<f32>::new() {
+        if !m.calibrated_accel_z.is_empty() {
             arr[len] = Field {
                 num: 7,
                 profile_type: ProfileType::FLOAT32,
@@ -228,7 +228,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.compressed_calibrated_accel_x != Vec::<i16>::new() {
+        if !m.compressed_calibrated_accel_x.is_empty() {
             arr[len] = Field {
                 num: 8,
                 profile_type: ProfileType::SINT16,
@@ -237,7 +237,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.compressed_calibrated_accel_y != Vec::<i16>::new() {
+        if !m.compressed_calibrated_accel_y.is_empty() {
             arr[len] = Field {
                 num: 9,
                 profile_type: ProfileType::SINT16,
@@ -246,7 +246,7 @@ impl From<AccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.compressed_calibrated_accel_z != Vec::<i16>::new() {
+        if !m.compressed_calibrated_accel_z.is_empty() {
             arr[len] = Field {
                 num: 10,
                 profile_type: ProfileType::SINT16,
@@ -256,11 +256,11 @@ impl From<AccelerometerData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::ACCELEROMETER_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/activity.rs
+++ b/rustyfit/src/profile/mesgdef/activity.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -92,14 +92,14 @@ impl Default for Activity {
 impl From<&Message> for Activity {
     /// from creates new Activity struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -209,11 +209,11 @@ impl From<Activity> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::ACTIVITY,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/ant_channel_id.rs
+++ b/rustyfit/src/profile/mesgdef/ant_channel_id.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -62,14 +62,14 @@ impl Default for AntChannelId {
 impl From<&Message> for AntChannelId {
     /// from creates new AntChannelId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 5] = [const { &Value::Invalid }; 5];
+        let mut vals = [const { &Value::Invalid }; 5];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -149,11 +149,11 @@ impl From<AntChannelId> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::ANT_CHANNEL_ID,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/ant_rx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_rx.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -55,9 +55,9 @@ impl AntRx {
             timestamp: typedef::DateTime(u32::MAX),
             fractional_timestamp: u16::MAX,
             mesg_id: u8::MAX,
-            mesg_data: Vec::<u8>::new(),
+            mesg_data: Vec::new(),
             channel_number: u8::MAX,
-            data: Vec::<u8>::new(),
+            data: Vec::new(),
             state: [0u8; 1],
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -113,7 +113,7 @@ impl Default for AntRx {
 impl From<&Message> for AntRx {
     /// from creates new AntRx struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 1];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
@@ -121,7 +121,7 @@ impl From<&Message> for AntRx {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -138,9 +138,9 @@ impl From<&Message> for AntRx {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             fractional_timestamp: vals[0].as_u16(),
             mesg_id: vals[1].as_u8(),
-            mesg_data: vals[2].as_vec_u8(),
+            mesg_data: vals[2].to_vec_u8(),
             channel_number: vals[3].as_u8(),
-            data: vals[4].as_vec_u8(),
+            data: vals[4].to_vec_u8(),
             state,
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -188,7 +188,7 @@ impl From<AntRx> for Message {
             };
             len += 1;
         }
-        if m.mesg_data != Vec::<u8>::new() {
+        if !m.mesg_data.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::BYTE,
@@ -206,7 +206,7 @@ impl From<AntRx> for Message {
             };
             len += 1;
         }
-        if m.data != Vec::<u8>::new() {
+        if !m.data.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::BYTE,
@@ -216,11 +216,11 @@ impl From<AntRx> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::ANT_RX,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/ant_tx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_tx.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -55,9 +55,9 @@ impl AntTx {
             timestamp: typedef::DateTime(u32::MAX),
             fractional_timestamp: u16::MAX,
             mesg_id: u8::MAX,
-            mesg_data: Vec::<u8>::new(),
+            mesg_data: Vec::new(),
             channel_number: u8::MAX,
-            data: Vec::<u8>::new(),
+            data: Vec::new(),
             state: [0u8; 1],
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -113,7 +113,7 @@ impl Default for AntTx {
 impl From<&Message> for AntTx {
     /// from creates new AntTx struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 1];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
@@ -121,7 +121,7 @@ impl From<&Message> for AntTx {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -138,9 +138,9 @@ impl From<&Message> for AntTx {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             fractional_timestamp: vals[0].as_u16(),
             mesg_id: vals[1].as_u8(),
-            mesg_data: vals[2].as_vec_u8(),
+            mesg_data: vals[2].to_vec_u8(),
             channel_number: vals[3].as_u8(),
-            data: vals[4].as_vec_u8(),
+            data: vals[4].to_vec_u8(),
             state,
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -188,7 +188,7 @@ impl From<AntTx> for Message {
             };
             len += 1;
         }
-        if m.mesg_data != Vec::<u8>::new() {
+        if !m.mesg_data.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::BYTE,
@@ -206,7 +206,7 @@ impl From<AntTx> for Message {
             };
             len += 1;
         }
-        if m.data != Vec::<u8>::new() {
+        if !m.data.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::BYTE,
@@ -216,11 +216,11 @@ impl From<AntTx> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::ANT_TX,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/aviation_attitude.rs
+++ b/rustyfit/src/profile/mesgdef/aviation_attitude.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -72,16 +72,16 @@ impl AviationAttitude {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
-            system_time: Vec::<u32>::new(),
-            pitch: Vec::<i16>::new(),
-            roll: Vec::<i16>::new(),
-            accel_lateral: Vec::<i16>::new(),
-            accel_normal: Vec::<i16>::new(),
-            turn_rate: Vec::<i16>::new(),
-            stage: Vec::<typedef::AttitudeStage>::new(),
-            attitude_stage_complete: Vec::<u8>::new(),
-            track: Vec::<u16>::new(),
-            validity: Vec::<typedef::AttitudeValidity>::new(),
+            system_time: Vec::new(),
+            pitch: Vec::new(),
+            roll: Vec::new(),
+            accel_lateral: Vec::new(),
+            accel_normal: Vec::new(),
+            turn_rate: Vec::new(),
+            stage: Vec::new(),
+            attitude_stage_complete: Vec::new(),
+            track: Vec::new(),
+            validity: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -89,7 +89,7 @@ impl AviationAttitude {
 
     /// Returns `pitch` in its scaled value. It returns invalid f64 when value is valid.
     pub fn pitch_scaled(&self) -> Vec<f64> {
-        if self.pitch == Vec::<i16>::new() {
+        if self.pitch.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.pitch.len());
@@ -119,7 +119,7 @@ impl AviationAttitude {
 
     /// Returns `roll` in its scaled value. It returns invalid f64 when value is valid.
     pub fn roll_scaled(&self) -> Vec<f64> {
-        if self.roll == Vec::<i16>::new() {
+        if self.roll.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.roll.len());
@@ -149,7 +149,7 @@ impl AviationAttitude {
 
     /// Returns `accel_lateral` in its scaled value. It returns invalid f64 when value is valid.
     pub fn accel_lateral_scaled(&self) -> Vec<f64> {
-        if self.accel_lateral == Vec::<i16>::new() {
+        if self.accel_lateral.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.accel_lateral.len());
@@ -179,7 +179,7 @@ impl AviationAttitude {
 
     /// Returns `accel_normal` in its scaled value. It returns invalid f64 when value is valid.
     pub fn accel_normal_scaled(&self) -> Vec<f64> {
-        if self.accel_normal == Vec::<i16>::new() {
+        if self.accel_normal.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.accel_normal.len());
@@ -209,7 +209,7 @@ impl AviationAttitude {
 
     /// Returns `turn_rate` in its scaled value. It returns invalid f64 when value is valid.
     pub fn turn_rate_scaled(&self) -> Vec<f64> {
-        if self.turn_rate == Vec::<i16>::new() {
+        if self.turn_rate.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.turn_rate.len());
@@ -239,7 +239,7 @@ impl AviationAttitude {
 
     /// Returns `track` in its scaled value. It returns invalid f64 when value is valid.
     pub fn track_scaled(&self) -> Vec<f64> {
-        if self.track == Vec::<u16>::new() {
+        if self.track.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.track.len());
@@ -277,14 +277,14 @@ impl Default for AviationAttitude {
 impl From<&Message> for AviationAttitude {
     /// from creates new AviationAttitude struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [2047, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -297,30 +297,26 @@ impl From<&Message> for AviationAttitude {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            system_time: vals[1].as_vec_u32(),
-            pitch: vals[2].as_vec_i16(),
-            roll: vals[3].as_vec_i16(),
-            accel_lateral: vals[4].as_vec_i16(),
-            accel_normal: vals[5].as_vec_i16(),
-            turn_rate: vals[6].as_vec_i16(),
+            system_time: vals[1].to_vec_u32(),
+            pitch: vals[2].to_vec_i16(),
+            roll: vals[3].to_vec_i16(),
+            accel_lateral: vals[4].to_vec_i16(),
+            accel_normal: vals[5].to_vec_i16(),
+            turn_rate: vals[6].to_vec_i16(),
             stage: match &vals[7] {
                 Value::VecUint8(v) => {
                     let mut vs = Vec::with_capacity(v.len());
-                    for x in v {
-                        vs.push(typedef::AttitudeStage(*x))
-                    }
+                    vs.extend(v.iter().map(|&x| typedef::AttitudeStage(x)));
                     vs
                 }
                 _ => Vec::new(),
             },
-            attitude_stage_complete: vals[8].as_vec_u8(),
-            track: vals[9].as_vec_u16(),
+            attitude_stage_complete: vals[8].to_vec_u8(),
+            track: vals[9].to_vec_u16(),
             validity: match &vals[10] {
                 Value::VecUint16(v) => {
                     let mut vs = Vec::with_capacity(v.len());
-                    for x in v {
-                        vs.push(typedef::AttitudeValidity(*x))
-                    }
+                    vs.extend(v.iter().map(|&x| typedef::AttitudeValidity(x)));
                     vs
                 }
                 _ => Vec::new(),
@@ -361,7 +357,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.system_time != Vec::<u32>::new() {
+        if !m.system_time.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
@@ -370,7 +366,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.pitch != Vec::<i16>::new() {
+        if !m.pitch.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::SINT16,
@@ -379,7 +375,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.roll != Vec::<i16>::new() {
+        if !m.roll.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::SINT16,
@@ -388,7 +384,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.accel_lateral != Vec::<i16>::new() {
+        if !m.accel_lateral.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::SINT16,
@@ -397,7 +393,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.accel_normal != Vec::<i16>::new() {
+        if !m.accel_normal.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::SINT16,
@@ -406,7 +402,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.turn_rate != Vec::<i16>::new() {
+        if !m.turn_rate.is_empty() {
             arr[len] = Field {
                 num: 6,
                 profile_type: ProfileType::SINT16,
@@ -415,7 +411,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.stage != Vec::<typedef::AttitudeStage>::new() {
+        if !m.stage.is_empty() {
             arr[len] = Field {
                 num: 7,
                 profile_type: ProfileType::ATTITUDE_STAGE,
@@ -427,7 +423,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.attitude_stage_complete != Vec::<u8>::new() {
+        if !m.attitude_stage_complete.is_empty() {
             arr[len] = Field {
                 num: 8,
                 profile_type: ProfileType::UINT8,
@@ -436,7 +432,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.track != Vec::<u16>::new() {
+        if !m.track.is_empty() {
             arr[len] = Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
@@ -445,7 +441,7 @@ impl From<AviationAttitude> for Message {
             };
             len += 1;
         }
-        if m.validity != Vec::<typedef::AttitudeValidity>::new() {
+        if !m.validity.is_empty() {
             arr[len] = Field {
                 num: 10,
                 profile_type: ProfileType::ATTITUDE_VALIDITY,
@@ -458,11 +454,11 @@ impl From<AviationAttitude> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::AVIATION_ATTITUDE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/barometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/barometer_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -42,8 +42,8 @@ impl BarometerData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
-            sample_time_offset: Vec::<u16>::new(),
-            baro_pres: Vec::<u32>::new(),
+            sample_time_offset: Vec::new(),
+            baro_pres: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -59,14 +59,14 @@ impl Default for BarometerData {
 impl From<&Message> for BarometerData {
     /// from creates new BarometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -79,8 +79,8 @@ impl From<&Message> for BarometerData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            sample_time_offset: vals[1].as_vec_u16(),
-            baro_pres: vals[2].as_vec_u32(),
+            sample_time_offset: vals[1].to_vec_u16(),
+            baro_pres: vals[2].to_vec_u32(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -117,7 +117,7 @@ impl From<BarometerData> for Message {
             };
             len += 1;
         }
-        if m.sample_time_offset != Vec::<u16>::new() {
+        if !m.sample_time_offset.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
@@ -126,7 +126,7 @@ impl From<BarometerData> for Message {
             };
             len += 1;
         }
-        if m.baro_pres != Vec::<u32>::new() {
+        if !m.baro_pres.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
@@ -136,11 +136,11 @@ impl From<BarometerData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::BAROMETER_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/beat_intervals.rs
+++ b/rustyfit/src/profile/mesgdef/beat_intervals.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -37,7 +37,7 @@ impl BeatIntervals {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
-            time: Vec::<u16>::new(),
+            time: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -53,14 +53,14 @@ impl Default for BeatIntervals {
 impl From<&Message> for BeatIntervals {
     /// from creates new BeatIntervals struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -73,7 +73,7 @@ impl From<&Message> for BeatIntervals {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            time: vals[1].as_vec_u16(),
+            time: vals[1].to_vec_u16(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -110,7 +110,7 @@ impl From<BeatIntervals> for Message {
             };
             len += 1;
         }
-        if m.time != Vec::<u16>::new() {
+        if !m.time.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
@@ -120,11 +120,11 @@ impl From<BeatIntervals> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::BEAT_INTERVALS,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/bike_profile.rs
+++ b/rustyfit/src/profile/mesgdef/bike_profile.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -168,9 +168,9 @@ impl BikeProfile {
             bike_power_ant_id_trans_type: u8::MIN,
             odometer_rollover: u8::MAX,
             front_gear_num: u8::MIN,
-            front_gear: Vec::<u8>::new(),
+            front_gear: Vec::new(),
             rear_gear_num: u8::MIN,
-            rear_gear: Vec::<u8>::new(),
+            rear_gear: Vec::new(),
             shimano_di2_enabled: typedef::Bool(u8::MAX),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -301,14 +301,14 @@ impl Default for BikeProfile {
 impl From<&Message> for BikeProfile {
     /// from creates new BikeProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [21852827156479, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -320,7 +320,7 @@ impl From<&Message> for BikeProfile {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            name: vals[0].as_string(),
+            name: vals[0].to_string(),
             sport: typedef::Sport(vals[1].as_u8()),
             sub_sport: typedef::SubSport(vals[2].as_u8()),
             odometer: vals[3].as_u32(),
@@ -347,9 +347,9 @@ impl From<&Message> for BikeProfile {
             bike_power_ant_id_trans_type: vals[24].as_u8z(),
             odometer_rollover: vals[37].as_u8(),
             front_gear_num: vals[38].as_u8z(),
-            front_gear: vals[39].as_vec_u8(),
+            front_gear: vals[39].to_vec_u8(),
             rear_gear_num: vals[40].as_u8z(),
-            rear_gear: vals[41].as_vec_u8(),
+            rear_gear: vals[41].to_vec_u8(),
             shimano_di2_enabled: typedef::Bool(vals[44].as_u8()),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -621,7 +621,7 @@ impl From<BikeProfile> for Message {
             };
             len += 1;
         }
-        if m.front_gear != Vec::<u8>::new() {
+        if !m.front_gear.is_empty() {
             arr[len] = Field {
                 num: 39,
                 profile_type: ProfileType::UINT8Z,
@@ -639,7 +639,7 @@ impl From<BikeProfile> for Message {
             };
             len += 1;
         }
-        if m.rear_gear != Vec::<u8>::new() {
+        if !m.rear_gear.is_empty() {
             arr[len] = Field {
                 num: 41,
                 profile_type: ProfileType::UINT8Z,
@@ -658,11 +658,11 @@ impl From<BikeProfile> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::BIKE_PROFILE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/blood_pressure.rs
+++ b/rustyfit/src/profile/mesgdef/blood_pressure.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -92,14 +92,14 @@ impl Default for BloodPressure {
 impl From<&Message> for BloodPressure {
     /// from creates new BloodPressure struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [1023, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -239,11 +239,11 @@ impl From<BloodPressure> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::BLOOD_PRESSURE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/cadence_zone.rs
+++ b/rustyfit/src/profile/mesgdef/cadence_zone.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -53,14 +53,14 @@ impl Default for CadenceZone {
 impl From<&Message> for CadenceZone {
     /// from creates new CadenceZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -73,7 +73,7 @@ impl From<&Message> for CadenceZone {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             high_value: vals[0].as_u8(),
-            name: vals[1].as_string(),
+            name: vals[1].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -120,11 +120,11 @@ impl From<CadenceZone> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::CADENCE_ZONE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/camera_event.rs
+++ b/rustyfit/src/profile/mesgdef/camera_event.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -62,14 +62,14 @@ impl Default for CameraEvent {
 impl From<&Message> for CameraEvent {
     /// from creates new CameraEvent struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -83,7 +83,7 @@ impl From<&Message> for CameraEvent {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
             camera_event_type: typedef::CameraEventType(vals[1].as_u8()),
-            camera_file_uuid: vals[2].as_string(),
+            camera_file_uuid: vals[2].to_string(),
             camera_orientation: typedef::CameraOrientationType(vals[3].as_u8()),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -149,11 +149,11 @@ impl From<CameraEvent> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::CAMERA_EVENT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/capabilities.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -40,8 +40,8 @@ impl Capabilities {
     /// Create new Capabilities with all fields being set to its corresponding invalid value.
     pub const fn new() -> Self {
         Self {
-            languages: Vec::<u8>::new(),
-            sports: Vec::<typedef::SportBits0>::new(),
+            languages: Vec::new(),
+            sports: Vec::new(),
             workouts_supported: typedef::WorkoutCapabilities(u32::MIN),
             connectivity_supported: typedef::ConnectivityCapabilities(u32::MIN),
             unknown_fields: Vec::new(),
@@ -59,14 +59,14 @@ impl Default for Capabilities {
 impl From<&Message> for Capabilities {
     /// from creates new Capabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 24] = [const { &Value::Invalid }; 24];
+        let mut vals = [const { &Value::Invalid }; 24];
 
         const KNOWN_NUMS: [u64; 4] = [10485763, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -77,13 +77,11 @@ impl From<&Message> for Capabilities {
         }
 
         Self {
-            languages: vals[0].as_vec_u8(),
+            languages: vals[0].to_vec_u8(),
             sports: match &vals[1] {
                 Value::VecUint8(v) => {
                     let mut vs = Vec::with_capacity(v.len());
-                    for x in v {
-                        vs.push(typedef::SportBits0(*x))
-                    }
+                    vs.extend(v.iter().map(|&x| typedef::SportBits0(x)));
                     vs
                 }
                 _ => Vec::new(),
@@ -108,7 +106,7 @@ impl From<Capabilities> for Message {
         }; 4];
         let mut len = 0usize;
 
-        if m.languages != Vec::<u8>::new() {
+        if !m.languages.is_empty() {
             arr[len] = Field {
                 num: 0,
                 profile_type: ProfileType::UINT8Z,
@@ -117,7 +115,7 @@ impl From<Capabilities> for Message {
             };
             len += 1;
         }
-        if m.sports != Vec::<typedef::SportBits0>::new() {
+        if !m.sports.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::SPORT_BITS_0,
@@ -148,11 +146,11 @@ impl From<Capabilities> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::CAPABILITIES,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -71,14 +71,14 @@ impl Default for ChronoShotData {
 impl From<&Message> for ChronoShotData {
     /// from creates new ChronoShotData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -138,11 +138,11 @@ impl From<ChronoShotData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::CHRONO_SHOT_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -171,14 +171,14 @@ impl Default for ChronoShotSession {
 impl From<&Message> for ChronoShotSession {
     /// from creates new ChronoShotSession struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -288,11 +288,11 @@ impl From<ChronoShotSession> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::CHRONO_SHOT_SESSION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/climb_pro.rs
+++ b/rustyfit/src/profile/mesgdef/climb_pro.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -82,14 +82,14 @@ impl Default for ClimbPro {
 impl From<&Message> for ClimbPro {
     /// from creates new ClimbPro struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -189,11 +189,11 @@ impl From<ClimbPro> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::CLIMB_PRO,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/connectivity.rs
+++ b/rustyfit/src/profile/mesgdef/connectivity.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -95,14 +95,14 @@ impl Default for Connectivity {
 impl From<&Message> for Connectivity {
     /// from creates new Connectivity struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 13] = [const { &Value::Invalid }; 13];
+        let mut vals = [const { &Value::Invalid }; 13];
 
         const KNOWN_NUMS: [u64; 4] = [8191, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -116,7 +116,7 @@ impl From<&Message> for Connectivity {
             bluetooth_enabled: typedef::Bool(vals[0].as_u8()),
             bluetooth_le_enabled: typedef::Bool(vals[1].as_u8()),
             ant_enabled: typedef::Bool(vals[2].as_u8()),
-            name: vals[3].as_string(),
+            name: vals[3].to_string(),
             live_tracking_enabled: typedef::Bool(vals[4].as_u8()),
             weather_conditions_enabled: typedef::Bool(vals[5].as_u8()),
             weather_alerts_enabled: typedef::Bool(vals[6].as_u8()),
@@ -262,11 +262,11 @@ impl From<Connectivity> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::CONNECTIVITY,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/course.rs
+++ b/rustyfit/src/profile/mesgdef/course.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -57,14 +57,14 @@ impl Default for Course {
 impl From<&Message> for Course {
     /// from creates new Course struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 8] = [const { &Value::Invalid }; 8];
+        let mut vals = [const { &Value::Invalid }; 8];
 
         const KNOWN_NUMS: [u64; 4] = [240, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -76,7 +76,7 @@ impl From<&Message> for Course {
 
         Self {
             sport: typedef::Sport(vals[4].as_u8()),
-            name: vals[5].as_string(),
+            name: vals[5].to_string(),
             capabilities: typedef::CourseCapabilities(vals[6].as_u32z()),
             sub_sport: typedef::SubSport(vals[7].as_u8()),
             unknown_fields,
@@ -134,11 +134,11 @@ impl From<Course> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::COURSE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -105,14 +105,14 @@ impl Default for CoursePoint {
 impl From<&Message> for CoursePoint {
     /// from creates new CoursePoint struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [382, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -129,7 +129,7 @@ impl From<&Message> for CoursePoint {
             position_long: vals[3].as_i32(),
             distance: vals[4].as_u32(),
             r#type: typedef::CoursePoint(vals[5].as_u8()),
-            name: vals[6].as_string(),
+            name: vals[6].to_string(),
             favorite: typedef::Bool(vals[8].as_u8()),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -222,11 +222,11 @@ impl From<CoursePoint> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::COURSE_POINT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/developer_data_id.rs
+++ b/rustyfit/src/profile/mesgdef/developer_data_id.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -37,8 +37,8 @@ impl DeveloperDataId {
     /// Create new DeveloperDataId with all fields being set to its corresponding invalid value.
     pub const fn new() -> Self {
         Self {
-            developer_id: Vec::<u8>::new(),
-            application_id: Vec::<u8>::new(),
+            developer_id: Vec::new(),
+            application_id: Vec::new(),
             manufacturer_id: typedef::Manufacturer(u16::MAX),
             developer_data_index: u8::MAX,
             application_version: u32::MAX,
@@ -56,14 +56,14 @@ impl Default for DeveloperDataId {
 impl From<&Message> for DeveloperDataId {
     /// from creates new DeveloperDataId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 5] = [const { &Value::Invalid }; 5];
+        let mut vals = [const { &Value::Invalid }; 5];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -74,8 +74,8 @@ impl From<&Message> for DeveloperDataId {
         }
 
         Self {
-            developer_id: vals[0].as_vec_u8(),
-            application_id: vals[1].as_vec_u8(),
+            developer_id: vals[0].to_vec_u8(),
+            application_id: vals[1].to_vec_u8(),
             manufacturer_id: typedef::Manufacturer(vals[2].as_u16()),
             developer_data_index: vals[3].as_u8(),
             application_version: vals[4].as_u32(),
@@ -96,7 +96,7 @@ impl From<DeveloperDataId> for Message {
         }; 5];
         let mut len = 0usize;
 
-        if m.developer_id != Vec::<u8>::new() {
+        if !m.developer_id.is_empty() {
             arr[len] = Field {
                 num: 0,
                 profile_type: ProfileType::BYTE,
@@ -105,7 +105,7 @@ impl From<DeveloperDataId> for Message {
             };
             len += 1;
         }
-        if m.application_id != Vec::<u8>::new() {
+        if !m.application_id.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::BYTE,
@@ -142,11 +142,11 @@ impl From<DeveloperDataId> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::DEVELOPER_DATA_ID,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -79,14 +79,14 @@ impl Default for DeviceAuxBatteryInfo {
 impl From<&Message> for DeviceAuxBatteryInfo {
     /// from creates new DeviceAuxBatteryInfo struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -166,11 +166,11 @@ impl From<DeviceAuxBatteryInfo> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::DEVICE_AUX_BATTERY_INFO,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/device_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_info.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -165,14 +165,14 @@ impl Default for DeviceInfo {
 impl From<&Message> for DeviceInfo {
     /// from creates new DeviceInfo struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [4470869247, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -195,12 +195,12 @@ impl From<&Message> for DeviceInfo {
             battery_voltage: vals[10].as_u16(),
             battery_status: typedef::BatteryStatus(vals[11].as_u8()),
             sensor_position: typedef::BodyLocation(vals[18].as_u8()),
-            descriptor: vals[19].as_string(),
+            descriptor: vals[19].to_string(),
             ant_transmission_type: vals[20].as_u8z(),
             ant_device_number: vals[21].as_u16z(),
             ant_network: typedef::AntNetwork(vals[22].as_u8()),
             source_type: typedef::SourceType(vals[25].as_u8()),
-            product_name: vals[27].as_string(),
+            product_name: vals[27].to_string(),
             battery_level: vals[32].as_u8(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -392,11 +392,11 @@ impl From<DeviceInfo> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::DEVICE_INFO,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/device_settings.rs
+++ b/rustyfit/src/profile/mesgdef/device_settings.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -119,18 +119,18 @@ impl DeviceSettings {
         Self {
             active_time_zone: u8::MAX,
             utc_offset: u32::MAX,
-            time_offset: Vec::<u32>::new(),
-            time_mode: Vec::<typedef::TimeMode>::new(),
-            time_zone_offset: Vec::<i8>::new(),
+            time_offset: Vec::new(),
+            time_mode: Vec::new(),
+            time_zone_offset: Vec::new(),
             backlight_mode: typedef::BacklightMode(u8::MAX),
             activity_tracker_enabled: typedef::Bool(u8::MAX),
             clock_time: typedef::DateTime(u32::MAX),
-            pages_enabled: Vec::<u16>::new(),
+            pages_enabled: Vec::new(),
             move_alert_enabled: typedef::Bool(u8::MAX),
             date_mode: typedef::DateMode(u8::MAX),
             display_orientation: typedef::DisplayOrientation(u8::MAX),
             mounting_side: typedef::Side(u8::MAX),
-            default_page: Vec::<u16>::new(),
+            default_page: Vec::new(),
             autosync_min_steps: u16::MAX,
             autosync_min_time: u16::MAX,
             lactate_threshold_autodetect_enabled: typedef::Bool(u8::MAX),
@@ -148,7 +148,7 @@ impl DeviceSettings {
 
     /// Returns `time_zone_offset` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_zone_offset_scaled(&self) -> Vec<f64> {
-        if self.time_zone_offset == Vec::<i8>::new() {
+        if self.time_zone_offset.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_zone_offset.len());
@@ -186,14 +186,14 @@ impl Default for DeviceSettings {
 impl From<&Message> for DeviceSettings {
     /// from creates new DeviceSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 175] = [const { &Value::Invalid }; 175];
+        let mut vals = [const { &Value::Invalid }; 175];
 
         const KNOWN_NUMS: [u64; 4] = [1117105531807338551, 3326148608, 70368744177728, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -206,27 +206,25 @@ impl From<&Message> for DeviceSettings {
         Self {
             active_time_zone: vals[0].as_u8(),
             utc_offset: vals[1].as_u32(),
-            time_offset: vals[2].as_vec_u32(),
+            time_offset: vals[2].to_vec_u32(),
             time_mode: match &vals[4] {
                 Value::VecUint8(v) => {
                     let mut vs = Vec::with_capacity(v.len());
-                    for x in v {
-                        vs.push(typedef::TimeMode(*x))
-                    }
+                    vs.extend(v.iter().map(|&x| typedef::TimeMode(x)));
                     vs
                 }
                 _ => Vec::new(),
             },
-            time_zone_offset: vals[5].as_vec_i8(),
+            time_zone_offset: vals[5].to_vec_i8(),
             backlight_mode: typedef::BacklightMode(vals[12].as_u8()),
             activity_tracker_enabled: typedef::Bool(vals[36].as_u8()),
             clock_time: typedef::DateTime(vals[39].as_u32()),
-            pages_enabled: vals[40].as_vec_u16(),
+            pages_enabled: vals[40].to_vec_u16(),
             move_alert_enabled: typedef::Bool(vals[46].as_u8()),
             date_mode: typedef::DateMode(vals[47].as_u8()),
             display_orientation: typedef::DisplayOrientation(vals[55].as_u8()),
             mounting_side: typedef::Side(vals[56].as_u8()),
-            default_page: vals[57].as_vec_u16(),
+            default_page: vals[57].to_vec_u16(),
             autosync_min_steps: vals[58].as_u16(),
             autosync_min_time: vals[59].as_u16(),
             lactate_threshold_autodetect_enabled: typedef::Bool(vals[80].as_u8()),
@@ -273,7 +271,7 @@ impl From<DeviceSettings> for Message {
             };
             len += 1;
         }
-        if m.time_offset != Vec::<u32>::new() {
+        if !m.time_offset.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
@@ -282,7 +280,7 @@ impl From<DeviceSettings> for Message {
             };
             len += 1;
         }
-        if m.time_mode != Vec::<typedef::TimeMode>::new() {
+        if !m.time_mode.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::TIME_MODE,
@@ -294,7 +292,7 @@ impl From<DeviceSettings> for Message {
             };
             len += 1;
         }
-        if m.time_zone_offset != Vec::<i8>::new() {
+        if !m.time_zone_offset.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::SINT8,
@@ -330,7 +328,7 @@ impl From<DeviceSettings> for Message {
             };
             len += 1;
         }
-        if m.pages_enabled != Vec::<u16>::new() {
+        if !m.pages_enabled.is_empty() {
             arr[len] = Field {
                 num: 40,
                 profile_type: ProfileType::UINT16,
@@ -375,7 +373,7 @@ impl From<DeviceSettings> for Message {
             };
             len += 1;
         }
-        if m.default_page != Vec::<u16>::new() {
+        if !m.default_page.is_empty() {
             arr[len] = Field {
                 num: 57,
                 profile_type: ProfileType::UINT16,
@@ -475,11 +473,11 @@ impl From<DeviceSettings> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::DEVICE_SETTINGS,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/dive_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_alarm.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -82,7 +82,7 @@ impl DiveAlarm {
             enabled: typedef::Bool(u8::MAX),
             alarm_type: typedef::DiveAlarmType(u8::MAX),
             sound: typedef::Tone(u8::MAX),
-            dive_types: Vec::<typedef::SubSport>::new(),
+            dive_types: Vec::new(),
             id: u32::MAX,
             popup_enabled: typedef::Bool(u8::MAX),
             trigger_on_descent: typedef::Bool(u8::MAX),
@@ -142,14 +142,14 @@ impl Default for DiveAlarm {
 impl From<&Message> for DiveAlarm {
     /// from creates new DiveAlarm struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [4095, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -169,9 +169,7 @@ impl From<&Message> for DiveAlarm {
             dive_types: match &vals[5] {
                 Value::VecUint8(v) => {
                     let mut vs = Vec::with_capacity(v.len());
-                    for x in v {
-                        vs.push(typedef::SubSport(*x))
-                    }
+                    vs.extend(v.iter().map(|&x| typedef::SubSport(x)));
                     vs
                 }
                 _ => Vec::new(),
@@ -254,7 +252,7 @@ impl From<DiveAlarm> for Message {
             };
             len += 1;
         }
-        if m.dive_types != Vec::<typedef::SubSport>::new() {
+        if !m.dive_types.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::SUB_SPORT,
@@ -321,11 +319,11 @@ impl From<DiveAlarm> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::DIVE_ALARM,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -82,7 +82,7 @@ impl DiveApneaAlarm {
             enabled: typedef::Bool(u8::MAX),
             alarm_type: typedef::DiveAlarmType(u8::MAX),
             sound: typedef::Tone(u8::MAX),
-            dive_types: Vec::<typedef::SubSport>::new(),
+            dive_types: Vec::new(),
             id: u32::MAX,
             popup_enabled: typedef::Bool(u8::MAX),
             trigger_on_descent: typedef::Bool(u8::MAX),
@@ -142,14 +142,14 @@ impl Default for DiveApneaAlarm {
 impl From<&Message> for DiveApneaAlarm {
     /// from creates new DiveApneaAlarm struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [4095, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -169,9 +169,7 @@ impl From<&Message> for DiveApneaAlarm {
             dive_types: match &vals[5] {
                 Value::VecUint8(v) => {
                     let mut vs = Vec::with_capacity(v.len());
-                    for x in v {
-                        vs.push(typedef::SubSport(*x))
-                    }
+                    vs.extend(v.iter().map(|&x| typedef::SubSport(x)));
                     vs
                 }
                 _ => Vec::new(),
@@ -254,7 +252,7 @@ impl From<DiveApneaAlarm> for Message {
             };
             len += 1;
         }
-        if m.dive_types != Vec::<typedef::SubSport>::new() {
+        if !m.dive_types.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::SUB_SPORT,
@@ -321,11 +319,11 @@ impl From<DiveApneaAlarm> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::DIVE_APNEA_ALARM,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/dive_gas.rs
+++ b/rustyfit/src/profile/mesgdef/dive_gas.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -61,14 +61,14 @@ impl Default for DiveGas {
 impl From<&Message> for DiveGas {
     /// from creates new DiveGas struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -148,11 +148,11 @@ impl From<DiveGas> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::DIVE_GAS,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/dive_settings.rs
+++ b/rustyfit/src/profile/mesgdef/dive_settings.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -352,14 +352,14 @@ impl Default for DiveSettings {
 impl From<&Message> for DiveSettings {
     /// from creates new DiveSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [242397216767, 0, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -372,7 +372,7 @@ impl From<&Message> for DiveSettings {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            name: vals[0].as_string(),
+            name: vals[0].to_string(),
             model: typedef::TissueModelType(vals[1].as_u8()),
             gf_low: vals[2].as_u8(),
             gf_high: vals[3].as_u8(),
@@ -739,11 +739,11 @@ impl From<DiveSettings> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::DIVE_SETTINGS,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/dive_summary.rs
+++ b/rustyfit/src/profile/mesgdef/dive_summary.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -398,14 +398,14 @@ impl Default for DiveSummary {
 impl From<&Message> for DiveSummary {
     /// from creates new DiveSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [63176703, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -665,11 +665,11 @@ impl From<DiveSummary> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::DIVE_SUMMARY,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/event.rs
+++ b/rustyfit/src/profile/mesgdef/event.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -197,7 +197,7 @@ impl Default for Event {
 impl From<&Message> for Event {
     /// from creates new Event struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 4];
 
         const KNOWN_NUMS: [u64; 4] = [31522719, 0, 0, 2305843009213693952];
@@ -205,7 +205,7 @@ impl From<&Message> for Event {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -430,11 +430,11 @@ impl From<Event> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::EVENT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -112,7 +112,7 @@ impl Default for ExdDataConceptConfiguration {
 impl From<&Message> for ExdDataConceptConfiguration {
     /// from creates new ExdDataConceptConfiguration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 12] = [const { &Value::Invalid }; 12];
+        let mut vals = [const { &Value::Invalid }; 12];
         let mut state = [0u8; 1];
 
         const KNOWN_NUMS: [u64; 4] = [3967, 0, 0, 0];
@@ -120,7 +120,7 @@ impl From<&Message> for ExdDataConceptConfiguration {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -265,11 +265,11 @@ impl From<ExdDataConceptConfiguration> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::EXD_DATA_CONCEPT_CONFIGURATION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -95,7 +95,7 @@ impl Default for ExdDataFieldConfiguration {
 impl From<&Message> for ExdDataFieldConfiguration {
     /// from creates new ExdDataFieldConfiguration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 6] = [const { &Value::Invalid }; 6];
+        let mut vals = [const { &Value::Invalid }; 6];
         let mut state = [0u8; 1];
 
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 0];
@@ -103,7 +103,7 @@ impl From<&Message> for ExdDataFieldConfiguration {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -207,11 +207,11 @@ impl From<ExdDataFieldConfiguration> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::EXD_DATA_FIELD_CONFIGURATION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -56,14 +56,14 @@ impl Default for ExdScreenConfiguration {
 impl From<&Message> for ExdScreenConfiguration {
     /// from creates new ExdScreenConfiguration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 4] = [const { &Value::Invalid }; 4];
+        let mut vals = [const { &Value::Invalid }; 4];
 
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -133,11 +133,11 @@ impl From<ExdScreenConfiguration> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::EXD_SCREEN_CONFIGURATION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/exercise_title.rs
+++ b/rustyfit/src/profile/mesgdef/exercise_title.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -40,7 +40,7 @@ impl ExerciseTitle {
             message_index: typedef::MessageIndex(u16::MAX),
             exercise_category: typedef::ExerciseCategory(u16::MAX),
             exercise_name: u16::MAX,
-            wkt_step_name: Vec::<String>::new(),
+            wkt_step_name: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -56,14 +56,14 @@ impl Default for ExerciseTitle {
 impl From<&Message> for ExerciseTitle {
     /// from creates new ExerciseTitle struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -77,7 +77,7 @@ impl From<&Message> for ExerciseTitle {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             exercise_category: typedef::ExerciseCategory(vals[0].as_u16()),
             exercise_name: vals[1].as_u16(),
-            wkt_step_name: vals[2].as_vec_string(),
+            wkt_step_name: vals[2].to_vec_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -123,7 +123,7 @@ impl From<ExerciseTitle> for Message {
             };
             len += 1;
         }
-        if m.wkt_step_name != Vec::<String>::new() {
+        if !m.wkt_step_name.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::STRING,
@@ -133,11 +133,11 @@ impl From<ExerciseTitle> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::EXERCISE_TITLE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/field_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/field_capabilities.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -59,14 +59,14 @@ impl Default for FieldCapabilities {
 impl From<&Message> for FieldCapabilities {
     /// from creates new FieldCapabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -146,11 +146,11 @@ impl From<FieldCapabilities> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::FIELD_CAPABILITIES,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/field_description.rs
+++ b/rustyfit/src/profile/mesgdef/field_description.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -68,12 +68,12 @@ impl FieldDescription {
             developer_data_index: u8::MAX,
             field_definition_number: u8::MAX,
             fit_base_type_id: typedef::FitBaseType(u8::MAX),
-            field_name: Vec::<String>::new(),
+            field_name: Vec::new(),
             array: u8::MAX,
             components: String::new(),
             scale: u8::MAX,
             offset: i8::MAX,
-            units: Vec::<String>::new(),
+            units: Vec::new(),
             bits: String::new(),
             accumulate: String::new(),
             fit_base_unit_id: typedef::FitBaseUnit(u16::MAX),
@@ -93,14 +93,14 @@ impl Default for FieldDescription {
 impl From<&Message> for FieldDescription {
     /// from creates new FieldDescription struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 16] = [const { &Value::Invalid }; 16];
+        let mut vals = [const { &Value::Invalid }; 16];
 
         const KNOWN_NUMS: [u64; 4] = [59391, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -114,14 +114,14 @@ impl From<&Message> for FieldDescription {
             developer_data_index: vals[0].as_u8(),
             field_definition_number: vals[1].as_u8(),
             fit_base_type_id: typedef::FitBaseType(vals[2].as_u8()),
-            field_name: vals[3].as_vec_string(),
+            field_name: vals[3].to_vec_string(),
             array: vals[4].as_u8(),
-            components: vals[5].as_string(),
+            components: vals[5].to_string(),
             scale: vals[6].as_u8(),
             offset: vals[7].as_i8(),
-            units: vals[8].as_vec_string(),
-            bits: vals[9].as_string(),
-            accumulate: vals[10].as_string(),
+            units: vals[8].to_vec_string(),
+            bits: vals[9].to_string(),
+            accumulate: vals[10].to_string(),
             fit_base_unit_id: typedef::FitBaseUnit(vals[13].as_u16()),
             native_mesg_num: typedef::MesgNum(vals[14].as_u16()),
             native_field_num: vals[15].as_u8(),
@@ -169,7 +169,7 @@ impl From<FieldDescription> for Message {
             };
             len += 1;
         }
-        if m.field_name != Vec::<String>::new() {
+        if !m.field_name.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::STRING,
@@ -214,7 +214,7 @@ impl From<FieldDescription> for Message {
             };
             len += 1;
         }
-        if m.units != Vec::<String>::new() {
+        if !m.units.is_empty() {
             arr[len] = Field {
                 num: 8,
                 profile_type: ProfileType::STRING,
@@ -269,11 +269,11 @@ impl From<FieldDescription> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::FIELD_DESCRIPTION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/file_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/file_capabilities.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -66,14 +66,14 @@ impl Default for FileCapabilities {
 impl From<&Message> for FileCapabilities {
     /// from creates new FileCapabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -87,7 +87,7 @@ impl From<&Message> for FileCapabilities {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             r#type: typedef::File(vals[0].as_u8()),
             flags: typedef::FileFlags(vals[1].as_u8z()),
-            directory: vals[2].as_string(),
+            directory: vals[2].to_string(),
             max_count: vals[3].as_u16(),
             max_size: vals[4].as_u32(),
             unknown_fields,
@@ -163,11 +163,11 @@ impl From<FileCapabilities> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::FILE_CAPABILITIES,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/file_creator.rs
+++ b/rustyfit/src/profile/mesgdef/file_creator.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -47,14 +47,14 @@ impl Default for FileCreator {
 impl From<&Message> for FileCreator {
     /// from creates new FileCreator struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 2] = [const { &Value::Invalid }; 2];
+        let mut vals = [const { &Value::Invalid }; 2];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -104,11 +104,11 @@ impl From<FileCreator> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::FILE_CREATOR,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/file_id.rs
+++ b/rustyfit/src/profile/mesgdef/file_id.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -69,14 +69,14 @@ impl Default for FileId {
 impl From<&Message> for FileId {
     /// from creates new FileId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 9] = [const { &Value::Invalid }; 9];
+        let mut vals = [const { &Value::Invalid }; 9];
 
         const KNOWN_NUMS: [u64; 4] = [319, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -93,7 +93,7 @@ impl From<&Message> for FileId {
             serial_number: vals[3].as_u32z(),
             time_created: typedef::DateTime(vals[4].as_u32()),
             number: vals[5].as_u16(),
-            product_name: vals[8].as_string(),
+            product_name: vals[8].to_string(),
             unknown_fields,
         }
     }
@@ -175,11 +175,11 @@ impl From<FileId> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::FILE_ID,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/goal.rs
+++ b/rustyfit/src/profile/mesgdef/goal.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -91,14 +91,14 @@ impl Default for Goal {
 impl From<&Message> for Goal {
     /// from creates new Goal struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [4095, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -258,11 +258,11 @@ impl From<Goal> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::GOAL,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -177,14 +177,14 @@ impl Default for GpsMetadata {
 impl From<&Message> for GpsMetadata {
     /// from creates new GpsMetadata struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -313,11 +313,11 @@ impl From<GpsMetadata> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::GPS_METADATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/gyroscope_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -62,13 +62,13 @@ impl GyroscopeData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
-            sample_time_offset: Vec::<u16>::new(),
-            gyro_x: Vec::<u16>::new(),
-            gyro_y: Vec::<u16>::new(),
-            gyro_z: Vec::<u16>::new(),
-            calibrated_gyro_x: Vec::<f32>::new(),
-            calibrated_gyro_y: Vec::<f32>::new(),
-            calibrated_gyro_z: Vec::<f32>::new(),
+            sample_time_offset: Vec::new(),
+            gyro_x: Vec::new(),
+            gyro_y: Vec::new(),
+            gyro_z: Vec::new(),
+            calibrated_gyro_x: Vec::new(),
+            calibrated_gyro_y: Vec::new(),
+            calibrated_gyro_z: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -84,14 +84,14 @@ impl Default for GyroscopeData {
 impl From<&Message> for GyroscopeData {
     /// from creates new GyroscopeData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -104,13 +104,13 @@ impl From<&Message> for GyroscopeData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            sample_time_offset: vals[1].as_vec_u16(),
-            gyro_x: vals[2].as_vec_u16(),
-            gyro_y: vals[3].as_vec_u16(),
-            gyro_z: vals[4].as_vec_u16(),
-            calibrated_gyro_x: vals[5].as_vec_f32(),
-            calibrated_gyro_y: vals[6].as_vec_f32(),
-            calibrated_gyro_z: vals[7].as_vec_f32(),
+            sample_time_offset: vals[1].to_vec_u16(),
+            gyro_x: vals[2].to_vec_u16(),
+            gyro_y: vals[3].to_vec_u16(),
+            gyro_z: vals[4].to_vec_u16(),
+            calibrated_gyro_x: vals[5].to_vec_f32(),
+            calibrated_gyro_y: vals[6].to_vec_f32(),
+            calibrated_gyro_z: vals[7].to_vec_f32(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -147,7 +147,7 @@ impl From<GyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.sample_time_offset != Vec::<u16>::new() {
+        if !m.sample_time_offset.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
@@ -156,7 +156,7 @@ impl From<GyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.gyro_x != Vec::<u16>::new() {
+        if !m.gyro_x.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
@@ -165,7 +165,7 @@ impl From<GyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.gyro_y != Vec::<u16>::new() {
+        if !m.gyro_y.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
@@ -174,7 +174,7 @@ impl From<GyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.gyro_z != Vec::<u16>::new() {
+        if !m.gyro_z.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
@@ -183,7 +183,7 @@ impl From<GyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.calibrated_gyro_x != Vec::<f32>::new() {
+        if !m.calibrated_gyro_x.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,
@@ -192,7 +192,7 @@ impl From<GyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.calibrated_gyro_y != Vec::<f32>::new() {
+        if !m.calibrated_gyro_y.is_empty() {
             arr[len] = Field {
                 num: 6,
                 profile_type: ProfileType::FLOAT32,
@@ -201,7 +201,7 @@ impl From<GyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.calibrated_gyro_z != Vec::<f32>::new() {
+        if !m.calibrated_gyro_z.is_empty() {
             arr[len] = Field {
                 num: 7,
                 profile_type: ProfileType::FLOAT32,
@@ -211,11 +211,11 @@ impl From<GyroscopeData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::GYROSCOPE_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hr.rs
+++ b/rustyfit/src/profile/mesgdef/hr.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -58,9 +58,9 @@ impl Hr {
             timestamp: typedef::DateTime(u32::MAX),
             fractional_timestamp: u16::MAX,
             time256: u8::MAX,
-            filtered_bpm: Vec::<u8>::new(),
-            event_timestamp: Vec::<u32>::new(),
-            event_timestamp_12: Vec::<u8>::new(),
+            filtered_bpm: Vec::new(),
+            event_timestamp: Vec::new(),
+            event_timestamp_12: Vec::new(),
             state: [0u8; 2],
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -107,7 +107,7 @@ impl Hr {
 
     /// Returns `event_timestamp` in its scaled value. It returns invalid f64 when value is valid.
     pub fn event_timestamp_scaled(&self) -> Vec<f64> {
-        if self.event_timestamp == Vec::<u32>::new() {
+        if self.event_timestamp.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.event_timestamp.len());
@@ -165,7 +165,7 @@ impl Default for Hr {
 impl From<&Message> for Hr {
     /// from creates new Hr struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 2];
 
         const KNOWN_NUMS: [u64; 4] = [1603, 0, 0, 2305843009213693952];
@@ -173,7 +173,7 @@ impl From<&Message> for Hr {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -190,9 +190,9 @@ impl From<&Message> for Hr {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             fractional_timestamp: vals[0].as_u16(),
             time256: vals[1].as_u8(),
-            filtered_bpm: vals[6].as_vec_u8(),
-            event_timestamp: vals[9].as_vec_u32(),
-            event_timestamp_12: vals[10].as_vec_u8(),
+            filtered_bpm: vals[6].to_vec_u8(),
+            event_timestamp: vals[9].to_vec_u32(),
+            event_timestamp_12: vals[10].to_vec_u8(),
             state,
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -240,7 +240,7 @@ impl From<Hr> for Message {
             };
             len += 1;
         }
-        if m.filtered_bpm != Vec::<u8>::new() {
+        if !m.filtered_bpm.is_empty() {
             arr[len] = Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
@@ -249,7 +249,7 @@ impl From<Hr> for Message {
             };
             len += 1;
         }
-        if m.event_timestamp != Vec::<u32>::new() {
+        if !m.event_timestamp.is_empty() {
             arr[len] = Field {
                 num: 9,
                 profile_type: ProfileType::UINT32,
@@ -258,7 +258,7 @@ impl From<Hr> for Message {
             };
             len += 1;
         }
-        if m.event_timestamp_12 != Vec::<u8>::new() {
+        if !m.event_timestamp_12.is_empty() {
             arr[len] = Field {
                 num: 10,
                 profile_type: ProfileType::BYTE,
@@ -268,11 +268,11 @@ impl From<Hr> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HR,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hr_zone.rs
+++ b/rustyfit/src/profile/mesgdef/hr_zone.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -53,14 +53,14 @@ impl Default for HrZone {
 impl From<&Message> for HrZone {
     /// from creates new HrZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [6, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -73,7 +73,7 @@ impl From<&Message> for HrZone {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             high_bpm: vals[1].as_u8(),
-            name: vals[2].as_string(),
+            name: vals[2].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -120,11 +120,11 @@ impl From<HrZone> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HR_ZONE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hrm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/hrm_profile.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -61,14 +61,14 @@ impl Default for HrmProfile {
 impl From<&Message> for HrmProfile {
     /// from creates new HrmProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -148,11 +148,11 @@ impl From<HrmProfile> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HRM_PROFILE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hrv.rs
+++ b/rustyfit/src/profile/mesgdef/hrv.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -28,7 +28,7 @@ impl Hrv {
     /// Create new Hrv with all fields being set to its corresponding invalid value.
     pub const fn new() -> Self {
         Self {
-            time: Vec::<u16>::new(),
+            time: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -36,7 +36,7 @@ impl Hrv {
 
     /// Returns `time` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_scaled(&self) -> Vec<f64> {
-        if self.time == Vec::<u16>::new() {
+        if self.time.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time.len());
@@ -74,14 +74,14 @@ impl Default for Hrv {
 impl From<&Message> for Hrv {
     /// from creates new Hrv struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 1] = [const { &Value::Invalid }; 1];
+        let mut vals = [const { &Value::Invalid }; 1];
 
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -92,7 +92,7 @@ impl From<&Message> for Hrv {
         }
 
         Self {
-            time: vals[0].as_vec_u16(),
+            time: vals[0].to_vec_u16(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -111,7 +111,7 @@ impl From<Hrv> for Message {
         }; 1];
         let mut len = 0usize;
 
-        if m.time != Vec::<u16>::new() {
+        if !m.time.is_empty() {
             arr[len] = Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
@@ -121,11 +121,11 @@ impl From<Hrv> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HRV,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -191,14 +191,14 @@ impl Default for HrvStatusSummary {
 impl From<&Message> for HrvStatusSummary {
     /// from creates new HrvStatusSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -308,11 +308,11 @@ impl From<HrvStatusSummary> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HRV_STATUS_SUMMARY,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hrv_value.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_value.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -67,14 +67,14 @@ impl Default for HrvValue {
 impl From<&Message> for HrvValue {
     /// from creates new HrvValue struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -124,11 +124,11 @@ impl From<HrvValue> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HRV_VALUE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -55,9 +55,9 @@ impl HsaAccelerometerData {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
             sampling_interval: u16::MAX,
-            accel_x: Vec::<i16>::new(),
-            accel_y: Vec::<i16>::new(),
-            accel_z: Vec::<i16>::new(),
+            accel_x: Vec::new(),
+            accel_y: Vec::new(),
+            accel_z: Vec::new(),
             timestamp_32k: u32::MAX,
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -66,7 +66,7 @@ impl HsaAccelerometerData {
 
     /// Returns `accel_x` in its scaled value. It returns invalid f64 when value is valid.
     pub fn accel_x_scaled(&self) -> Vec<f64> {
-        if self.accel_x == Vec::<i16>::new() {
+        if self.accel_x.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.accel_x.len());
@@ -96,7 +96,7 @@ impl HsaAccelerometerData {
 
     /// Returns `accel_y` in its scaled value. It returns invalid f64 when value is valid.
     pub fn accel_y_scaled(&self) -> Vec<f64> {
-        if self.accel_y == Vec::<i16>::new() {
+        if self.accel_y.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.accel_y.len());
@@ -126,7 +126,7 @@ impl HsaAccelerometerData {
 
     /// Returns `accel_z` in its scaled value. It returns invalid f64 when value is valid.
     pub fn accel_z_scaled(&self) -> Vec<f64> {
-        if self.accel_z == Vec::<i16>::new() {
+        if self.accel_z.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.accel_z.len());
@@ -164,14 +164,14 @@ impl Default for HsaAccelerometerData {
 impl From<&Message> for HsaAccelerometerData {
     /// from creates new HsaAccelerometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -185,9 +185,9 @@ impl From<&Message> for HsaAccelerometerData {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
             sampling_interval: vals[1].as_u16(),
-            accel_x: vals[2].as_vec_i16(),
-            accel_y: vals[3].as_vec_i16(),
-            accel_z: vals[4].as_vec_i16(),
+            accel_x: vals[2].to_vec_i16(),
+            accel_y: vals[3].to_vec_i16(),
+            accel_z: vals[4].to_vec_i16(),
             timestamp_32k: vals[5].as_u32(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -234,7 +234,7 @@ impl From<HsaAccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.accel_x != Vec::<i16>::new() {
+        if !m.accel_x.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::SINT16,
@@ -243,7 +243,7 @@ impl From<HsaAccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.accel_y != Vec::<i16>::new() {
+        if !m.accel_y.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::SINT16,
@@ -252,7 +252,7 @@ impl From<HsaAccelerometerData> for Message {
             };
             len += 1;
         }
-        if m.accel_z != Vec::<i16>::new() {
+        if !m.accel_z.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::SINT16,
@@ -271,11 +271,11 @@ impl From<HsaAccelerometerData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_ACCELEROMETER_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -46,9 +46,9 @@ impl HsaBodyBatteryData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             processing_interval: u16::MAX,
-            level: Vec::<i8>::new(),
-            charged: Vec::<i16>::new(),
-            uncharged: Vec::<i16>::new(),
+            level: Vec::new(),
+            charged: Vec::new(),
+            uncharged: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -64,14 +64,14 @@ impl Default for HsaBodyBatteryData {
 impl From<&Message> for HsaBodyBatteryData {
     /// from creates new HsaBodyBatteryData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -84,9 +84,9 @@ impl From<&Message> for HsaBodyBatteryData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             processing_interval: vals[0].as_u16(),
-            level: vals[1].as_vec_i8(),
-            charged: vals[2].as_vec_i16(),
-            uncharged: vals[3].as_vec_i16(),
+            level: vals[1].to_vec_i8(),
+            charged: vals[2].to_vec_i16(),
+            uncharged: vals[3].to_vec_i16(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -123,7 +123,7 @@ impl From<HsaBodyBatteryData> for Message {
             };
             len += 1;
         }
-        if m.level != Vec::<i8>::new() {
+        if !m.level.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::SINT8,
@@ -132,7 +132,7 @@ impl From<HsaBodyBatteryData> for Message {
             };
             len += 1;
         }
-        if m.charged != Vec::<i16>::new() {
+        if !m.charged.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::SINT16,
@@ -141,7 +141,7 @@ impl From<HsaBodyBatteryData> for Message {
             };
             len += 1;
         }
-        if m.uncharged != Vec::<i16>::new() {
+        if !m.uncharged.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::SINT16,
@@ -151,11 +151,11 @@ impl From<HsaBodyBatteryData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_BODY_BATTERY_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -37,7 +37,7 @@ impl HsaConfigurationData {
     pub const fn new() -> Self {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
-            data: Vec::<u8>::new(),
+            data: Vec::new(),
             data_size: u8::MAX,
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -54,14 +54,14 @@ impl Default for HsaConfigurationData {
 impl From<&Message> for HsaConfigurationData {
     /// from creates new HsaConfigurationData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -73,7 +73,7 @@ impl From<&Message> for HsaConfigurationData {
 
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
-            data: vals[0].as_vec_u8(),
+            data: vals[0].to_vec_u8(),
             data_size: vals[1].as_u8(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -102,7 +102,7 @@ impl From<HsaConfigurationData> for Message {
             };
             len += 1;
         }
-        if m.data != Vec::<u8>::new() {
+        if !m.data.is_empty() {
             arr[len] = Field {
                 num: 0,
                 profile_type: ProfileType::BYTE,
@@ -121,11 +121,11 @@ impl From<HsaConfigurationData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_CONFIGURATION_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_event.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_event.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -49,14 +49,14 @@ impl Default for HsaEvent {
 impl From<&Message> for HsaEvent {
     /// from creates new HsaEvent struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -106,11 +106,11 @@ impl From<HsaEvent> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_EVENT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -55,9 +55,9 @@ impl HsaGyroscopeData {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
             sampling_interval: u16::MAX,
-            gyro_x: Vec::<i16>::new(),
-            gyro_y: Vec::<i16>::new(),
-            gyro_z: Vec::<i16>::new(),
+            gyro_x: Vec::new(),
+            gyro_y: Vec::new(),
+            gyro_z: Vec::new(),
             timestamp_32k: u32::MAX,
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -66,7 +66,7 @@ impl HsaGyroscopeData {
 
     /// Returns `gyro_x` in its scaled value. It returns invalid f64 when value is valid.
     pub fn gyro_x_scaled(&self) -> Vec<f64> {
-        if self.gyro_x == Vec::<i16>::new() {
+        if self.gyro_x.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.gyro_x.len());
@@ -96,7 +96,7 @@ impl HsaGyroscopeData {
 
     /// Returns `gyro_y` in its scaled value. It returns invalid f64 when value is valid.
     pub fn gyro_y_scaled(&self) -> Vec<f64> {
-        if self.gyro_y == Vec::<i16>::new() {
+        if self.gyro_y.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.gyro_y.len());
@@ -126,7 +126,7 @@ impl HsaGyroscopeData {
 
     /// Returns `gyro_z` in its scaled value. It returns invalid f64 when value is valid.
     pub fn gyro_z_scaled(&self) -> Vec<f64> {
-        if self.gyro_z == Vec::<i16>::new() {
+        if self.gyro_z.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.gyro_z.len());
@@ -164,14 +164,14 @@ impl Default for HsaGyroscopeData {
 impl From<&Message> for HsaGyroscopeData {
     /// from creates new HsaGyroscopeData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -185,9 +185,9 @@ impl From<&Message> for HsaGyroscopeData {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
             sampling_interval: vals[1].as_u16(),
-            gyro_x: vals[2].as_vec_i16(),
-            gyro_y: vals[3].as_vec_i16(),
-            gyro_z: vals[4].as_vec_i16(),
+            gyro_x: vals[2].to_vec_i16(),
+            gyro_y: vals[3].to_vec_i16(),
+            gyro_z: vals[4].to_vec_i16(),
             timestamp_32k: vals[5].as_u32(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -234,7 +234,7 @@ impl From<HsaGyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.gyro_x != Vec::<i16>::new() {
+        if !m.gyro_x.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::SINT16,
@@ -243,7 +243,7 @@ impl From<HsaGyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.gyro_y != Vec::<i16>::new() {
+        if !m.gyro_y.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::SINT16,
@@ -252,7 +252,7 @@ impl From<HsaGyroscopeData> for Message {
             };
             len += 1;
         }
-        if m.gyro_z != Vec::<i16>::new() {
+        if !m.gyro_z.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::SINT16,
@@ -271,11 +271,11 @@ impl From<HsaGyroscopeData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_GYROSCOPE_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -43,7 +43,7 @@ impl HsaHeartRateData {
             timestamp: typedef::DateTime(u32::MAX),
             processing_interval: u16::MAX,
             status: u8::MAX,
-            heart_rate: Vec::<u8>::new(),
+            heart_rate: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -59,14 +59,14 @@ impl Default for HsaHeartRateData {
 impl From<&Message> for HsaHeartRateData {
     /// from creates new HsaHeartRateData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -80,7 +80,7 @@ impl From<&Message> for HsaHeartRateData {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             processing_interval: vals[0].as_u16(),
             status: vals[1].as_u8(),
-            heart_rate: vals[2].as_vec_u8(),
+            heart_rate: vals[2].to_vec_u8(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -126,7 +126,7 @@ impl From<HsaHeartRateData> for Message {
             };
             len += 1;
         }
-        if m.heart_rate != Vec::<u8>::new() {
+        if !m.heart_rate.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
@@ -136,11 +136,11 @@ impl From<HsaHeartRateData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_HEART_RATE_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -38,7 +38,7 @@ impl HsaRespirationData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             processing_interval: u16::MAX,
-            respiration_rate: Vec::<i16>::new(),
+            respiration_rate: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -46,7 +46,7 @@ impl HsaRespirationData {
 
     /// Returns `respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
     pub fn respiration_rate_scaled(&self) -> Vec<f64> {
-        if self.respiration_rate == Vec::<i16>::new() {
+        if self.respiration_rate.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.respiration_rate.len());
@@ -84,14 +84,14 @@ impl Default for HsaRespirationData {
 impl From<&Message> for HsaRespirationData {
     /// from creates new HsaRespirationData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -104,7 +104,7 @@ impl From<&Message> for HsaRespirationData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             processing_interval: vals[0].as_u16(),
-            respiration_rate: vals[1].as_vec_i16(),
+            respiration_rate: vals[1].to_vec_i16(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -141,7 +141,7 @@ impl From<HsaRespirationData> for Message {
             };
             len += 1;
         }
-        if m.respiration_rate != Vec::<i16>::new() {
+        if !m.respiration_rate.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::SINT16,
@@ -151,11 +151,11 @@ impl From<HsaRespirationData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_RESPIRATION_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -42,8 +42,8 @@ impl HsaSpo2Data {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             processing_interval: u16::MAX,
-            reading_spo2: Vec::<u8>::new(),
-            confidence: Vec::<u8>::new(),
+            reading_spo2: Vec::new(),
+            confidence: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -59,14 +59,14 @@ impl Default for HsaSpo2Data {
 impl From<&Message> for HsaSpo2Data {
     /// from creates new HsaSpo2Data struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -79,8 +79,8 @@ impl From<&Message> for HsaSpo2Data {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             processing_interval: vals[0].as_u16(),
-            reading_spo2: vals[1].as_vec_u8(),
-            confidence: vals[2].as_vec_u8(),
+            reading_spo2: vals[1].to_vec_u8(),
+            confidence: vals[2].to_vec_u8(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -117,7 +117,7 @@ impl From<HsaSpo2Data> for Message {
             };
             len += 1;
         }
-        if m.reading_spo2 != Vec::<u8>::new() {
+        if !m.reading_spo2.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
@@ -126,7 +126,7 @@ impl From<HsaSpo2Data> for Message {
             };
             len += 1;
         }
-        if m.confidence != Vec::<u8>::new() {
+        if !m.confidence.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
@@ -136,11 +136,11 @@ impl From<HsaSpo2Data> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_SPO2_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_step_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_step_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -38,7 +38,7 @@ impl HsaStepData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             processing_interval: u16::MAX,
-            steps: Vec::<u32>::new(),
+            steps: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -54,14 +54,14 @@ impl Default for HsaStepData {
 impl From<&Message> for HsaStepData {
     /// from creates new HsaStepData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -74,7 +74,7 @@ impl From<&Message> for HsaStepData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             processing_interval: vals[0].as_u16(),
-            steps: vals[1].as_vec_u32(),
+            steps: vals[1].to_vec_u32(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -111,7 +111,7 @@ impl From<HsaStepData> for Message {
             };
             len += 1;
         }
-        if m.steps != Vec::<u32>::new() {
+        if !m.steps.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
@@ -121,11 +121,11 @@ impl From<HsaStepData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_STEP_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -37,7 +37,7 @@ impl HsaStressData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             processing_interval: u16::MAX,
-            stress_level: Vec::<i8>::new(),
+            stress_level: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -53,14 +53,14 @@ impl Default for HsaStressData {
 impl From<&Message> for HsaStressData {
     /// from creates new HsaStressData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -73,7 +73,7 @@ impl From<&Message> for HsaStressData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             processing_interval: vals[0].as_u16(),
-            stress_level: vals[1].as_vec_i8(),
+            stress_level: vals[1].to_vec_i8(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -110,7 +110,7 @@ impl From<HsaStressData> for Message {
             };
             len += 1;
         }
-        if m.stress_level != Vec::<i8>::new() {
+        if !m.stress_level.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::SINT8,
@@ -120,11 +120,11 @@ impl From<HsaStressData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_STRESS_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -38,7 +38,7 @@ impl HsaWristTemperatureData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             processing_interval: u16::MAX,
-            value: Vec::<u16>::new(),
+            value: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -46,7 +46,7 @@ impl HsaWristTemperatureData {
 
     /// Returns `value` in its scaled value. It returns invalid f64 when value is valid.
     pub fn value_scaled(&self) -> Vec<f64> {
-        if self.value == Vec::<u16>::new() {
+        if self.value.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.value.len());
@@ -84,14 +84,14 @@ impl Default for HsaWristTemperatureData {
 impl From<&Message> for HsaWristTemperatureData {
     /// from creates new HsaWristTemperatureData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -104,7 +104,7 @@ impl From<&Message> for HsaWristTemperatureData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             processing_interval: vals[0].as_u16(),
-            value: vals[1].as_vec_u16(),
+            value: vals[1].to_vec_u16(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -141,7 +141,7 @@ impl From<HsaWristTemperatureData> for Message {
             };
             len += 1;
         }
-        if m.value != Vec::<u16>::new() {
+        if !m.value.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
@@ -151,11 +151,11 @@ impl From<HsaWristTemperatureData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::HSA_WRIST_TEMPERATURE_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -166,7 +166,7 @@ impl Default for Jump {
 impl From<&Message> for Jump {
     /// from creates new Jump struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 2];
 
         const KNOWN_NUMS: [u64; 4] = [511, 0, 0, 2305843009213693952];
@@ -174,7 +174,7 @@ impl From<&Message> for Jump {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -309,11 +309,11 @@ impl From<Jump> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::JUMP,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -563,18 +563,18 @@ impl Lap {
             avg_neg_vertical_speed: i16::MAX,
             max_pos_vertical_speed: i16::MAX,
             max_neg_vertical_speed: i16::MAX,
-            time_in_hr_zone: Vec::<u32>::new(),
-            time_in_speed_zone: Vec::<u32>::new(),
-            time_in_cadence_zone: Vec::<u32>::new(),
-            time_in_power_zone: Vec::<u32>::new(),
+            time_in_hr_zone: Vec::new(),
+            time_in_speed_zone: Vec::new(),
+            time_in_cadence_zone: Vec::new(),
+            time_in_power_zone: Vec::new(),
             repetition_num: u16::MAX,
             min_altitude: u16::MAX,
             min_heart_rate: u8::MAX,
             active_time: u32::MAX,
             wkt_step_index: typedef::MessageIndex(u16::MAX),
             opponent_score: u16::MAX,
-            stroke_count: Vec::<u16>::new(),
-            zone_count: Vec::<u16>::new(),
+            stroke_count: Vec::new(),
+            zone_count: Vec::new(),
             avg_vertical_oscillation: u16::MAX,
             avg_stance_time_percent: u16::MAX,
             avg_stance_time: u16::MAX,
@@ -582,12 +582,12 @@ impl Lap {
             max_fractional_cadence: u8::MAX,
             total_fractional_cycles: u8::MAX,
             player_score: u16::MAX,
-            avg_total_hemoglobin_conc: Vec::<u16>::new(),
-            min_total_hemoglobin_conc: Vec::<u16>::new(),
-            max_total_hemoglobin_conc: Vec::<u16>::new(),
-            avg_saturated_hemoglobin_percent: Vec::<u16>::new(),
-            min_saturated_hemoglobin_percent: Vec::<u16>::new(),
-            max_saturated_hemoglobin_percent: Vec::<u16>::new(),
+            avg_total_hemoglobin_conc: Vec::new(),
+            min_total_hemoglobin_conc: Vec::new(),
+            max_total_hemoglobin_conc: Vec::new(),
+            avg_saturated_hemoglobin_percent: Vec::new(),
+            min_saturated_hemoglobin_percent: Vec::new(),
+            max_saturated_hemoglobin_percent: Vec::new(),
             avg_left_torque_effectiveness: u8::MAX,
             avg_right_torque_effectiveness: u8::MAX,
             avg_left_pedal_smoothness: u8::MAX,
@@ -597,14 +597,14 @@ impl Lap {
             stand_count: u16::MAX,
             avg_left_pco: i8::MAX,
             avg_right_pco: i8::MAX,
-            avg_left_power_phase: Vec::<u8>::new(),
-            avg_left_power_phase_peak: Vec::<u8>::new(),
-            avg_right_power_phase: Vec::<u8>::new(),
-            avg_right_power_phase_peak: Vec::<u8>::new(),
-            avg_power_position: Vec::<u16>::new(),
-            max_power_position: Vec::<u16>::new(),
-            avg_cadence_position: Vec::<u8>::new(),
-            max_cadence_position: Vec::<u8>::new(),
+            avg_left_power_phase: Vec::new(),
+            avg_left_power_phase_peak: Vec::new(),
+            avg_right_power_phase: Vec::new(),
+            avg_right_power_phase_peak: Vec::new(),
+            avg_power_position: Vec::new(),
+            max_power_position: Vec::new(),
+            avg_cadence_position: Vec::new(),
+            max_cadence_position: Vec::new(),
             enhanced_avg_speed: u32::MAX,
             enhanced_max_speed: u32::MAX,
             enhanced_avg_altitude: u32::MAX,
@@ -1004,7 +1004,7 @@ impl Lap {
 
     /// Returns `time_in_hr_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_hr_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_hr_zone == Vec::<u32>::new() {
+        if self.time_in_hr_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_hr_zone.len());
@@ -1034,7 +1034,7 @@ impl Lap {
 
     /// Returns `time_in_speed_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_speed_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_speed_zone == Vec::<u32>::new() {
+        if self.time_in_speed_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_speed_zone.len());
@@ -1064,7 +1064,7 @@ impl Lap {
 
     /// Returns `time_in_cadence_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_cadence_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_cadence_zone == Vec::<u32>::new() {
+        if self.time_in_cadence_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_cadence_zone.len());
@@ -1094,7 +1094,7 @@ impl Lap {
 
     /// Returns `time_in_power_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_power_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_power_zone == Vec::<u32>::new() {
+        if self.time_in_power_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_power_zone.len());
@@ -1276,7 +1276,7 @@ impl Lap {
 
     /// Returns `avg_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
-        if self.avg_total_hemoglobin_conc == Vec::<u16>::new() {
+        if self.avg_total_hemoglobin_conc.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_total_hemoglobin_conc.len());
@@ -1306,7 +1306,7 @@ impl Lap {
 
     /// Returns `min_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
     pub fn min_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
-        if self.min_total_hemoglobin_conc == Vec::<u16>::new() {
+        if self.min_total_hemoglobin_conc.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.min_total_hemoglobin_conc.len());
@@ -1336,7 +1336,7 @@ impl Lap {
 
     /// Returns `max_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
     pub fn max_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
-        if self.max_total_hemoglobin_conc == Vec::<u16>::new() {
+        if self.max_total_hemoglobin_conc.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.max_total_hemoglobin_conc.len());
@@ -1366,7 +1366,7 @@ impl Lap {
 
     /// Returns `avg_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
-        if self.avg_saturated_hemoglobin_percent == Vec::<u16>::new() {
+        if self.avg_saturated_hemoglobin_percent.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_saturated_hemoglobin_percent.len());
@@ -1396,7 +1396,7 @@ impl Lap {
 
     /// Returns `min_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
     pub fn min_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
-        if self.min_saturated_hemoglobin_percent == Vec::<u16>::new() {
+        if self.min_saturated_hemoglobin_percent.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.min_saturated_hemoglobin_percent.len());
@@ -1426,7 +1426,7 @@ impl Lap {
 
     /// Returns `max_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
     pub fn max_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
-        if self.max_saturated_hemoglobin_percent == Vec::<u16>::new() {
+        if self.max_saturated_hemoglobin_percent.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.max_saturated_hemoglobin_percent.len());
@@ -1570,7 +1570,7 @@ impl Lap {
 
     /// Returns `avg_left_power_phase` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_left_power_phase_scaled(&self) -> Vec<f64> {
-        if self.avg_left_power_phase == Vec::<u8>::new() {
+        if self.avg_left_power_phase.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase.len());
@@ -1600,7 +1600,7 @@ impl Lap {
 
     /// Returns `avg_left_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_left_power_phase_peak_scaled(&self) -> Vec<f64> {
-        if self.avg_left_power_phase_peak == Vec::<u8>::new() {
+        if self.avg_left_power_phase_peak.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase_peak.len());
@@ -1630,7 +1630,7 @@ impl Lap {
 
     /// Returns `avg_right_power_phase` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_right_power_phase_scaled(&self) -> Vec<f64> {
-        if self.avg_right_power_phase == Vec::<u8>::new() {
+        if self.avg_right_power_phase.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase.len());
@@ -1660,7 +1660,7 @@ impl Lap {
 
     /// Returns `avg_right_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_right_power_phase_peak_scaled(&self) -> Vec<f64> {
-        if self.avg_right_power_phase_peak == Vec::<u8>::new() {
+        if self.avg_right_power_phase_peak.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase_peak.len());
@@ -2079,7 +2079,7 @@ impl Default for Lap {
 impl From<&Message> for Lap {
     /// from creates new Lap struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 18];
 
         const KNOWN_NUMS: [u64; 4] = [
@@ -2092,7 +2092,7 @@ impl From<&Message> for Lap {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -2159,18 +2159,18 @@ impl From<&Message> for Lap {
             avg_neg_vertical_speed: vals[54].as_i16(),
             max_pos_vertical_speed: vals[55].as_i16(),
             max_neg_vertical_speed: vals[56].as_i16(),
-            time_in_hr_zone: vals[57].as_vec_u32(),
-            time_in_speed_zone: vals[58].as_vec_u32(),
-            time_in_cadence_zone: vals[59].as_vec_u32(),
-            time_in_power_zone: vals[60].as_vec_u32(),
+            time_in_hr_zone: vals[57].to_vec_u32(),
+            time_in_speed_zone: vals[58].to_vec_u32(),
+            time_in_cadence_zone: vals[59].to_vec_u32(),
+            time_in_power_zone: vals[60].to_vec_u32(),
             repetition_num: vals[61].as_u16(),
             min_altitude: vals[62].as_u16(),
             min_heart_rate: vals[63].as_u8(),
             active_time: vals[70].as_u32(),
             wkt_step_index: typedef::MessageIndex(vals[71].as_u16()),
             opponent_score: vals[74].as_u16(),
-            stroke_count: vals[75].as_vec_u16(),
-            zone_count: vals[76].as_vec_u16(),
+            stroke_count: vals[75].to_vec_u16(),
+            zone_count: vals[76].to_vec_u16(),
             avg_vertical_oscillation: vals[77].as_u16(),
             avg_stance_time_percent: vals[78].as_u16(),
             avg_stance_time: vals[79].as_u16(),
@@ -2178,12 +2178,12 @@ impl From<&Message> for Lap {
             max_fractional_cadence: vals[81].as_u8(),
             total_fractional_cycles: vals[82].as_u8(),
             player_score: vals[83].as_u16(),
-            avg_total_hemoglobin_conc: vals[84].as_vec_u16(),
-            min_total_hemoglobin_conc: vals[85].as_vec_u16(),
-            max_total_hemoglobin_conc: vals[86].as_vec_u16(),
-            avg_saturated_hemoglobin_percent: vals[87].as_vec_u16(),
-            min_saturated_hemoglobin_percent: vals[88].as_vec_u16(),
-            max_saturated_hemoglobin_percent: vals[89].as_vec_u16(),
+            avg_total_hemoglobin_conc: vals[84].to_vec_u16(),
+            min_total_hemoglobin_conc: vals[85].to_vec_u16(),
+            max_total_hemoglobin_conc: vals[86].to_vec_u16(),
+            avg_saturated_hemoglobin_percent: vals[87].to_vec_u16(),
+            min_saturated_hemoglobin_percent: vals[88].to_vec_u16(),
+            max_saturated_hemoglobin_percent: vals[89].to_vec_u16(),
             avg_left_torque_effectiveness: vals[91].as_u8(),
             avg_right_torque_effectiveness: vals[92].as_u8(),
             avg_left_pedal_smoothness: vals[93].as_u8(),
@@ -2193,14 +2193,14 @@ impl From<&Message> for Lap {
             stand_count: vals[99].as_u16(),
             avg_left_pco: vals[100].as_i8(),
             avg_right_pco: vals[101].as_i8(),
-            avg_left_power_phase: vals[102].as_vec_u8(),
-            avg_left_power_phase_peak: vals[103].as_vec_u8(),
-            avg_right_power_phase: vals[104].as_vec_u8(),
-            avg_right_power_phase_peak: vals[105].as_vec_u8(),
-            avg_power_position: vals[106].as_vec_u16(),
-            max_power_position: vals[107].as_vec_u16(),
-            avg_cadence_position: vals[108].as_vec_u8(),
-            max_cadence_position: vals[109].as_vec_u8(),
+            avg_left_power_phase: vals[102].to_vec_u8(),
+            avg_left_power_phase_peak: vals[103].to_vec_u8(),
+            avg_right_power_phase: vals[104].to_vec_u8(),
+            avg_right_power_phase_peak: vals[105].to_vec_u8(),
+            avg_power_position: vals[106].to_vec_u16(),
+            max_power_position: vals[107].to_vec_u16(),
+            avg_cadence_position: vals[108].to_vec_u8(),
+            max_cadence_position: vals[109].to_vec_u8(),
             enhanced_avg_speed: vals[110].as_u32(),
             enhanced_max_speed: vals[111].as_u32(),
             enhanced_avg_altitude: vals[112].as_u32(),
@@ -2727,7 +2727,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.time_in_hr_zone != Vec::<u32>::new() {
+        if !m.time_in_hr_zone.is_empty() {
             arr[len] = Field {
                 num: 57,
                 profile_type: ProfileType::UINT32,
@@ -2736,7 +2736,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.time_in_speed_zone != Vec::<u32>::new() {
+        if !m.time_in_speed_zone.is_empty() {
             arr[len] = Field {
                 num: 58,
                 profile_type: ProfileType::UINT32,
@@ -2745,7 +2745,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.time_in_cadence_zone != Vec::<u32>::new() {
+        if !m.time_in_cadence_zone.is_empty() {
             arr[len] = Field {
                 num: 59,
                 profile_type: ProfileType::UINT32,
@@ -2754,7 +2754,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.time_in_power_zone != Vec::<u32>::new() {
+        if !m.time_in_power_zone.is_empty() {
             arr[len] = Field {
                 num: 60,
                 profile_type: ProfileType::UINT32,
@@ -2817,7 +2817,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.stroke_count != Vec::<u16>::new() {
+        if !m.stroke_count.is_empty() {
             arr[len] = Field {
                 num: 75,
                 profile_type: ProfileType::UINT16,
@@ -2826,7 +2826,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.zone_count != Vec::<u16>::new() {
+        if !m.zone_count.is_empty() {
             arr[len] = Field {
                 num: 76,
                 profile_type: ProfileType::UINT16,
@@ -2898,7 +2898,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.avg_total_hemoglobin_conc != Vec::<u16>::new() {
+        if !m.avg_total_hemoglobin_conc.is_empty() {
             arr[len] = Field {
                 num: 84,
                 profile_type: ProfileType::UINT16,
@@ -2907,7 +2907,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.min_total_hemoglobin_conc != Vec::<u16>::new() {
+        if !m.min_total_hemoglobin_conc.is_empty() {
             arr[len] = Field {
                 num: 85,
                 profile_type: ProfileType::UINT16,
@@ -2916,7 +2916,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.max_total_hemoglobin_conc != Vec::<u16>::new() {
+        if !m.max_total_hemoglobin_conc.is_empty() {
             arr[len] = Field {
                 num: 86,
                 profile_type: ProfileType::UINT16,
@@ -2925,7 +2925,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.avg_saturated_hemoglobin_percent != Vec::<u16>::new() {
+        if !m.avg_saturated_hemoglobin_percent.is_empty() {
             arr[len] = Field {
                 num: 87,
                 profile_type: ProfileType::UINT16,
@@ -2934,7 +2934,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.min_saturated_hemoglobin_percent != Vec::<u16>::new() {
+        if !m.min_saturated_hemoglobin_percent.is_empty() {
             arr[len] = Field {
                 num: 88,
                 profile_type: ProfileType::UINT16,
@@ -2943,7 +2943,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.max_saturated_hemoglobin_percent != Vec::<u16>::new() {
+        if !m.max_saturated_hemoglobin_percent.is_empty() {
             arr[len] = Field {
                 num: 89,
                 profile_type: ProfileType::UINT16,
@@ -3033,7 +3033,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.avg_left_power_phase != Vec::<u8>::new() {
+        if !m.avg_left_power_phase.is_empty() {
             arr[len] = Field {
                 num: 102,
                 profile_type: ProfileType::UINT8,
@@ -3042,7 +3042,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.avg_left_power_phase_peak != Vec::<u8>::new() {
+        if !m.avg_left_power_phase_peak.is_empty() {
             arr[len] = Field {
                 num: 103,
                 profile_type: ProfileType::UINT8,
@@ -3051,7 +3051,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.avg_right_power_phase != Vec::<u8>::new() {
+        if !m.avg_right_power_phase.is_empty() {
             arr[len] = Field {
                 num: 104,
                 profile_type: ProfileType::UINT8,
@@ -3060,7 +3060,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.avg_right_power_phase_peak != Vec::<u8>::new() {
+        if !m.avg_right_power_phase_peak.is_empty() {
             arr[len] = Field {
                 num: 105,
                 profile_type: ProfileType::UINT8,
@@ -3069,7 +3069,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.avg_power_position != Vec::<u16>::new() {
+        if !m.avg_power_position.is_empty() {
             arr[len] = Field {
                 num: 106,
                 profile_type: ProfileType::UINT16,
@@ -3078,7 +3078,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.max_power_position != Vec::<u16>::new() {
+        if !m.max_power_position.is_empty() {
             arr[len] = Field {
                 num: 107,
                 profile_type: ProfileType::UINT16,
@@ -3087,7 +3087,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.avg_cadence_position != Vec::<u8>::new() {
+        if !m.avg_cadence_position.is_empty() {
             arr[len] = Field {
                 num: 108,
                 profile_type: ProfileType::UINT8,
@@ -3096,7 +3096,7 @@ impl From<Lap> for Message {
             };
             len += 1;
         }
-        if m.max_cadence_position != Vec::<u8>::new() {
+        if !m.max_cadence_position.is_empty() {
             arr[len] = Field {
                 num: 109,
                 profile_type: ProfileType::UINT8,
@@ -3367,11 +3367,11 @@ impl From<Lap> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::LAP,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/length.rs
+++ b/rustyfit/src/profile/mesgdef/length.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -125,8 +125,8 @@ impl Length {
             length_type: typedef::LengthType(u8::MAX),
             player_score: u16::MAX,
             opponent_score: u16::MAX,
-            stroke_count: Vec::<u16>::new(),
-            zone_count: Vec::<u16>::new(),
+            stroke_count: Vec::new(),
+            zone_count: Vec::new(),
             enhanced_avg_respiration_rate: u16::MAX,
             enhanced_max_respiration_rate: u16::MAX,
             avg_respiration_rate: u8::MAX,
@@ -262,7 +262,7 @@ impl Default for Length {
 impl From<&Message> for Length {
     /// from creates new Length struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 3];
 
         const KNOWN_NUMS: [u64; 4] = [66854655, 0, 0, 6917529027641081856];
@@ -270,7 +270,7 @@ impl From<&Message> for Length {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -300,8 +300,8 @@ impl From<&Message> for Length {
             length_type: typedef::LengthType(vals[12].as_u8()),
             player_score: vals[18].as_u16(),
             opponent_score: vals[19].as_u16(),
-            stroke_count: vals[20].as_vec_u16(),
-            zone_count: vals[21].as_vec_u16(),
+            stroke_count: vals[20].to_vec_u16(),
+            zone_count: vals[21].to_vec_u16(),
             enhanced_avg_respiration_rate: vals[22].as_u16(),
             enhanced_max_respiration_rate: vals[23].as_u16(),
             avg_respiration_rate: vals[24].as_u8(),
@@ -470,7 +470,7 @@ impl From<Length> for Message {
             };
             len += 1;
         }
-        if m.stroke_count != Vec::<u16>::new() {
+        if !m.stroke_count.is_empty() {
             arr[len] = Field {
                 num: 20,
                 profile_type: ProfileType::UINT16,
@@ -479,7 +479,7 @@ impl From<Length> for Message {
             };
             len += 1;
         }
-        if m.zone_count != Vec::<u16>::new() {
+        if !m.zone_count.is_empty() {
             arr[len] = Field {
                 num: 21,
                 profile_type: ProfileType::UINT16,
@@ -525,11 +525,11 @@ impl From<Length> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::LENGTH,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/magnetometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/magnetometer_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -62,13 +62,13 @@ impl MagnetometerData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
-            sample_time_offset: Vec::<u16>::new(),
-            mag_x: Vec::<u16>::new(),
-            mag_y: Vec::<u16>::new(),
-            mag_z: Vec::<u16>::new(),
-            calibrated_mag_x: Vec::<f32>::new(),
-            calibrated_mag_y: Vec::<f32>::new(),
-            calibrated_mag_z: Vec::<f32>::new(),
+            sample_time_offset: Vec::new(),
+            mag_x: Vec::new(),
+            mag_y: Vec::new(),
+            mag_z: Vec::new(),
+            calibrated_mag_x: Vec::new(),
+            calibrated_mag_y: Vec::new(),
+            calibrated_mag_z: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -84,14 +84,14 @@ impl Default for MagnetometerData {
 impl From<&Message> for MagnetometerData {
     /// from creates new MagnetometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -104,13 +104,13 @@ impl From<&Message> for MagnetometerData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            sample_time_offset: vals[1].as_vec_u16(),
-            mag_x: vals[2].as_vec_u16(),
-            mag_y: vals[3].as_vec_u16(),
-            mag_z: vals[4].as_vec_u16(),
-            calibrated_mag_x: vals[5].as_vec_f32(),
-            calibrated_mag_y: vals[6].as_vec_f32(),
-            calibrated_mag_z: vals[7].as_vec_f32(),
+            sample_time_offset: vals[1].to_vec_u16(),
+            mag_x: vals[2].to_vec_u16(),
+            mag_y: vals[3].to_vec_u16(),
+            mag_z: vals[4].to_vec_u16(),
+            calibrated_mag_x: vals[5].to_vec_f32(),
+            calibrated_mag_y: vals[6].to_vec_f32(),
+            calibrated_mag_z: vals[7].to_vec_f32(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -147,7 +147,7 @@ impl From<MagnetometerData> for Message {
             };
             len += 1;
         }
-        if m.sample_time_offset != Vec::<u16>::new() {
+        if !m.sample_time_offset.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
@@ -156,7 +156,7 @@ impl From<MagnetometerData> for Message {
             };
             len += 1;
         }
-        if m.mag_x != Vec::<u16>::new() {
+        if !m.mag_x.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
@@ -165,7 +165,7 @@ impl From<MagnetometerData> for Message {
             };
             len += 1;
         }
-        if m.mag_y != Vec::<u16>::new() {
+        if !m.mag_y.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
@@ -174,7 +174,7 @@ impl From<MagnetometerData> for Message {
             };
             len += 1;
         }
-        if m.mag_z != Vec::<u16>::new() {
+        if !m.mag_z.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
@@ -183,7 +183,7 @@ impl From<MagnetometerData> for Message {
             };
             len += 1;
         }
-        if m.calibrated_mag_x != Vec::<f32>::new() {
+        if !m.calibrated_mag_x.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,
@@ -192,7 +192,7 @@ impl From<MagnetometerData> for Message {
             };
             len += 1;
         }
-        if m.calibrated_mag_y != Vec::<f32>::new() {
+        if !m.calibrated_mag_y.is_empty() {
             arr[len] = Field {
                 num: 6,
                 profile_type: ProfileType::FLOAT32,
@@ -201,7 +201,7 @@ impl From<MagnetometerData> for Message {
             };
             len += 1;
         }
-        if m.calibrated_mag_z != Vec::<f32>::new() {
+        if !m.calibrated_mag_z.is_empty() {
             arr[len] = Field {
                 num: 7,
                 profile_type: ProfileType::FLOAT32,
@@ -211,11 +211,11 @@ impl From<MagnetometerData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::MAGNETOMETER_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/max_met_data.rs
+++ b/rustyfit/src/profile/mesgdef/max_met_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -95,14 +95,14 @@ impl Default for MaxMetData {
 impl From<&Message> for MaxMetData {
     /// from creates new MaxMetData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 14] = [const { &Value::Invalid }; 14];
+        let mut vals = [const { &Value::Invalid }; 14];
 
         const KNOWN_NUMS: [u64; 4] = [13157, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -212,11 +212,11 @@ impl From<MaxMetData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::MAX_MET_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/memo_glob.rs
+++ b/rustyfit/src/profile/mesgdef/memo_glob.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -49,11 +49,11 @@ impl MemoGlob {
     pub const fn new() -> Self {
         Self {
             part_index: u32::MAX,
-            memo: Vec::<u8>::new(),
+            memo: Vec::new(),
             mesg_num: typedef::MesgNum(u16::MAX),
             parent_index: typedef::MessageIndex(u16::MAX),
             field_num: u8::MAX,
-            data: Vec::<u8>::new(),
+            data: Vec::new(),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -69,14 +69,14 @@ impl Default for MemoGlob {
 impl From<&Message> for MemoGlob {
     /// from creates new MemoGlob struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 251] = [const { &Value::Invalid }; 251];
+        let mut vals = [const { &Value::Invalid }; 251];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 288230376151711744];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -88,11 +88,11 @@ impl From<&Message> for MemoGlob {
 
         Self {
             part_index: vals[250].as_u32(),
-            memo: vals[0].as_vec_u8(),
+            memo: vals[0].to_vec_u8(),
             mesg_num: typedef::MesgNum(vals[1].as_u16()),
             parent_index: typedef::MessageIndex(vals[2].as_u16()),
             field_num: vals[3].as_u8(),
-            data: vals[4].as_vec_u8(),
+            data: vals[4].to_vec_u8(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -120,7 +120,7 @@ impl From<MemoGlob> for Message {
             };
             len += 1;
         }
-        if m.memo != Vec::<u8>::new() {
+        if !m.memo.is_empty() {
             arr[len] = Field {
                 num: 0,
                 profile_type: ProfileType::BYTE,
@@ -156,7 +156,7 @@ impl From<MemoGlob> for Message {
             };
             len += 1;
         }
-        if m.data != Vec::<u8>::new() {
+        if !m.data.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::UINT8Z,
@@ -166,11 +166,11 @@ impl From<MemoGlob> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::MEMO_GLOB,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -59,14 +59,14 @@ impl Default for MesgCapabilities {
 impl From<&Message> for MesgCapabilities {
     /// from creates new MesgCapabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -146,11 +146,11 @@ impl From<MesgCapabilities> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::MESG_CAPABILITIES,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/met_zone.rs
+++ b/rustyfit/src/profile/mesgdef/met_zone.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -95,14 +95,14 @@ impl Default for MetZone {
 impl From<&Message> for MetZone {
     /// from creates new MetZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [14, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -172,11 +172,11 @@ impl From<MetZone> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::MET_ZONE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/monitoring.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -381,7 +381,7 @@ impl Default for Monitoring {
 impl From<&Message> for Monitoring {
     /// from creates new Monitoring struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 4];
 
         const KNOWN_NUMS: [u64; 4] = [34343608319, 0, 0, 2305843009213693952];
@@ -389,7 +389,7 @@ impl From<&Message> for Monitoring {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -723,11 +723,11 @@ impl From<Monitoring> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::MONITORING,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -54,14 +54,14 @@ impl Default for MonitoringHrData {
 impl From<&Message> for MonitoringHrData {
     /// from creates new MonitoringHrData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -121,11 +121,11 @@ impl From<MonitoringHrData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::MONITORING_HR_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/monitoring_info.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_info.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -49,9 +49,9 @@ impl MonitoringInfo {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             local_timestamp: typedef::LocalDateTime(u32::MAX),
-            activity_type: Vec::<typedef::ActivityType>::new(),
-            cycles_to_distance: Vec::<u16>::new(),
-            cycles_to_calories: Vec::<u16>::new(),
+            activity_type: Vec::new(),
+            cycles_to_distance: Vec::new(),
+            cycles_to_calories: Vec::new(),
             resting_metabolic_rate: u16::MAX,
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -60,7 +60,7 @@ impl MonitoringInfo {
 
     /// Returns `cycles_to_distance` in its scaled value. It returns invalid f64 when value is valid.
     pub fn cycles_to_distance_scaled(&self) -> Vec<f64> {
-        if self.cycles_to_distance == Vec::<u16>::new() {
+        if self.cycles_to_distance.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.cycles_to_distance.len());
@@ -90,7 +90,7 @@ impl MonitoringInfo {
 
     /// Returns `cycles_to_calories` in its scaled value. It returns invalid f64 when value is valid.
     pub fn cycles_to_calories_scaled(&self) -> Vec<f64> {
-        if self.cycles_to_calories == Vec::<u16>::new() {
+        if self.cycles_to_calories.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.cycles_to_calories.len());
@@ -128,14 +128,14 @@ impl Default for MonitoringInfo {
 impl From<&Message> for MonitoringInfo {
     /// from creates new MonitoringInfo struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [59, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -151,15 +151,13 @@ impl From<&Message> for MonitoringInfo {
             activity_type: match &vals[1] {
                 Value::VecUint8(v) => {
                     let mut vs = Vec::with_capacity(v.len());
-                    for x in v {
-                        vs.push(typedef::ActivityType(*x))
-                    }
+                    vs.extend(v.iter().map(|&x| typedef::ActivityType(x)));
                     vs
                 }
                 _ => Vec::new(),
             },
-            cycles_to_distance: vals[3].as_vec_u16(),
-            cycles_to_calories: vals[4].as_vec_u16(),
+            cycles_to_distance: vals[3].to_vec_u16(),
+            cycles_to_calories: vals[4].to_vec_u16(),
             resting_metabolic_rate: vals[5].as_u16(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -197,7 +195,7 @@ impl From<MonitoringInfo> for Message {
             };
             len += 1;
         }
-        if m.activity_type != Vec::<typedef::ActivityType>::new() {
+        if !m.activity_type.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::ACTIVITY_TYPE,
@@ -209,7 +207,7 @@ impl From<MonitoringInfo> for Message {
             };
             len += 1;
         }
-        if m.cycles_to_distance != Vec::<u16>::new() {
+        if !m.cycles_to_distance.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
@@ -218,7 +216,7 @@ impl From<MonitoringInfo> for Message {
             };
             len += 1;
         }
-        if m.cycles_to_calories != Vec::<u16>::new() {
+        if !m.cycles_to_calories.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
@@ -237,11 +235,11 @@ impl From<MonitoringInfo> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::MONITORING_INFO,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/nap_event.rs
+++ b/rustyfit/src/profile/mesgdef/nap_event.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -84,14 +84,14 @@ impl Default for NapEvent {
 impl From<&Message> for NapEvent {
     /// from creates new NapEvent struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -221,11 +221,11 @@ impl From<NapEvent> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::NAP_EVENT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/nmea_sentence.rs
+++ b/rustyfit/src/profile/mesgdef/nmea_sentence.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -55,14 +55,14 @@ impl Default for NmeaSentence {
 impl From<&Message> for NmeaSentence {
     /// from creates new NmeaSentence struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -75,7 +75,7 @@ impl From<&Message> for NmeaSentence {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            sentence: vals[1].as_string(),
+            sentence: vals[1].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -122,11 +122,11 @@ impl From<NmeaSentence> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::NMEA_SENTENCE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/obdii_data.rs
+++ b/rustyfit/src/profile/mesgdef/obdii_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -62,11 +62,11 @@ impl ObdiiData {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
-            time_offset: Vec::<u16>::new(),
+            time_offset: Vec::new(),
             pid: u8::MAX,
-            raw_data: Vec::<u8>::new(),
-            pid_data_size: Vec::<u8>::new(),
-            system_time: Vec::<u32>::new(),
+            raw_data: Vec::new(),
+            pid_data_size: Vec::new(),
+            system_time: Vec::new(),
             start_timestamp: typedef::DateTime(u32::MAX),
             start_timestamp_ms: u16::MAX,
             unknown_fields: Vec::new(),
@@ -84,14 +84,14 @@ impl Default for ObdiiData {
 impl From<&Message> for ObdiiData {
     /// from creates new ObdiiData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -104,11 +104,11 @@ impl From<&Message> for ObdiiData {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            time_offset: vals[1].as_vec_u16(),
+            time_offset: vals[1].to_vec_u16(),
             pid: vals[2].as_u8(),
-            raw_data: vals[3].as_vec_u8(),
-            pid_data_size: vals[4].as_vec_u8(),
-            system_time: vals[5].as_vec_u32(),
+            raw_data: vals[3].to_vec_u8(),
+            pid_data_size: vals[4].to_vec_u8(),
+            system_time: vals[5].to_vec_u32(),
             start_timestamp: typedef::DateTime(vals[6].as_u32()),
             start_timestamp_ms: vals[7].as_u16(),
             unknown_fields,
@@ -147,7 +147,7 @@ impl From<ObdiiData> for Message {
             };
             len += 1;
         }
-        if m.time_offset != Vec::<u16>::new() {
+        if !m.time_offset.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
@@ -165,7 +165,7 @@ impl From<ObdiiData> for Message {
             };
             len += 1;
         }
-        if m.raw_data != Vec::<u8>::new() {
+        if !m.raw_data.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::BYTE,
@@ -174,7 +174,7 @@ impl From<ObdiiData> for Message {
             };
             len += 1;
         }
-        if m.pid_data_size != Vec::<u8>::new() {
+        if !m.pid_data_size.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
@@ -183,7 +183,7 @@ impl From<ObdiiData> for Message {
             };
             len += 1;
         }
-        if m.system_time != Vec::<u32>::new() {
+        if !m.system_time.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
@@ -211,11 +211,11 @@ impl From<ObdiiData> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::OBDII_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/ohr_settings.rs
+++ b/rustyfit/src/profile/mesgdef/ohr_settings.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -48,14 +48,14 @@ impl Default for OhrSettings {
 impl From<&Message> for OhrSettings {
     /// from creates new OhrSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -105,11 +105,11 @@ impl From<OhrSettings> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::OHR_SETTINGS,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -69,14 +69,14 @@ impl Default for OneDSensorCalibration {
 impl From<&Message> for OneDSensorCalibration {
     /// from creates new OneDSensorCalibration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -166,11 +166,11 @@ impl From<OneDSensorCalibration> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::ONE_D_SENSOR_CALIBRATION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/power_zone.rs
+++ b/rustyfit/src/profile/mesgdef/power_zone.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -53,14 +53,14 @@ impl Default for PowerZone {
 impl From<&Message> for PowerZone {
     /// from creates new PowerZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [6, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -73,7 +73,7 @@ impl From<&Message> for PowerZone {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             high_value: vals[1].as_u16(),
-            name: vals[2].as_string(),
+            name: vals[2].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -120,11 +120,11 @@ impl From<PowerZone> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::POWER_ZONE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/raw_bbi.rs
+++ b/rustyfit/src/profile/mesgdef/raw_bbi.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -57,10 +57,10 @@ impl RawBbi {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             timestamp_ms: u16::MAX,
-            data: Vec::<u16>::new(),
-            time: Vec::<u16>::new(),
-            quality: Vec::<u8>::new(),
-            gap: Vec::<u8>::new(),
+            data: Vec::new(),
+            time: Vec::new(),
+            quality: Vec::new(),
+            gap: Vec::new(),
             state: [0u8; 1],
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -97,7 +97,7 @@ impl Default for RawBbi {
 impl From<&Message> for RawBbi {
     /// from creates new RawBbi struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 1];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
@@ -105,7 +105,7 @@ impl From<&Message> for RawBbi {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -121,10 +121,10 @@ impl From<&Message> for RawBbi {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            data: vals[1].as_vec_u16(),
-            time: vals[2].as_vec_u16(),
-            quality: vals[3].as_vec_u8(),
-            gap: vals[4].as_vec_u8(),
+            data: vals[1].to_vec_u16(),
+            time: vals[2].to_vec_u16(),
+            quality: vals[3].to_vec_u8(),
+            gap: vals[4].to_vec_u8(),
             state,
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -163,7 +163,7 @@ impl From<RawBbi> for Message {
             };
             len += 1;
         }
-        if m.data != Vec::<u16>::new() {
+        if !m.data.is_empty() {
             arr[len] = Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
@@ -172,7 +172,7 @@ impl From<RawBbi> for Message {
             };
             len += 1;
         }
-        if m.time != Vec::<u16>::new() {
+        if !m.time.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
@@ -181,7 +181,7 @@ impl From<RawBbi> for Message {
             };
             len += 1;
         }
-        if m.quality != Vec::<u8>::new() {
+        if !m.quality.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
@@ -190,7 +190,7 @@ impl From<RawBbi> for Message {
             };
             len += 1;
         }
-        if m.gap != Vec::<u8>::new() {
+        if !m.gap.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
@@ -200,11 +200,11 @@ impl From<RawBbi> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::RAW_BBI,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -379,7 +379,7 @@ impl Record {
             time_from_course: i32::MAX,
             cycle_length: u8::MAX,
             temperature: i8::MAX,
-            speed_1s: Vec::<u8>::new(),
+            speed_1s: Vec::new(),
             cycles: u8::MAX,
             total_cycles: u32::MAX,
             compressed_accumulated_power: u16::MAX,
@@ -412,10 +412,10 @@ impl Record {
             device_index: typedef::DeviceIndex(u8::MAX),
             left_pco: i8::MAX,
             right_pco: i8::MAX,
-            left_power_phase: Vec::<u8>::new(),
-            left_power_phase_peak: Vec::<u8>::new(),
-            right_power_phase: Vec::<u8>::new(),
-            right_power_phase_peak: Vec::<u8>::new(),
+            left_power_phase: Vec::new(),
+            left_power_phase_peak: Vec::new(),
+            right_power_phase: Vec::new(),
+            right_power_phase_peak: Vec::new(),
             enhanced_speed: u32::MAX,
             enhanced_altitude: u32::MAX,
             battery_soc: u8::MAX,
@@ -580,7 +580,7 @@ impl Record {
 
     /// Returns `speed_1s` in its scaled value. It returns invalid f64 when value is valid.
     pub fn speed_1s_scaled(&self) -> Vec<f64> {
-        if self.speed_1s == Vec::<u8>::new() {
+        if self.speed_1s.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.speed_1s.len());
@@ -971,7 +971,7 @@ impl Record {
 
     /// Returns `left_power_phase` in its scaled value. It returns invalid f64 when value is valid.
     pub fn left_power_phase_scaled(&self) -> Vec<f64> {
-        if self.left_power_phase == Vec::<u8>::new() {
+        if self.left_power_phase.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.left_power_phase.len());
@@ -1001,7 +1001,7 @@ impl Record {
 
     /// Returns `left_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
     pub fn left_power_phase_peak_scaled(&self) -> Vec<f64> {
-        if self.left_power_phase_peak == Vec::<u8>::new() {
+        if self.left_power_phase_peak.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.left_power_phase_peak.len());
@@ -1031,7 +1031,7 @@ impl Record {
 
     /// Returns `right_power_phase` in its scaled value. It returns invalid f64 when value is valid.
     pub fn right_power_phase_scaled(&self) -> Vec<f64> {
-        if self.right_power_phase == Vec::<u8>::new() {
+        if self.right_power_phase.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.right_power_phase.len());
@@ -1061,7 +1061,7 @@ impl Record {
 
     /// Returns `right_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
     pub fn right_power_phase_peak_scaled(&self) -> Vec<f64> {
-        if self.right_power_phase_peak == Vec::<u8>::new() {
+        if self.right_power_phase_peak.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.right_power_phase_peak.len());
@@ -1442,7 +1442,7 @@ impl Default for Record {
 impl From<&Message> for Record {
     /// from creates new Record struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
         let mut state = [0u8; 14];
 
         const KNOWN_NUMS: [u64; 4] = [
@@ -1455,7 +1455,7 @@ impl From<&Message> for Record {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -1493,7 +1493,7 @@ impl From<&Message> for Record {
             time_from_course: vals[11].as_i32(),
             cycle_length: vals[12].as_u8(),
             temperature: vals[13].as_i8(),
-            speed_1s: vals[17].as_vec_u8(),
+            speed_1s: vals[17].to_vec_u8(),
             cycles: vals[18].as_u8(),
             total_cycles: vals[19].as_u32(),
             compressed_accumulated_power: vals[28].as_u16(),
@@ -1526,10 +1526,10 @@ impl From<&Message> for Record {
             device_index: typedef::DeviceIndex(vals[62].as_u8()),
             left_pco: vals[67].as_i8(),
             right_pco: vals[68].as_i8(),
-            left_power_phase: vals[69].as_vec_u8(),
-            left_power_phase_peak: vals[70].as_vec_u8(),
-            right_power_phase: vals[71].as_vec_u8(),
-            right_power_phase_peak: vals[72].as_vec_u8(),
+            left_power_phase: vals[69].to_vec_u8(),
+            left_power_phase_peak: vals[70].to_vec_u8(),
+            right_power_phase: vals[71].to_vec_u8(),
+            right_power_phase_peak: vals[72].to_vec_u8(),
             enhanced_speed: vals[73].as_u32(),
             enhanced_altitude: vals[78].as_u32(),
             battery_soc: vals[81].as_u8(),
@@ -1717,7 +1717,7 @@ impl From<Record> for Message {
             };
             len += 1;
         }
-        if m.speed_1s != Vec::<u8>::new() {
+        if !m.speed_1s.is_empty() {
             arr[len] = Field {
                 num: 17,
                 profile_type: ProfileType::UINT8,
@@ -2014,7 +2014,7 @@ impl From<Record> for Message {
             };
             len += 1;
         }
-        if m.left_power_phase != Vec::<u8>::new() {
+        if !m.left_power_phase.is_empty() {
             arr[len] = Field {
                 num: 69,
                 profile_type: ProfileType::UINT8,
@@ -2023,7 +2023,7 @@ impl From<Record> for Message {
             };
             len += 1;
         }
-        if m.left_power_phase_peak != Vec::<u8>::new() {
+        if !m.left_power_phase_peak.is_empty() {
             arr[len] = Field {
                 num: 70,
                 profile_type: ProfileType::UINT8,
@@ -2032,7 +2032,7 @@ impl From<Record> for Message {
             };
             len += 1;
         }
-        if m.right_power_phase != Vec::<u8>::new() {
+        if !m.right_power_phase.is_empty() {
             arr[len] = Field {
                 num: 71,
                 profile_type: ProfileType::UINT8,
@@ -2041,7 +2041,7 @@ impl From<Record> for Message {
             };
             len += 1;
         }
-        if m.right_power_phase_peak != Vec::<u8>::new() {
+        if !m.right_power_phase_peak.is_empty() {
             arr[len] = Field {
                 num: 72,
                 profile_type: ProfileType::UINT8,
@@ -2339,11 +2339,11 @@ impl From<Record> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::RECORD,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/respiration_rate.rs
+++ b/rustyfit/src/profile/mesgdef/respiration_rate.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -67,14 +67,14 @@ impl Default for RespirationRate {
 impl From<&Message> for RespirationRate {
     /// from creates new RespirationRate struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -124,11 +124,11 @@ impl From<RespirationRate> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::RESPIRATION_RATE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/schedule.rs
+++ b/rustyfit/src/profile/mesgdef/schedule.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -72,14 +72,14 @@ impl Default for Schedule {
 impl From<&Message> for Schedule {
     /// from creates new Schedule struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 7] = [const { &Value::Invalid }; 7];
+        let mut vals = [const { &Value::Invalid }; 7];
 
         const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -179,11 +179,11 @@ impl From<Schedule> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SCHEDULE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/sdm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/sdm_profile.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -115,14 +115,14 @@ impl Default for SdmProfile {
 impl From<&Message> for SdmProfile {
     /// from creates new SdmProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [191, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -232,11 +232,11 @@ impl From<SdmProfile> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SDM_PROFILE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/segment_file.rs
+++ b/rustyfit/src/profile/mesgdef/segment_file.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -64,10 +64,10 @@ impl SegmentFile {
             file_uuid: String::new(),
             enabled: typedef::Bool(u8::MAX),
             user_profile_primary_key: u32::MAX,
-            leader_type: Vec::<typedef::SegmentLeaderboardType>::new(),
-            leader_group_primary_key: Vec::<u32>::new(),
-            leader_activity_id: Vec::<u32>::new(),
-            leader_activity_id_string: Vec::<String>::new(),
+            leader_type: Vec::new(),
+            leader_group_primary_key: Vec::new(),
+            leader_activity_id: Vec::new(),
+            leader_activity_id_string: Vec::new(),
             default_race_leader: u8::MAX,
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
@@ -84,14 +84,14 @@ impl Default for SegmentFile {
 impl From<&Message> for SegmentFile {
     /// from creates new SegmentFile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [3994, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -103,22 +103,20 @@ impl From<&Message> for SegmentFile {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            file_uuid: vals[1].as_string(),
+            file_uuid: vals[1].to_string(),
             enabled: typedef::Bool(vals[3].as_u8()),
             user_profile_primary_key: vals[4].as_u32(),
             leader_type: match &vals[7] {
                 Value::VecUint8(v) => {
                     let mut vs = Vec::with_capacity(v.len());
-                    for x in v {
-                        vs.push(typedef::SegmentLeaderboardType(*x))
-                    }
+                    vs.extend(v.iter().map(|&x| typedef::SegmentLeaderboardType(x)));
                     vs
                 }
                 _ => Vec::new(),
             },
-            leader_group_primary_key: vals[8].as_vec_u32(),
-            leader_activity_id: vals[9].as_vec_u32(),
-            leader_activity_id_string: vals[10].as_vec_string(),
+            leader_group_primary_key: vals[8].to_vec_u32(),
+            leader_activity_id: vals[9].to_vec_u32(),
+            leader_activity_id_string: vals[10].to_vec_string(),
             default_race_leader: vals[11].as_u8(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -174,7 +172,7 @@ impl From<SegmentFile> for Message {
             };
             len += 1;
         }
-        if m.leader_type != Vec::<typedef::SegmentLeaderboardType>::new() {
+        if !m.leader_type.is_empty() {
             arr[len] = Field {
                 num: 7,
                 profile_type: ProfileType::SEGMENT_LEADERBOARD_TYPE,
@@ -186,7 +184,7 @@ impl From<SegmentFile> for Message {
             };
             len += 1;
         }
-        if m.leader_group_primary_key != Vec::<u32>::new() {
+        if !m.leader_group_primary_key.is_empty() {
             arr[len] = Field {
                 num: 8,
                 profile_type: ProfileType::UINT32,
@@ -195,7 +193,7 @@ impl From<SegmentFile> for Message {
             };
             len += 1;
         }
-        if m.leader_activity_id != Vec::<u32>::new() {
+        if !m.leader_activity_id.is_empty() {
             arr[len] = Field {
                 num: 9,
                 profile_type: ProfileType::UINT32,
@@ -204,7 +202,7 @@ impl From<SegmentFile> for Message {
             };
             len += 1;
         }
-        if m.leader_activity_id_string != Vec::<String>::new() {
+        if !m.leader_activity_id_string.is_empty() {
             arr[len] = Field {
                 num: 10,
                 profile_type: ProfileType::STRING,
@@ -223,11 +221,11 @@ impl From<SegmentFile> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_FILE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/segment_id.rs
+++ b/rustyfit/src/profile/mesgdef/segment_id.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -85,14 +85,14 @@ impl Default for SegmentId {
 impl From<&Message> for SegmentId {
     /// from creates new SegmentId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 9] = [const { &Value::Invalid }; 9];
+        let mut vals = [const { &Value::Invalid }; 9];
 
         const KNOWN_NUMS: [u64; 4] = [511, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -103,8 +103,8 @@ impl From<&Message> for SegmentId {
         }
 
         Self {
-            name: vals[0].as_string(),
-            uuid: vals[1].as_string(),
+            name: vals[0].to_string(),
+            uuid: vals[1].to_string(),
             sport: typedef::Sport(vals[2].as_u8()),
             enabled: typedef::Bool(vals[3].as_u8()),
             user_profile_primary_key: vals[4].as_u32(),
@@ -212,11 +212,11 @@ impl From<SegmentId> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_ID,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -449,10 +449,10 @@ impl SegmentLap {
             avg_neg_vertical_speed: i16::MAX,
             max_pos_vertical_speed: i16::MAX,
             max_neg_vertical_speed: i16::MAX,
-            time_in_hr_zone: Vec::<u32>::new(),
-            time_in_speed_zone: Vec::<u32>::new(),
-            time_in_cadence_zone: Vec::<u32>::new(),
-            time_in_power_zone: Vec::<u32>::new(),
+            time_in_hr_zone: Vec::new(),
+            time_in_speed_zone: Vec::new(),
+            time_in_cadence_zone: Vec::new(),
+            time_in_power_zone: Vec::new(),
             repetition_num: u16::MAX,
             min_altitude: u16::MAX,
             min_heart_rate: u8::MAX,
@@ -475,14 +475,14 @@ impl SegmentLap {
             stand_count: u16::MAX,
             avg_left_pco: i8::MAX,
             avg_right_pco: i8::MAX,
-            avg_left_power_phase: Vec::<u8>::new(),
-            avg_left_power_phase_peak: Vec::<u8>::new(),
-            avg_right_power_phase: Vec::<u8>::new(),
-            avg_right_power_phase_peak: Vec::<u8>::new(),
-            avg_power_position: Vec::<u16>::new(),
-            max_power_position: Vec::<u16>::new(),
-            avg_cadence_position: Vec::<u8>::new(),
-            max_cadence_position: Vec::<u8>::new(),
+            avg_left_power_phase: Vec::new(),
+            avg_left_power_phase_peak: Vec::new(),
+            avg_right_power_phase: Vec::new(),
+            avg_right_power_phase_peak: Vec::new(),
+            avg_power_position: Vec::new(),
+            max_power_position: Vec::new(),
+            avg_cadence_position: Vec::new(),
+            max_cadence_position: Vec::new(),
             manufacturer: typedef::Manufacturer(u16::MAX),
             total_grit: f32::MAX,
             total_flow: f32::MAX,
@@ -864,7 +864,7 @@ impl SegmentLap {
 
     /// Returns `time_in_hr_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_hr_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_hr_zone == Vec::<u32>::new() {
+        if self.time_in_hr_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_hr_zone.len());
@@ -894,7 +894,7 @@ impl SegmentLap {
 
     /// Returns `time_in_speed_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_speed_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_speed_zone == Vec::<u32>::new() {
+        if self.time_in_speed_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_speed_zone.len());
@@ -924,7 +924,7 @@ impl SegmentLap {
 
     /// Returns `time_in_cadence_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_cadence_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_cadence_zone == Vec::<u32>::new() {
+        if self.time_in_cadence_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_cadence_zone.len());
@@ -954,7 +954,7 @@ impl SegmentLap {
 
     /// Returns `time_in_power_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_power_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_power_zone == Vec::<u32>::new() {
+        if self.time_in_power_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_power_zone.len());
@@ -1193,7 +1193,7 @@ impl SegmentLap {
 
     /// Returns `avg_left_power_phase` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_left_power_phase_scaled(&self) -> Vec<f64> {
-        if self.avg_left_power_phase == Vec::<u8>::new() {
+        if self.avg_left_power_phase.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase.len());
@@ -1223,7 +1223,7 @@ impl SegmentLap {
 
     /// Returns `avg_left_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_left_power_phase_peak_scaled(&self) -> Vec<f64> {
-        if self.avg_left_power_phase_peak == Vec::<u8>::new() {
+        if self.avg_left_power_phase_peak.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase_peak.len());
@@ -1253,7 +1253,7 @@ impl SegmentLap {
 
     /// Returns `avg_right_power_phase` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_right_power_phase_scaled(&self) -> Vec<f64> {
-        if self.avg_right_power_phase == Vec::<u8>::new() {
+        if self.avg_right_power_phase.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase.len());
@@ -1283,7 +1283,7 @@ impl SegmentLap {
 
     /// Returns `avg_right_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_right_power_phase_peak_scaled(&self) -> Vec<f64> {
-        if self.avg_right_power_phase_peak == Vec::<u8>::new() {
+        if self.avg_right_power_phase_peak.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase_peak.len());
@@ -1436,7 +1436,7 @@ impl Default for SegmentLap {
 impl From<&Message> for SegmentLap {
     /// from creates new SegmentLap struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 12];
 
         const KNOWN_NUMS: [u64; 4] = [18446744073709551615, 1056964607, 0, 6917529027641081856];
@@ -1444,7 +1444,7 @@ impl From<&Message> for SegmentLap {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -1489,7 +1489,7 @@ impl From<&Message> for SegmentLap {
             nec_long: vals[26].as_i32(),
             swc_lat: vals[27].as_i32(),
             swc_long: vals[28].as_i32(),
-            name: vals[29].as_string(),
+            name: vals[29].to_string(),
             normalized_power: vals[30].as_u16(),
             left_right_balance: typedef::LeftRightBalance100(vals[31].as_u16()),
             sub_sport: typedef::SubSport(vals[32].as_u8()),
@@ -1509,10 +1509,10 @@ impl From<&Message> for SegmentLap {
             avg_neg_vertical_speed: vals[46].as_i16(),
             max_pos_vertical_speed: vals[47].as_i16(),
             max_neg_vertical_speed: vals[48].as_i16(),
-            time_in_hr_zone: vals[49].as_vec_u32(),
-            time_in_speed_zone: vals[50].as_vec_u32(),
-            time_in_cadence_zone: vals[51].as_vec_u32(),
-            time_in_power_zone: vals[52].as_vec_u32(),
+            time_in_hr_zone: vals[49].to_vec_u32(),
+            time_in_speed_zone: vals[50].to_vec_u32(),
+            time_in_cadence_zone: vals[51].to_vec_u32(),
+            time_in_power_zone: vals[52].to_vec_u32(),
             repetition_num: vals[53].as_u16(),
             min_altitude: vals[54].as_u16(),
             min_heart_rate: vals[55].as_u8(),
@@ -1525,7 +1525,7 @@ impl From<&Message> for SegmentLap {
             avg_right_pedal_smoothness: vals[62].as_u8(),
             avg_combined_pedal_smoothness: vals[63].as_u8(),
             status: typedef::SegmentLapStatus(vals[64].as_u8()),
-            uuid: vals[65].as_string(),
+            uuid: vals[65].to_string(),
             avg_fractional_cadence: vals[66].as_u8(),
             max_fractional_cadence: vals[67].as_u8(),
             total_fractional_cycles: vals[68].as_u8(),
@@ -1535,14 +1535,14 @@ impl From<&Message> for SegmentLap {
             stand_count: vals[72].as_u16(),
             avg_left_pco: vals[73].as_i8(),
             avg_right_pco: vals[74].as_i8(),
-            avg_left_power_phase: vals[75].as_vec_u8(),
-            avg_left_power_phase_peak: vals[76].as_vec_u8(),
-            avg_right_power_phase: vals[77].as_vec_u8(),
-            avg_right_power_phase_peak: vals[78].as_vec_u8(),
-            avg_power_position: vals[79].as_vec_u16(),
-            max_power_position: vals[80].as_vec_u16(),
-            avg_cadence_position: vals[81].as_vec_u8(),
-            max_cadence_position: vals[82].as_vec_u8(),
+            avg_left_power_phase: vals[75].to_vec_u8(),
+            avg_left_power_phase_peak: vals[76].to_vec_u8(),
+            avg_right_power_phase: vals[77].to_vec_u8(),
+            avg_right_power_phase_peak: vals[78].to_vec_u8(),
+            avg_power_position: vals[79].to_vec_u16(),
+            max_power_position: vals[80].to_vec_u16(),
+            avg_cadence_position: vals[81].to_vec_u8(),
+            max_cadence_position: vals[82].to_vec_u8(),
             manufacturer: typedef::Manufacturer(vals[83].as_u16()),
             total_grit: vals[84].as_f32(),
             total_flow: vals[85].as_f32(),
@@ -2032,7 +2032,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.time_in_hr_zone != Vec::<u32>::new() {
+        if !m.time_in_hr_zone.is_empty() {
             arr[len] = Field {
                 num: 49,
                 profile_type: ProfileType::UINT32,
@@ -2041,7 +2041,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.time_in_speed_zone != Vec::<u32>::new() {
+        if !m.time_in_speed_zone.is_empty() {
             arr[len] = Field {
                 num: 50,
                 profile_type: ProfileType::UINT32,
@@ -2050,7 +2050,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.time_in_cadence_zone != Vec::<u32>::new() {
+        if !m.time_in_cadence_zone.is_empty() {
             arr[len] = Field {
                 num: 51,
                 profile_type: ProfileType::UINT32,
@@ -2059,7 +2059,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.time_in_power_zone != Vec::<u32>::new() {
+        if !m.time_in_power_zone.is_empty() {
             arr[len] = Field {
                 num: 52,
                 profile_type: ProfileType::UINT32,
@@ -2266,7 +2266,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.avg_left_power_phase != Vec::<u8>::new() {
+        if !m.avg_left_power_phase.is_empty() {
             arr[len] = Field {
                 num: 75,
                 profile_type: ProfileType::UINT8,
@@ -2275,7 +2275,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.avg_left_power_phase_peak != Vec::<u8>::new() {
+        if !m.avg_left_power_phase_peak.is_empty() {
             arr[len] = Field {
                 num: 76,
                 profile_type: ProfileType::UINT8,
@@ -2284,7 +2284,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.avg_right_power_phase != Vec::<u8>::new() {
+        if !m.avg_right_power_phase.is_empty() {
             arr[len] = Field {
                 num: 77,
                 profile_type: ProfileType::UINT8,
@@ -2293,7 +2293,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.avg_right_power_phase_peak != Vec::<u8>::new() {
+        if !m.avg_right_power_phase_peak.is_empty() {
             arr[len] = Field {
                 num: 78,
                 profile_type: ProfileType::UINT8,
@@ -2302,7 +2302,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.avg_power_position != Vec::<u16>::new() {
+        if !m.avg_power_position.is_empty() {
             arr[len] = Field {
                 num: 79,
                 profile_type: ProfileType::UINT16,
@@ -2311,7 +2311,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.max_power_position != Vec::<u16>::new() {
+        if !m.max_power_position.is_empty() {
             arr[len] = Field {
                 num: 80,
                 profile_type: ProfileType::UINT16,
@@ -2320,7 +2320,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.avg_cadence_position != Vec::<u8>::new() {
+        if !m.avg_cadence_position.is_empty() {
             arr[len] = Field {
                 num: 81,
                 profile_type: ProfileType::UINT8,
@@ -2329,7 +2329,7 @@ impl From<SegmentLap> for Message {
             };
             len += 1;
         }
-        if m.max_cadence_position != Vec::<u8>::new() {
+        if !m.max_cadence_position.is_empty() {
             arr[len] = Field {
                 num: 82,
                 profile_type: ProfileType::UINT8,
@@ -2429,11 +2429,11 @@ impl From<SegmentLap> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_LAP,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
+++ b/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -93,14 +93,14 @@ impl Default for SegmentLeaderboardEntry {
 impl From<&Message> for SegmentLeaderboardEntry {
     /// from creates new SegmentLeaderboardEntry struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -112,12 +112,12 @@ impl From<&Message> for SegmentLeaderboardEntry {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            name: vals[0].as_string(),
+            name: vals[0].to_string(),
             r#type: typedef::SegmentLeaderboardType(vals[1].as_u8()),
             group_primary_key: vals[2].as_u32(),
             activity_id: vals[3].as_u32(),
             segment_time: vals[4].as_u32(),
-            activity_id_string: vals[5].as_string(),
+            activity_id_string: vals[5].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -200,11 +200,11 @@ impl From<SegmentLeaderboardEntry> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_LEADERBOARD_ENTRY,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/segment_point.rs
+++ b/rustyfit/src/profile/mesgdef/segment_point.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -65,7 +65,7 @@ impl SegmentPoint {
             position_long: i32::MAX,
             distance: u32::MAX,
             altitude: u16::MAX,
-            leader_time: Vec::<u32>::new(),
+            leader_time: Vec::new(),
             enhanced_altitude: u32::MAX,
             state: [0u8; 1],
             unknown_fields: Vec::new(),
@@ -123,7 +123,7 @@ impl SegmentPoint {
 
     /// Returns `leader_time` in its scaled value. It returns invalid f64 when value is valid.
     pub fn leader_time_scaled(&self) -> Vec<f64> {
-        if self.leader_time == Vec::<u32>::new() {
+        if self.leader_time.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.leader_time.len());
@@ -200,7 +200,7 @@ impl Default for SegmentPoint {
 impl From<&Message> for SegmentPoint {
     /// from creates new SegmentPoint struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 1];
 
         const KNOWN_NUMS: [u64; 4] = [126, 0, 0, 4611686018427387904];
@@ -208,7 +208,7 @@ impl From<&Message> for SegmentPoint {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -227,7 +227,7 @@ impl From<&Message> for SegmentPoint {
             position_long: vals[2].as_i32(),
             distance: vals[3].as_u32(),
             altitude: vals[4].as_u16(),
-            leader_time: vals[5].as_vec_u32(),
+            leader_time: vals[5].to_vec_u32(),
             enhanced_altitude: vals[6].as_u32(),
             state,
             unknown_fields,
@@ -294,7 +294,7 @@ impl From<SegmentPoint> for Message {
             };
             len += 1;
         }
-        if m.leader_time != Vec::<u32>::new() {
+        if !m.leader_time.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
@@ -313,11 +313,11 @@ impl From<SegmentPoint> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_POINT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -714,10 +714,10 @@ impl Session {
             max_pos_vertical_speed: i16::MAX,
             max_neg_vertical_speed: i16::MAX,
             min_heart_rate: u8::MAX,
-            time_in_hr_zone: Vec::<u32>::new(),
-            time_in_speed_zone: Vec::<u32>::new(),
-            time_in_cadence_zone: Vec::<u32>::new(),
-            time_in_power_zone: Vec::<u32>::new(),
+            time_in_hr_zone: Vec::new(),
+            time_in_speed_zone: Vec::new(),
+            time_in_cadence_zone: Vec::new(),
+            time_in_power_zone: Vec::new(),
             avg_lap_time: u32::MAX,
             best_lap_index: u16::MAX,
             min_altitude: u16::MAX,
@@ -725,8 +725,8 @@ impl Session {
             player_score: u16::MAX,
             opponent_score: u16::MAX,
             opponent_name: String::new(),
-            stroke_count: Vec::<u16>::new(),
-            zone_count: Vec::<u16>::new(),
+            stroke_count: Vec::new(),
+            zone_count: Vec::new(),
             max_ball_speed: u16::MAX,
             avg_ball_speed: u16::MAX,
             avg_vertical_oscillation: u16::MAX,
@@ -735,12 +735,12 @@ impl Session {
             avg_fractional_cadence: u8::MAX,
             max_fractional_cadence: u8::MAX,
             total_fractional_cycles: u8::MAX,
-            avg_total_hemoglobin_conc: Vec::<u16>::new(),
-            min_total_hemoglobin_conc: Vec::<u16>::new(),
-            max_total_hemoglobin_conc: Vec::<u16>::new(),
-            avg_saturated_hemoglobin_percent: Vec::<u16>::new(),
-            min_saturated_hemoglobin_percent: Vec::<u16>::new(),
-            max_saturated_hemoglobin_percent: Vec::<u16>::new(),
+            avg_total_hemoglobin_conc: Vec::new(),
+            min_total_hemoglobin_conc: Vec::new(),
+            max_total_hemoglobin_conc: Vec::new(),
+            avg_saturated_hemoglobin_percent: Vec::new(),
+            min_saturated_hemoglobin_percent: Vec::new(),
+            max_saturated_hemoglobin_percent: Vec::new(),
             avg_left_torque_effectiveness: u8::MAX,
             avg_right_torque_effectiveness: u8::MAX,
             avg_left_pedal_smoothness: u8::MAX,
@@ -752,14 +752,14 @@ impl Session {
             stand_count: u16::MAX,
             avg_left_pco: i8::MAX,
             avg_right_pco: i8::MAX,
-            avg_left_power_phase: Vec::<u8>::new(),
-            avg_left_power_phase_peak: Vec::<u8>::new(),
-            avg_right_power_phase: Vec::<u8>::new(),
-            avg_right_power_phase_peak: Vec::<u8>::new(),
-            avg_power_position: Vec::<u16>::new(),
-            max_power_position: Vec::<u16>::new(),
-            avg_cadence_position: Vec::<u8>::new(),
-            max_cadence_position: Vec::<u8>::new(),
+            avg_left_power_phase: Vec::new(),
+            avg_left_power_phase_peak: Vec::new(),
+            avg_right_power_phase: Vec::new(),
+            avg_right_power_phase_peak: Vec::new(),
+            avg_power_position: Vec::new(),
+            max_power_position: Vec::new(),
+            avg_cadence_position: Vec::new(),
+            max_cadence_position: Vec::new(),
             enhanced_avg_speed: u32::MAX,
             enhanced_max_speed: u32::MAX,
             enhanced_avg_altitude: u32::MAX,
@@ -1292,7 +1292,7 @@ impl Session {
 
     /// Returns `time_in_hr_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_hr_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_hr_zone == Vec::<u32>::new() {
+        if self.time_in_hr_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_hr_zone.len());
@@ -1322,7 +1322,7 @@ impl Session {
 
     /// Returns `time_in_speed_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_speed_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_speed_zone == Vec::<u32>::new() {
+        if self.time_in_speed_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_speed_zone.len());
@@ -1352,7 +1352,7 @@ impl Session {
 
     /// Returns `time_in_cadence_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_cadence_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_cadence_zone == Vec::<u32>::new() {
+        if self.time_in_cadence_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_cadence_zone.len());
@@ -1382,7 +1382,7 @@ impl Session {
 
     /// Returns `time_in_power_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_power_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_power_zone == Vec::<u32>::new() {
+        if self.time_in_power_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_power_zone.len());
@@ -1621,7 +1621,7 @@ impl Session {
 
     /// Returns `avg_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
-        if self.avg_total_hemoglobin_conc == Vec::<u16>::new() {
+        if self.avg_total_hemoglobin_conc.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_total_hemoglobin_conc.len());
@@ -1651,7 +1651,7 @@ impl Session {
 
     /// Returns `min_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
     pub fn min_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
-        if self.min_total_hemoglobin_conc == Vec::<u16>::new() {
+        if self.min_total_hemoglobin_conc.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.min_total_hemoglobin_conc.len());
@@ -1681,7 +1681,7 @@ impl Session {
 
     /// Returns `max_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
     pub fn max_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
-        if self.max_total_hemoglobin_conc == Vec::<u16>::new() {
+        if self.max_total_hemoglobin_conc.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.max_total_hemoglobin_conc.len());
@@ -1711,7 +1711,7 @@ impl Session {
 
     /// Returns `avg_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
-        if self.avg_saturated_hemoglobin_percent == Vec::<u16>::new() {
+        if self.avg_saturated_hemoglobin_percent.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_saturated_hemoglobin_percent.len());
@@ -1741,7 +1741,7 @@ impl Session {
 
     /// Returns `min_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
     pub fn min_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
-        if self.min_saturated_hemoglobin_percent == Vec::<u16>::new() {
+        if self.min_saturated_hemoglobin_percent.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.min_saturated_hemoglobin_percent.len());
@@ -1771,7 +1771,7 @@ impl Session {
 
     /// Returns `max_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
     pub fn max_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
-        if self.max_saturated_hemoglobin_percent == Vec::<u16>::new() {
+        if self.max_saturated_hemoglobin_percent.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.max_saturated_hemoglobin_percent.len());
@@ -1915,7 +1915,7 @@ impl Session {
 
     /// Returns `avg_left_power_phase` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_left_power_phase_scaled(&self) -> Vec<f64> {
-        if self.avg_left_power_phase == Vec::<u8>::new() {
+        if self.avg_left_power_phase.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase.len());
@@ -1945,7 +1945,7 @@ impl Session {
 
     /// Returns `avg_left_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_left_power_phase_peak_scaled(&self) -> Vec<f64> {
-        if self.avg_left_power_phase_peak == Vec::<u8>::new() {
+        if self.avg_left_power_phase_peak.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase_peak.len());
@@ -1975,7 +1975,7 @@ impl Session {
 
     /// Returns `avg_right_power_phase` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_right_power_phase_scaled(&self) -> Vec<f64> {
-        if self.avg_right_power_phase == Vec::<u8>::new() {
+        if self.avg_right_power_phase.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase.len());
@@ -2005,7 +2005,7 @@ impl Session {
 
     /// Returns `avg_right_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
     pub fn avg_right_power_phase_peak_scaled(&self) -> Vec<f64> {
-        if self.avg_right_power_phase_peak == Vec::<u8>::new() {
+        if self.avg_right_power_phase_peak.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase_peak.len());
@@ -2481,7 +2481,7 @@ impl Default for Session {
 impl From<&Message> for Session {
     /// from creates new Session struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
         let mut state = [0u8; 23];
 
         const KNOWN_NUMS: [u64; 4] = [
@@ -2494,7 +2494,7 @@ impl From<&Message> for Session {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -2573,19 +2573,19 @@ impl From<&Message> for Session {
             max_pos_vertical_speed: vals[62].as_i16(),
             max_neg_vertical_speed: vals[63].as_i16(),
             min_heart_rate: vals[64].as_u8(),
-            time_in_hr_zone: vals[65].as_vec_u32(),
-            time_in_speed_zone: vals[66].as_vec_u32(),
-            time_in_cadence_zone: vals[67].as_vec_u32(),
-            time_in_power_zone: vals[68].as_vec_u32(),
+            time_in_hr_zone: vals[65].to_vec_u32(),
+            time_in_speed_zone: vals[66].to_vec_u32(),
+            time_in_cadence_zone: vals[67].to_vec_u32(),
+            time_in_power_zone: vals[68].to_vec_u32(),
             avg_lap_time: vals[69].as_u32(),
             best_lap_index: vals[70].as_u16(),
             min_altitude: vals[71].as_u16(),
             active_time: vals[78].as_u32(),
             player_score: vals[82].as_u16(),
             opponent_score: vals[83].as_u16(),
-            opponent_name: vals[84].as_string(),
-            stroke_count: vals[85].as_vec_u16(),
-            zone_count: vals[86].as_vec_u16(),
+            opponent_name: vals[84].to_string(),
+            stroke_count: vals[85].to_vec_u16(),
+            zone_count: vals[86].to_vec_u16(),
             max_ball_speed: vals[87].as_u16(),
             avg_ball_speed: vals[88].as_u16(),
             avg_vertical_oscillation: vals[89].as_u16(),
@@ -2594,31 +2594,31 @@ impl From<&Message> for Session {
             avg_fractional_cadence: vals[92].as_u8(),
             max_fractional_cadence: vals[93].as_u8(),
             total_fractional_cycles: vals[94].as_u8(),
-            avg_total_hemoglobin_conc: vals[95].as_vec_u16(),
-            min_total_hemoglobin_conc: vals[96].as_vec_u16(),
-            max_total_hemoglobin_conc: vals[97].as_vec_u16(),
-            avg_saturated_hemoglobin_percent: vals[98].as_vec_u16(),
-            min_saturated_hemoglobin_percent: vals[99].as_vec_u16(),
-            max_saturated_hemoglobin_percent: vals[100].as_vec_u16(),
+            avg_total_hemoglobin_conc: vals[95].to_vec_u16(),
+            min_total_hemoglobin_conc: vals[96].to_vec_u16(),
+            max_total_hemoglobin_conc: vals[97].to_vec_u16(),
+            avg_saturated_hemoglobin_percent: vals[98].to_vec_u16(),
+            min_saturated_hemoglobin_percent: vals[99].to_vec_u16(),
+            max_saturated_hemoglobin_percent: vals[100].to_vec_u16(),
             avg_left_torque_effectiveness: vals[101].as_u8(),
             avg_right_torque_effectiveness: vals[102].as_u8(),
             avg_left_pedal_smoothness: vals[103].as_u8(),
             avg_right_pedal_smoothness: vals[104].as_u8(),
             avg_combined_pedal_smoothness: vals[105].as_u8(),
-            sport_profile_name: vals[110].as_string(),
+            sport_profile_name: vals[110].to_string(),
             sport_index: vals[111].as_u8(),
             time_standing: vals[112].as_u32(),
             stand_count: vals[113].as_u16(),
             avg_left_pco: vals[114].as_i8(),
             avg_right_pco: vals[115].as_i8(),
-            avg_left_power_phase: vals[116].as_vec_u8(),
-            avg_left_power_phase_peak: vals[117].as_vec_u8(),
-            avg_right_power_phase: vals[118].as_vec_u8(),
-            avg_right_power_phase_peak: vals[119].as_vec_u8(),
-            avg_power_position: vals[120].as_vec_u16(),
-            max_power_position: vals[121].as_vec_u16(),
-            avg_cadence_position: vals[122].as_vec_u8(),
-            max_cadence_position: vals[123].as_vec_u8(),
+            avg_left_power_phase: vals[116].to_vec_u8(),
+            avg_left_power_phase_peak: vals[117].to_vec_u8(),
+            avg_right_power_phase: vals[118].to_vec_u8(),
+            avg_right_power_phase_peak: vals[119].to_vec_u8(),
+            avg_power_position: vals[120].to_vec_u16(),
+            max_power_position: vals[121].to_vec_u16(),
+            avg_cadence_position: vals[122].to_vec_u8(),
+            max_cadence_position: vals[123].to_vec_u8(),
             enhanced_avg_speed: vals[124].as_u32(),
             enhanced_max_speed: vals[125].as_u32(),
             enhanced_avg_altitude: vals[126].as_u32(),
@@ -3271,7 +3271,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.time_in_hr_zone != Vec::<u32>::new() {
+        if !m.time_in_hr_zone.is_empty() {
             arr[len] = Field {
                 num: 65,
                 profile_type: ProfileType::UINT32,
@@ -3280,7 +3280,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.time_in_speed_zone != Vec::<u32>::new() {
+        if !m.time_in_speed_zone.is_empty() {
             arr[len] = Field {
                 num: 66,
                 profile_type: ProfileType::UINT32,
@@ -3289,7 +3289,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.time_in_cadence_zone != Vec::<u32>::new() {
+        if !m.time_in_cadence_zone.is_empty() {
             arr[len] = Field {
                 num: 67,
                 profile_type: ProfileType::UINT32,
@@ -3298,7 +3298,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.time_in_power_zone != Vec::<u32>::new() {
+        if !m.time_in_power_zone.is_empty() {
             arr[len] = Field {
                 num: 68,
                 profile_type: ProfileType::UINT32,
@@ -3370,7 +3370,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.stroke_count != Vec::<u16>::new() {
+        if !m.stroke_count.is_empty() {
             arr[len] = Field {
                 num: 85,
                 profile_type: ProfileType::UINT16,
@@ -3379,7 +3379,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.zone_count != Vec::<u16>::new() {
+        if !m.zone_count.is_empty() {
             arr[len] = Field {
                 num: 86,
                 profile_type: ProfileType::UINT16,
@@ -3460,7 +3460,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.avg_total_hemoglobin_conc != Vec::<u16>::new() {
+        if !m.avg_total_hemoglobin_conc.is_empty() {
             arr[len] = Field {
                 num: 95,
                 profile_type: ProfileType::UINT16,
@@ -3469,7 +3469,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.min_total_hemoglobin_conc != Vec::<u16>::new() {
+        if !m.min_total_hemoglobin_conc.is_empty() {
             arr[len] = Field {
                 num: 96,
                 profile_type: ProfileType::UINT16,
@@ -3478,7 +3478,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.max_total_hemoglobin_conc != Vec::<u16>::new() {
+        if !m.max_total_hemoglobin_conc.is_empty() {
             arr[len] = Field {
                 num: 97,
                 profile_type: ProfileType::UINT16,
@@ -3487,7 +3487,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.avg_saturated_hemoglobin_percent != Vec::<u16>::new() {
+        if !m.avg_saturated_hemoglobin_percent.is_empty() {
             arr[len] = Field {
                 num: 98,
                 profile_type: ProfileType::UINT16,
@@ -3496,7 +3496,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.min_saturated_hemoglobin_percent != Vec::<u16>::new() {
+        if !m.min_saturated_hemoglobin_percent.is_empty() {
             arr[len] = Field {
                 num: 99,
                 profile_type: ProfileType::UINT16,
@@ -3505,7 +3505,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.max_saturated_hemoglobin_percent != Vec::<u16>::new() {
+        if !m.max_saturated_hemoglobin_percent.is_empty() {
             arr[len] = Field {
                 num: 100,
                 profile_type: ProfileType::UINT16,
@@ -3613,7 +3613,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.avg_left_power_phase != Vec::<u8>::new() {
+        if !m.avg_left_power_phase.is_empty() {
             arr[len] = Field {
                 num: 116,
                 profile_type: ProfileType::UINT8,
@@ -3622,7 +3622,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.avg_left_power_phase_peak != Vec::<u8>::new() {
+        if !m.avg_left_power_phase_peak.is_empty() {
             arr[len] = Field {
                 num: 117,
                 profile_type: ProfileType::UINT8,
@@ -3631,7 +3631,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.avg_right_power_phase != Vec::<u8>::new() {
+        if !m.avg_right_power_phase.is_empty() {
             arr[len] = Field {
                 num: 118,
                 profile_type: ProfileType::UINT8,
@@ -3640,7 +3640,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.avg_right_power_phase_peak != Vec::<u8>::new() {
+        if !m.avg_right_power_phase_peak.is_empty() {
             arr[len] = Field {
                 num: 119,
                 profile_type: ProfileType::UINT8,
@@ -3649,7 +3649,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.avg_power_position != Vec::<u16>::new() {
+        if !m.avg_power_position.is_empty() {
             arr[len] = Field {
                 num: 120,
                 profile_type: ProfileType::UINT16,
@@ -3658,7 +3658,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.max_power_position != Vec::<u16>::new() {
+        if !m.max_power_position.is_empty() {
             arr[len] = Field {
                 num: 121,
                 profile_type: ProfileType::UINT16,
@@ -3667,7 +3667,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.avg_cadence_position != Vec::<u8>::new() {
+        if !m.avg_cadence_position.is_empty() {
             arr[len] = Field {
                 num: 122,
                 profile_type: ProfileType::UINT8,
@@ -3676,7 +3676,7 @@ impl From<Session> for Message {
             };
             len += 1;
         }
-        if m.max_cadence_position != Vec::<u8>::new() {
+        if !m.max_cadence_position.is_empty() {
             arr[len] = Field {
                 num: 123,
                 profile_type: ProfileType::UINT8,
@@ -4109,11 +4109,11 @@ impl From<Session> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SESSION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/set.rs
+++ b/rustyfit/src/profile/mesgdef/set.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -69,8 +69,8 @@ impl Set {
             weight: u16::MAX,
             set_type: typedef::SetType(u8::MAX),
             start_time: typedef::DateTime(u32::MAX),
-            category: Vec::<typedef::ExerciseCategory>::new(),
-            category_subtype: Vec::<u16>::new(),
+            category: Vec::new(),
+            category_subtype: Vec::new(),
             weight_display_unit: typedef::FitBaseUnit(u16::MAX),
             message_index: typedef::MessageIndex(u16::MAX),
             wkt_step_index: typedef::MessageIndex(u16::MAX),
@@ -127,14 +127,14 @@ impl Default for Set {
 impl From<&Message> for Set {
     /// from creates new Set struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [4089, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -154,14 +154,12 @@ impl From<&Message> for Set {
             category: match &vals[7] {
                 Value::VecUint16(v) => {
                     let mut vs = Vec::with_capacity(v.len());
-                    for x in v {
-                        vs.push(typedef::ExerciseCategory(*x))
-                    }
+                    vs.extend(v.iter().map(|&x| typedef::ExerciseCategory(x)));
                     vs
                 }
                 _ => Vec::new(),
             },
-            category_subtype: vals[8].as_vec_u16(),
+            category_subtype: vals[8].to_vec_u16(),
             weight_display_unit: typedef::FitBaseUnit(vals[9].as_u16()),
             message_index: typedef::MessageIndex(vals[10].as_u16()),
             wkt_step_index: typedef::MessageIndex(vals[11].as_u16()),
@@ -237,7 +235,7 @@ impl From<Set> for Message {
             };
             len += 1;
         }
-        if m.category != Vec::<typedef::ExerciseCategory>::new() {
+        if !m.category.is_empty() {
             arr[len] = Field {
                 num: 7,
                 profile_type: ProfileType::EXERCISE_CATEGORY,
@@ -249,7 +247,7 @@ impl From<Set> for Message {
             };
             len += 1;
         }
-        if m.category_subtype != Vec::<u16>::new() {
+        if !m.category_subtype.is_empty() {
             arr[len] = Field {
                 num: 8,
                 profile_type: ProfileType::UINT16,
@@ -286,11 +284,11 @@ impl From<Set> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SET,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
+++ b/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -62,14 +62,14 @@ impl Default for SkinTempOvernight {
 impl From<&Message> for SkinTempOvernight {
     /// from creates new SkinTempOvernight struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [23, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -149,11 +149,11 @@ impl From<SkinTempOvernight> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SKIN_TEMP_OVERNIGHT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/slave_device.rs
+++ b/rustyfit/src/profile/mesgdef/slave_device.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -47,14 +47,14 @@ impl Default for SlaveDevice {
 impl From<&Message> for SlaveDevice {
     /// from creates new SlaveDevice struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 2] = [const { &Value::Invalid }; 2];
+        let mut vals = [const { &Value::Invalid }; 2];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -104,11 +104,11 @@ impl From<SlaveDevice> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SLAVE_DEVICE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/sleep_assessment.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_assessment.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -128,14 +128,14 @@ impl Default for SleepAssessment {
 impl From<&Message> for SleepAssessment {
     /// from creates new SleepAssessment struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 16] = [const { &Value::Invalid }; 16];
+        let mut vals = [const { &Value::Invalid }; 16];
 
         const KNOWN_NUMS: [u64; 4] = [53247, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -305,11 +305,11 @@ impl From<SleepAssessment> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SLEEP_ASSESSMENT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -47,14 +47,14 @@ impl Default for SleepDisruptionOvernightSeverity {
 impl From<&Message> for SleepDisruptionOvernightSeverity {
     /// from creates new SleepDisruptionOvernightSeverity struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -104,11 +104,11 @@ impl From<SleepDisruptionOvernightSeverity> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SLEEP_DISRUPTION_OVERNIGHT_SEVERITY,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -51,14 +51,14 @@ impl Default for SleepDisruptionSeverityPeriod {
 impl From<&Message> for SleepDisruptionSeverityPeriod {
     /// from creates new SleepDisruptionSeverityPeriod struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -118,11 +118,11 @@ impl From<SleepDisruptionSeverityPeriod> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SLEEP_DISRUPTION_SEVERITY_PERIOD,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/sleep_level.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_level.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -48,14 +48,14 @@ impl Default for SleepLevel {
 impl From<&Message> for SleepLevel {
     /// from creates new SleepLevel struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -105,11 +105,11 @@ impl From<SleepLevel> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SLEEP_LEVEL,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/software.rs
+++ b/rustyfit/src/profile/mesgdef/software.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -72,14 +72,14 @@ impl Default for Software {
 impl From<&Message> for Software {
     /// from creates new Software struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [40, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -92,7 +92,7 @@ impl From<&Message> for Software {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             version: vals[3].as_u16(),
-            part_number: vals[5].as_string(),
+            part_number: vals[5].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -139,11 +139,11 @@ impl From<Software> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SOFTWARE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/speed_zone.rs
+++ b/rustyfit/src/profile/mesgdef/speed_zone.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -72,14 +72,14 @@ impl Default for SpeedZone {
 impl From<&Message> for SpeedZone {
     /// from creates new SpeedZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -92,7 +92,7 @@ impl From<&Message> for SpeedZone {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             high_value: vals[0].as_u16(),
-            name: vals[1].as_string(),
+            name: vals[1].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -139,11 +139,11 @@ impl From<SpeedZone> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SPEED_ZONE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/split.rs
+++ b/rustyfit/src/profile/mesgdef/split.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -327,14 +327,14 @@ impl Default for Split {
 impl From<&Message> for Split {
     /// from creates new Split struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [534798879, 70368744195072, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -564,11 +564,11 @@ impl From<Split> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SPLIT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/split_summary.rs
+++ b/rustyfit/src/profile/mesgdef/split_summary.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -244,14 +244,14 @@ impl Default for SplitSummary {
 impl From<&Message> for SplitSummary {
     /// from creates new SplitSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [16377, 8194, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -431,11 +431,11 @@ impl From<SplitSummary> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SPLIT_SUMMARY,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/spo2_data.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -58,14 +58,14 @@ impl Default for Spo2Data {
 impl From<&Message> for Spo2Data {
     /// from creates new Spo2Data struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -135,11 +135,11 @@ impl From<Spo2Data> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SPO2_DATA,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/sport.rs
+++ b/rustyfit/src/profile/mesgdef/sport.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -52,14 +52,14 @@ impl Default for Sport {
 impl From<&Message> for Sport {
     /// from creates new Sport struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 4] = [const { &Value::Invalid }; 4];
+        let mut vals = [const { &Value::Invalid }; 4];
 
         const KNOWN_NUMS: [u64; 4] = [11, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -72,7 +72,7 @@ impl From<&Message> for Sport {
         Self {
             sport: typedef::Sport(vals[0].as_u8()),
             sub_sport: typedef::SubSport(vals[1].as_u8()),
-            name: vals[3].as_string(),
+            name: vals[3].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -119,11 +119,11 @@ impl From<Sport> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::SPORT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/stress_level.rs
+++ b/rustyfit/src/profile/mesgdef/stress_level.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -48,14 +48,14 @@ impl Default for StressLevel {
 impl From<&Message> for StressLevel {
     /// from creates new StressLevel struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 2] = [const { &Value::Invalid }; 2];
+        let mut vals = [const { &Value::Invalid }; 2];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -105,11 +105,11 @@ impl From<StressLevel> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::STRESS_LEVEL,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/tank_summary.rs
+++ b/rustyfit/src/profile/mesgdef/tank_summary.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -121,14 +121,14 @@ impl Default for TankSummary {
 impl From<&Message> for TankSummary {
     /// from creates new TankSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -208,11 +208,11 @@ impl From<TankSummary> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::TANK_SUMMARY,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/tank_update.rs
+++ b/rustyfit/src/profile/mesgdef/tank_update.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -73,14 +73,14 @@ impl Default for TankUpdate {
 impl From<&Message> for TankUpdate {
     /// from creates new TankUpdate struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -140,11 +140,11 @@ impl From<TankUpdate> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::TANK_UPDATE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -99,14 +99,14 @@ impl Default for ThreeDSensorCalibration {
 impl From<&Message> for ThreeDSensorCalibration {
     /// from creates new ThreeDSensorCalibration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -224,11 +224,11 @@ impl From<ThreeDSensorCalibration> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::THREE_D_SENSOR_CALIBRATION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/time_in_zone.rs
+++ b/rustyfit/src/profile/mesgdef/time_in_zone.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -87,14 +87,14 @@ impl TimeInZone {
             timestamp: typedef::DateTime(u32::MAX),
             reference_mesg: typedef::MesgNum(u16::MAX),
             reference_index: typedef::MessageIndex(u16::MAX),
-            time_in_hr_zone: Vec::<u32>::new(),
-            time_in_speed_zone: Vec::<u32>::new(),
-            time_in_cadence_zone: Vec::<u32>::new(),
-            time_in_power_zone: Vec::<u32>::new(),
-            hr_zone_high_boundary: Vec::<u8>::new(),
-            speed_zone_high_boundary: Vec::<u16>::new(),
-            cadence_zone_high_boundary: Vec::<u8>::new(),
-            power_zone_high_boundary: Vec::<u16>::new(),
+            time_in_hr_zone: Vec::new(),
+            time_in_speed_zone: Vec::new(),
+            time_in_cadence_zone: Vec::new(),
+            time_in_power_zone: Vec::new(),
+            hr_zone_high_boundary: Vec::new(),
+            speed_zone_high_boundary: Vec::new(),
+            cadence_zone_high_boundary: Vec::new(),
+            power_zone_high_boundary: Vec::new(),
             hr_calc_type: typedef::HrZoneCalc(u8::MAX),
             max_heart_rate: u8::MAX,
             resting_heart_rate: u8::MAX,
@@ -108,7 +108,7 @@ impl TimeInZone {
 
     /// Returns `time_in_hr_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_hr_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_hr_zone == Vec::<u32>::new() {
+        if self.time_in_hr_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_hr_zone.len());
@@ -138,7 +138,7 @@ impl TimeInZone {
 
     /// Returns `time_in_speed_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_speed_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_speed_zone == Vec::<u32>::new() {
+        if self.time_in_speed_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_speed_zone.len());
@@ -168,7 +168,7 @@ impl TimeInZone {
 
     /// Returns `time_in_cadence_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_cadence_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_cadence_zone == Vec::<u32>::new() {
+        if self.time_in_cadence_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_cadence_zone.len());
@@ -198,7 +198,7 @@ impl TimeInZone {
 
     /// Returns `time_in_power_zone` in its scaled value. It returns invalid f64 when value is valid.
     pub fn time_in_power_zone_scaled(&self) -> Vec<f64> {
-        if self.time_in_power_zone == Vec::<u32>::new() {
+        if self.time_in_power_zone.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.time_in_power_zone.len());
@@ -228,7 +228,7 @@ impl TimeInZone {
 
     /// Returns `speed_zone_high_boundary` in its scaled value. It returns invalid f64 when value is valid.
     pub fn speed_zone_high_boundary_scaled(&self) -> Vec<f64> {
-        if self.speed_zone_high_boundary == Vec::<u16>::new() {
+        if self.speed_zone_high_boundary.is_empty() {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(self.speed_zone_high_boundary.len());
@@ -266,14 +266,14 @@ impl Default for TimeInZone {
 impl From<&Message> for TimeInZone {
     /// from creates new TimeInZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [65535, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -287,14 +287,14 @@ impl From<&Message> for TimeInZone {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             reference_mesg: typedef::MesgNum(vals[0].as_u16()),
             reference_index: typedef::MessageIndex(vals[1].as_u16()),
-            time_in_hr_zone: vals[2].as_vec_u32(),
-            time_in_speed_zone: vals[3].as_vec_u32(),
-            time_in_cadence_zone: vals[4].as_vec_u32(),
-            time_in_power_zone: vals[5].as_vec_u32(),
-            hr_zone_high_boundary: vals[6].as_vec_u8(),
-            speed_zone_high_boundary: vals[7].as_vec_u16(),
-            cadence_zone_high_boundary: vals[8].as_vec_u8(),
-            power_zone_high_boundary: vals[9].as_vec_u16(),
+            time_in_hr_zone: vals[2].to_vec_u32(),
+            time_in_speed_zone: vals[3].to_vec_u32(),
+            time_in_cadence_zone: vals[4].to_vec_u32(),
+            time_in_power_zone: vals[5].to_vec_u32(),
+            hr_zone_high_boundary: vals[6].to_vec_u8(),
+            speed_zone_high_boundary: vals[7].to_vec_u16(),
+            cadence_zone_high_boundary: vals[8].to_vec_u8(),
+            power_zone_high_boundary: vals[9].to_vec_u16(),
             hr_calc_type: typedef::HrZoneCalc(vals[10].as_u8()),
             max_heart_rate: vals[11].as_u8(),
             resting_heart_rate: vals[12].as_u8(),
@@ -346,7 +346,7 @@ impl From<TimeInZone> for Message {
             };
             len += 1;
         }
-        if m.time_in_hr_zone != Vec::<u32>::new() {
+        if !m.time_in_hr_zone.is_empty() {
             arr[len] = Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
@@ -355,7 +355,7 @@ impl From<TimeInZone> for Message {
             };
             len += 1;
         }
-        if m.time_in_speed_zone != Vec::<u32>::new() {
+        if !m.time_in_speed_zone.is_empty() {
             arr[len] = Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
@@ -364,7 +364,7 @@ impl From<TimeInZone> for Message {
             };
             len += 1;
         }
-        if m.time_in_cadence_zone != Vec::<u32>::new() {
+        if !m.time_in_cadence_zone.is_empty() {
             arr[len] = Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
@@ -373,7 +373,7 @@ impl From<TimeInZone> for Message {
             };
             len += 1;
         }
-        if m.time_in_power_zone != Vec::<u32>::new() {
+        if !m.time_in_power_zone.is_empty() {
             arr[len] = Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
@@ -382,7 +382,7 @@ impl From<TimeInZone> for Message {
             };
             len += 1;
         }
-        if m.hr_zone_high_boundary != Vec::<u8>::new() {
+        if !m.hr_zone_high_boundary.is_empty() {
             arr[len] = Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
@@ -391,7 +391,7 @@ impl From<TimeInZone> for Message {
             };
             len += 1;
         }
-        if m.speed_zone_high_boundary != Vec::<u16>::new() {
+        if !m.speed_zone_high_boundary.is_empty() {
             arr[len] = Field {
                 num: 7,
                 profile_type: ProfileType::UINT16,
@@ -400,7 +400,7 @@ impl From<TimeInZone> for Message {
             };
             len += 1;
         }
-        if m.cadence_zone_high_boundary != Vec::<u8>::new() {
+        if !m.cadence_zone_high_boundary.is_empty() {
             arr[len] = Field {
                 num: 8,
                 profile_type: ProfileType::UINT8,
@@ -409,7 +409,7 @@ impl From<TimeInZone> for Message {
             };
             len += 1;
         }
-        if m.power_zone_high_boundary != Vec::<u16>::new() {
+        if !m.power_zone_high_boundary.is_empty() {
             arr[len] = Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
@@ -473,11 +473,11 @@ impl From<TimeInZone> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::TIME_IN_ZONE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
+++ b/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -112,14 +112,14 @@ impl Default for TimestampCorrelation {
 impl From<&Message> for TimestampCorrelation {
     /// from creates new TimestampCorrelation struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -219,11 +219,11 @@ impl From<TimestampCorrelation> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::TIMESTAMP_CORRELATION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/totals.rs
+++ b/rustyfit/src/profile/mesgdef/totals.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -85,14 +85,14 @@ impl Default for Totals {
 impl From<&Message> for Totals {
     /// from creates new Totals struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [639, 0, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -222,11 +222,11 @@ impl From<Totals> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::TOTALS,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/training_file.rs
+++ b/rustyfit/src/profile/mesgdef/training_file.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -64,14 +64,14 @@ impl Default for TrainingFile {
 impl From<&Message> for TrainingFile {
     /// from creates new TrainingFile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -161,11 +161,11 @@ impl From<TrainingFile> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::TRAINING_FILE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/training_settings.rs
+++ b/rustyfit/src/profile/mesgdef/training_settings.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -116,14 +116,14 @@ impl Default for TrainingSettings {
 impl From<&Message> for TrainingSettings {
     /// from creates new TrainingSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 154] = [const { &Value::Invalid }; 154];
+        let mut vals = [const { &Value::Invalid }; 154];
 
         const KNOWN_NUMS: [u64; 4] = [15032385536, 0, 33554432, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -193,11 +193,11 @@ impl From<TrainingSettings> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::TRAINING_SETTINGS,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/user_profile.rs
+++ b/rustyfit/src/profile/mesgdef/user_profile.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -245,14 +245,14 @@ impl Default for UserProfile {
 impl From<&Message> for UserProfile {
     /// from creates new UserProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [703695778447359, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -264,7 +264,7 @@ impl From<&Message> for UserProfile {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            friendly_name: vals[0].as_string(),
+            friendly_name: vals[0].to_string(),
             gender: typedef::Gender(vals[1].as_u8()),
             age: vals[2].as_u8(),
             height: vals[3].as_u8(),
@@ -581,11 +581,11 @@ impl From<UserProfile> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::USER_PROFILE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/video.rs
+++ b/rustyfit/src/profile/mesgdef/video.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -53,14 +53,14 @@ impl Default for Video {
 impl From<&Message> for Video {
     /// from creates new Video struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 3] = [const { &Value::Invalid }; 3];
+        let mut vals = [const { &Value::Invalid }; 3];
 
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -71,8 +71,8 @@ impl From<&Message> for Video {
         }
 
         Self {
-            url: vals[0].as_string(),
-            hosting_provider: vals[1].as_string(),
+            url: vals[0].to_string(),
+            hosting_provider: vals[1].to_string(),
             duration: vals[2].as_u32(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
@@ -120,11 +120,11 @@ impl From<Video> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::VIDEO,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/video_clip.rs
+++ b/rustyfit/src/profile/mesgdef/video_clip.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -69,14 +69,14 @@ impl Default for VideoClip {
 impl From<&Message> for VideoClip {
     /// from creates new VideoClip struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 8] = [const { &Value::Invalid }; 8];
+        let mut vals = [const { &Value::Invalid }; 8];
 
         const KNOWN_NUMS: [u64; 4] = [223, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -176,11 +176,11 @@ impl From<VideoClip> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::VIDEO_CLIP,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/video_description.rs
+++ b/rustyfit/src/profile/mesgdef/video_description.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -54,14 +54,14 @@ impl Default for VideoDescription {
 impl From<&Message> for VideoDescription {
     /// from creates new VideoDescription struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -74,7 +74,7 @@ impl From<&Message> for VideoDescription {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             message_count: vals[0].as_u16(),
-            text: vals[1].as_string(),
+            text: vals[1].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -121,11 +121,11 @@ impl From<VideoDescription> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::VIDEO_DESCRIPTION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/video_frame.rs
+++ b/rustyfit/src/profile/mesgdef/video_frame.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -54,14 +54,14 @@ impl Default for VideoFrame {
 impl From<&Message> for VideoFrame {
     /// from creates new VideoFrame struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -121,11 +121,11 @@ impl From<VideoFrame> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::VIDEO_FRAME,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/video_title.rs
+++ b/rustyfit/src/profile/mesgdef/video_title.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -54,14 +54,14 @@ impl Default for VideoTitle {
 impl From<&Message> for VideoTitle {
     /// from creates new VideoTitle struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -74,7 +74,7 @@ impl From<&Message> for VideoTitle {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             message_count: vals[0].as_u16(),
-            text: vals[1].as_string(),
+            text: vals[1].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -121,11 +121,11 @@ impl From<VideoTitle> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::VIDEO_TITLE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/watchface_settings.rs
+++ b/rustyfit/src/profile/mesgdef/watchface_settings.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -51,14 +51,14 @@ impl Default for WatchfaceSettings {
 impl From<&Message> for WatchfaceSettings {
     /// from creates new WatchfaceSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -118,11 +118,11 @@ impl From<WatchfaceSettings> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::WATCHFACE_SETTINGS,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/weather_alert.rs
+++ b/rustyfit/src/profile/mesgdef/weather_alert.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -69,14 +69,14 @@ impl Default for WeatherAlert {
 impl From<&Message> for WeatherAlert {
     /// from creates new WeatherAlert struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -88,7 +88,7 @@ impl From<&Message> for WeatherAlert {
 
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
-            report_id: vals[0].as_string(),
+            report_id: vals[0].to_string(),
             issue_time: typedef::DateTime(vals[1].as_u32()),
             expire_time: typedef::DateTime(vals[2].as_u32()),
             severity: typedef::WeatherSeverity(vals[3].as_u8()),
@@ -166,11 +166,11 @@ impl From<WeatherAlert> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::WEATHER_ALERT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -147,14 +147,14 @@ impl Default for WeatherConditions {
 impl From<&Message> for WeatherConditions {
     /// from creates new WeatherConditions struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [32767, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -174,7 +174,7 @@ impl From<&Message> for WeatherConditions {
             precipitation_probability: vals[5].as_u8(),
             temperature_feels_like: vals[6].as_i8(),
             relative_humidity: vals[7].as_u8(),
-            location: vals[8].as_string(),
+            location: vals[8].to_string(),
             observed_at_time: typedef::DateTime(vals[9].as_u32()),
             observed_location_lat: vals[10].as_i32(),
             observed_location_long: vals[11].as_i32(),
@@ -344,11 +344,11 @@ impl From<WeatherConditions> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::WEATHER_CONDITIONS,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/weight_scale.rs
+++ b/rustyfit/src/profile/mesgdef/weight_scale.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -278,14 +278,14 @@ impl Default for WeightScale {
 impl From<&Message> for WeightScale {
     /// from creates new WeightScale struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 254] = [const { &Value::Invalid }; 254];
+        let mut vals = [const { &Value::Invalid }; 254];
 
         const KNOWN_NUMS: [u64; 4] = [16319, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -455,11 +455,11 @@ impl From<WeightScale> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::WEIGHT_SCALE,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/workout.rs
+++ b/rustyfit/src/profile/mesgdef/workout.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -99,14 +99,14 @@ impl Default for Workout {
 impl From<&Message> for Workout {
     /// from creates new Workout struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [182640, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -121,11 +121,11 @@ impl From<&Message> for Workout {
             sport: typedef::Sport(vals[4].as_u8()),
             capabilities: typedef::WorkoutCapabilities(vals[5].as_u32z()),
             num_valid_steps: vals[6].as_u16(),
-            wkt_name: vals[8].as_string(),
+            wkt_name: vals[8].to_string(),
             sub_sport: typedef::SubSport(vals[11].as_u8()),
             pool_length: vals[14].as_u16(),
             pool_length_unit: typedef::DisplayMeasure(vals[15].as_u8()),
-            wkt_description: vals[17].as_string(),
+            wkt_description: vals[17].to_string(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }
@@ -226,11 +226,11 @@ impl From<Workout> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::WORKOUT,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/workout_session.rs
+++ b/rustyfit/src/profile/mesgdef/workout_session.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -87,14 +87,14 @@ impl Default for WorkoutSession {
 impl From<&Message> for WorkoutSession {
     /// from creates new WorkoutSession struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -194,11 +194,11 @@ impl From<WorkoutSession> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::WORKOUT_SESSION,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/workout_step.rs
+++ b/rustyfit/src/profile/mesgdef/workout_step.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -136,14 +136,14 @@ impl Default for WorkoutStep {
 impl From<&Message> for WorkoutStep {
     /// from creates new WorkoutStep struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 255] = [const { &Value::Invalid }; 255];
+        let mut vals = [const { &Value::Invalid }; 255];
 
         const KNOWN_NUMS: [u64; 4] = [7880703, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -155,7 +155,7 @@ impl From<&Message> for WorkoutStep {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            wkt_step_name: vals[0].as_string(),
+            wkt_step_name: vals[0].to_string(),
             duration_type: typedef::WktStepDuration(vals[1].as_u8()),
             duration_value: vals[2].as_u32(),
             target_type: typedef::WktStepTarget(vals[3].as_u8()),
@@ -163,7 +163,7 @@ impl From<&Message> for WorkoutStep {
             custom_target_value_low: vals[5].as_u32(),
             custom_target_value_high: vals[6].as_u32(),
             intensity: typedef::Intensity(vals[7].as_u8()),
-            notes: vals[8].as_string(),
+            notes: vals[8].to_string(),
             equipment: typedef::WorkoutEquipment(vals[9].as_u8()),
             exercise_category: typedef::ExerciseCategory(vals[10].as_u16()),
             exercise_name: vals[11].as_u16(),
@@ -363,11 +363,11 @@ impl From<WorkoutStep> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::WORKOUT_STEP,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/profile/mesgdef/zones_target.rs
+++ b/rustyfit/src/profile/mesgdef/zones_target.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::comparison_to_empty, clippy::manual_range_patterns)]
+#![allow(unused, clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -59,14 +59,14 @@ impl Default for ZonesTarget {
 impl From<&Message> for ZonesTarget {
     /// from creates new ZonesTarget struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals: [&Value; 8] = [const { &Value::Invalid }; 8];
+        let mut vals = [const { &Value::Invalid }; 8];
 
         const KNOWN_NUMS: [u64; 4] = [174, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields: Vec<Field> = Vec::with_capacity(n as usize);
+        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
             if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
@@ -146,11 +146,11 @@ impl From<ZonesTarget> for Message {
             len += 1;
         }
 
-        Message {
+        Self {
             header: 0,
             num: typedef::MesgNum::ZONES_TARGET,
             fields: {
-                let mut fields: Vec<Field> = Vec::with_capacity(len + m.unknown_fields.len());
+                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
                 fields.extend_from_slice(&arr[..len]);
                 fields.extend_from_slice(&m.unknown_fields);
                 fields

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -676,208 +676,216 @@ impl Value {
         }
     }
 
-    /// Returns i8 or its invalid value when it's not an i8 value.
-    pub fn as_i8(&self) -> i8 {
+    /// Returns `i8` or its invalid value when it's not an `i8` value.
+    pub(crate) fn as_i8(&self) -> i8 {
         if let Value::Int8(v) = self {
             return *v;
         }
         i8::MAX
     }
 
-    /// Returns u8 or its invalid value when it's not an u8 value.
-    pub fn as_u8(&self) -> u8 {
+    /// Returns `u8` or its invalid value when it's not an `u8` value.
+    pub(crate) fn as_u8(&self) -> u8 {
         if let Value::Uint8(v) = self {
             return *v;
         }
         u8::MAX
     }
 
-    /// Returns u8z or its invalid value when it's not an u8z value.
-    pub fn as_u8z(&self) -> u8 {
+    /// Returns `u8z` or its invalid value when it's not an `u8z` value.
+    pub(crate) fn as_u8z(&self) -> u8 {
         if let Value::Uint8(v) = self {
             return *v;
         }
         0
     }
 
-    /// Returns i16 or its invalid value when it's not an i16 value.
-    pub fn as_i16(&self) -> i16 {
+    /// Returns `i16` or its invalid value when it's not an `i16` value.
+    pub(crate) fn as_i16(&self) -> i16 {
         if let Value::Int16(v) = self {
             return *v;
         }
         i16::MAX
     }
 
-    /// Returns u16 or its invalid value when it's not an u16 value.
-    pub fn as_u16(&self) -> u16 {
+    /// Returns `u16` or its invalid value when it's not an `u16` value.
+    pub(crate) fn as_u16(&self) -> u16 {
         if let Value::Uint16(v) = self {
             return *v;
         }
         u16::MAX
     }
 
-    /// Returns u16z or its invalid value when it's not an u16z value.
-    pub fn as_u16z(&self) -> u16 {
+    /// Returns `u16z` or its invalid value when it's not an `u16z` value.
+    pub(crate) fn as_u16z(&self) -> u16 {
         if let Value::Uint16(v) = self {
             return *v;
         }
         0
     }
 
-    /// Returns i32 or its invalid value when it's not an i32 value.
-    pub fn as_i32(&self) -> i32 {
+    /// Returns `i32` or its invalid value when it's not an `i32` value.
+    pub(crate) fn as_i32(&self) -> i32 {
         if let Value::Int32(v) = self {
             return *v;
         }
         i32::MAX
     }
 
-    /// Returns u32 or its invalid value when it's not an u32 value.
-    pub fn as_u32(&self) -> u32 {
+    /// Returns `u32` or its invalid value when it's not an `u32` value.
+    pub(crate) fn as_u32(&self) -> u32 {
         if let Value::Uint32(v) = self {
             return *v;
         }
         u32::MAX
     }
 
-    /// Returns u32z or its invalid value when it's not an u32z value.
-    pub fn as_u32z(&self) -> u32 {
+    /// Returns `u32z` or its invalid value when it's not an `u32z` value.
+    pub(crate) fn as_u32z(&self) -> u32 {
         if let Value::Uint32(v) = self {
             return *v;
         }
         0
     }
 
-    /// Returns string (clone) or empty string when it's not a string.
-    pub fn as_string(&self) -> String {
+    /// Returns `String` by clone. Return empty string if it's not a `string` value.
+    pub(crate) fn to_string(&self) -> String {
         if let Value::String(v) = self {
             return v.clone();
         }
         String::new()
     }
 
-    /// Returns f32 or its invalid value when it's not a f32 value.
-    pub fn as_f32(&self) -> f32 {
+    /// Returns `f32` or its invalid value when it's not a `f32` value.
+    pub(crate) fn as_f32(&self) -> f32 {
         if let Value::Float32(v) = self {
             return *v;
         }
         f32::MAX
     }
 
-    /// Returns f64 or its invalid value when it's not a f64 value.
-    pub fn as_f64(&self) -> f64 {
+    /// Returns `f64` or its invalid value when it's not a `f64` value.
+    #[allow(unused)] // May be used on code generated files.
+    pub(crate) fn as_f64(&self) -> f64 {
         if let Value::Float64(v) = self {
             return *v;
         }
         f64::MAX
     }
 
-    /// Returns i64 or its invalid value when it's not an i64 value.
-    pub fn as_i64(&self) -> i64 {
+    /// Returns `i64` or its invalid value when it's not an `i64` value.
+    #[allow(unused)] // May be used on code generated files.
+    pub(crate) fn as_i64(&self) -> i64 {
         if let Value::Int64(v) = self {
             return *v;
         }
         i64::MAX
     }
 
-    /// Returns u64 or its invalid value when it's not an u64 value.
-    pub fn as_u64(&self) -> u64 {
+    /// Returns `u64` or its invalid value when it's not an `u64` value.
+    #[allow(unused)] // May be used on code generated files.
+    pub(crate) fn as_u64(&self) -> u64 {
         if let Value::Uint64(v) = self {
             return *v;
         }
         u64::MAX
     }
 
-    /// Returns u64z or its invalid value when it's not an u64z value.
-    pub fn as_u64z(&self) -> u64 {
+    /// Returns `u64z` or its invalid value when it's not an `u64z` value.
+    #[allow(unused)] // May be used on code generated files.
+    pub(crate) fn as_u64z(&self) -> u64 {
         if let Value::Uint64(v) = self {
             return *v;
         }
         0
     }
 
-    /// Returns Vec<i8> (clone) or empty vector when it's not a Vec<i8> value.
-    pub fn as_vec_i8(&self) -> Vec<i8> {
+    /// Returns value as `Vec<i8>` by clone. Return empty vector if it's not a `Vec<i8>` value.
+    pub(crate) fn to_vec_i8(&self) -> Vec<i8> {
         if let Value::VecInt8(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<u8> (clone) or empty vector when it's not a Vec<u8> value.
-    pub fn as_vec_u8(&self) -> Vec<u8> {
+    /// Returns value as `Vec<u8>` by clone. Return empty vector if it's not a `Vec<u8>` value.
+    pub(crate) fn to_vec_u8(&self) -> Vec<u8> {
         if let Value::VecUint8(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<i16> (clone) or empty vector when it's not a Vec<i16> value.
-    pub fn as_vec_i16(&self) -> Vec<i16> {
+    /// Returns value as `Vec<i16>` by clone. Return empty vector if it's not a `Vec<i16>` value.
+    pub(crate) fn to_vec_i16(&self) -> Vec<i16> {
         if let Value::VecInt16(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<u16> (clone) or empty vector when it's not a Vec<u16> value.
-    pub fn as_vec_u16(&self) -> Vec<u16> {
+    /// Returns value as `Vec<u16>` by clone. Return empty vector if it's not a `Vec<u16>` value.
+    pub(crate) fn to_vec_u16(&self) -> Vec<u16> {
         if let Value::VecUint16(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<i32> (clone) or empty vector when it's not a Vec<i32> value.
-    pub fn as_vec_i32(&self) -> Vec<i32> {
+    /// Returns value as `Vec<i32>` by clone. Return empty vector if it's not a `Vec<i32>` value.
+    #[allow(unused)] // May be used on code generated files.
+    pub(crate) fn to_vec_i32(&self) -> Vec<i32> {
         if let Value::VecInt32(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<u32> (clone) or empty vector when it's not a Vec<u32> value.
-    pub fn as_vec_u32(&self) -> Vec<u32> {
+    /// Returns value as `Vec<u32>` by clone. Return empty vector if it's not a `Vec<u32>` value.
+    pub(crate) fn to_vec_u32(&self) -> Vec<u32> {
         if let Value::VecUint32(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<String> (clone) or empty vector when it's not a Vec<String> value.
-    pub fn as_vec_string(&self) -> Vec<String> {
+    /// Returns value as `Vec<String>` by clone. Return empty vector if it's not a `Vec<String>` value.
+    pub(crate) fn to_vec_string(&self) -> Vec<String> {
         if let Value::VecString(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<f32> (clone) or empty vector when it's not a Vec<f32> value.
-    pub fn as_vec_f32(&self) -> Vec<f32> {
+    /// Returns value as `Vec<f32>` by clone. Return empty vector if it's not a `Vec<f32>` value.
+    pub(crate) fn to_vec_f32(&self) -> Vec<f32> {
         if let Value::VecFloat32(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<f64> (clone) or empty vector when it's not a Vec<f64> value.
-    pub fn as_vec_f64(&self) -> Vec<f64> {
+    /// Returns value as `Vec<f64>` by clone. Return empty vector if it's not a `Vec<f64>` value.
+    #[allow(unused)] // May be used on code generated files.
+    pub(crate) fn to_vec_f64(&self) -> Vec<f64> {
         if let Value::VecFloat64(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<i64> (clone) or empty vector when it's not a Vec<i64> value.
-    pub fn as_vec_i64(&self) -> Vec<i64> {
+    /// Returns value as `Vec<i64>` by clone. Return empty vector if it's not a `Vec<i64>` value.
+    #[allow(unused)] // May be used on code generated files.
+    pub(crate) fn to_vec_i64(&self) -> Vec<i64> {
         if let Value::VecInt64(v) = self {
             return v.clone();
         }
         Vec::new()
     }
 
-    /// Returns Vec<u64> (clone) or empty vector when it's not a Vec<u64> value.
-    pub fn as_vec_u64(&self) -> Vec<u64> {
+    /// Returns value as `Vec<u64>` by clone. Return empty vector if it's not a `Vec<u64>` value.
+    #[allow(unused)] // May be used on code generated files.
+    pub(crate) fn to_vec_u64(&self) -> Vec<u64> {
         if let Value::VecUint64(v) = self {
             return v.clone();
         }
@@ -1104,7 +1112,7 @@ impl From<&Message> for LocalFieldDescription {
                 _ => {}
             };
         }
-        return s;
+        s
     }
 }
 


### PR DESCRIPTION
- `proto::Value` methods: Term `as` is for lightweight (copy), where `as_vec` is not right since we clone the value. change to `to_vec` instead. And since these methods are only used on code generated files, let's make it private, pattern matching for enum is preferred for regular code. I rarely run in situation that need to use these methods other than to make the generated code more readable.
- Improve mesgdef code generated files on comparison to empty value. And make code more concise.