### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -192,9 +192,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-io"
@@ -233,6 +233,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,10 +284,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -329,6 +355,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -487,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -503,6 +535,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spinning_top"
@@ -562,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -575,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -585,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -598,18 +636,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("messages count: {}", fit.messages.len());
     for field in &fit.messages[0].fields {
         // first message: file_id
-        if field.num == mesgdef::FileId::TYPE {
-            if let Value::Uint8(v) = field.value {
-                println!("file type: {}", typedef::File(v));
-            }
+        if field.num == mesgdef::FileId::TYPE
+            && let Value::Uint8(v) = field.value
+        {
+            println!("file type: {}", typedef::File(v));
         }
     }
     
@@ -72,10 +72,10 @@ We can decode chained FIT file using `while let`, e.g:
         println!("messages count: {}", fit.messages.len());
         for field in &fit.messages[0].fields {
             // first message: file_id
-            if field.num == mesgdef::FileId::TYPE {
-                if let Value::Uint8(v) = field.value {
-                    println!("file type: {}", typedef::File(v));
-                }
+            if field.num == mesgdef::FileId::TYPE
+                && let Value::Uint8(v) = field.value
+            {
+                println!("file type: {}", typedef::File(v));
             }
         }
     }

--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -134,9 +134,7 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			}
 			if strings.Contains(field.Type, "String") {
 				imports["alloc::string::String"] = struct{}{}
-				if fixedArraySize > 0 {
-					imports["alloc::borrow::ToOwned"] = struct{}{}
-				}
+				imports["alloc::borrow::ToOwned"] = struct{}{}
 			}
 			if field.Units == "semicircles" {
 				imports["crate::semconv"] = struct{}{}
@@ -414,7 +412,7 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 	var value string
 	if array == "" {
 		if rustAsType == "string" {
-			value = fmt.Sprintf(`vals[%d].to_string()`, num)
+			value = fmt.Sprintf(`vals[%d].as_str().to_owned()`, num)
 		} else {
 			value = fmt.Sprintf(`vals[%d].as_%s()`, num, rustAsType)
 		}

--- a/rustyfit/Cargo.toml
+++ b/rustyfit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.93"
 name = "rustyfit"
 version = "0.6.1"
 description = """

--- a/rustyfit/src/decoder/bits.rs
+++ b/rustyfit/src/decoder/bits.rs
@@ -1,6 +1,6 @@
 use crate::{profile::lookup, proto::Value};
 
-const N: usize = ((lookup::MAX_COMPONENT_BITS / 8) + 7) / 8;
+const N: usize = ((lookup::MAX_COMPONENT_BITS.div_ceil(8)) + 7).div_ceil(8);
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub(super) struct Bits {
@@ -84,15 +84,15 @@ macro_rules! impl_as_u64 {
 
 impl_as_u64!(i8, u8, i16, u16, i32, u32, i64, u64, f32, f64);
 
-fn bits_from_slice<T: AsU64>(v: &mut Bits, s: &[T], bitsize: usize) {
-    for i in 0..s.len() {
-        let x = i * bitsize;
-        let index = x >> 6;
-        if index >= v.store.len() {
+fn bits_from_slice<T: AsU64>(bits: &mut Bits, v: &[T], bitsize: usize) {
+    for (i, x) in v.iter().enumerate() {
+        let pos = i * bitsize;
+        let index = pos >> 6;
+        if index >= bits.store.len() {
             break;
         }
-        v.store[index] |= s[i].as_u64() << (x & 63);
-        v.size += bitsize as u64;
+        bits.store[index] |= x.as_u64() << (pos & 63);
+        bits.size += bitsize as u64;
     }
 }
 

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -352,9 +352,9 @@ impl<R: Read> Decoder<R> {
             });
         }
 
-        self.decode_fields(mesg, &mesg_def)?;
+        self.decode_fields(mesg, mesg_def)?;
 
-        self.decode_developer_fields(mesg, &mesg_def)?;
+        self.decode_developer_fields(mesg, mesg_def)?;
 
         // Developer Data Lookup, currently we allow missing developer_data_id
         if mesg.num == MesgNum::FIELD_DESCRIPTION {
@@ -440,11 +440,12 @@ impl<R: Read> Decoder<R> {
 
             let value = Value::unmarshal(buf, array, base_type, mesg_def.arch);
 
-            if num == Field::TIMESTAMP && base_type == FitBaseType::UINT32 {
-                if let Value::Uint32(v) = value {
-                    self.timestamp = v;
-                    self.last_time_offset = v as u8 & Message::COMPRESSED_TIME_MASK;
-                }
+            if num == Field::TIMESTAMP
+                && base_type == FitBaseType::UINT32
+                && let Value::Uint32(v) = value
+            {
+                self.timestamp = v;
+                self.last_time_offset = v as u8 & Message::COMPRESSED_TIME_MASK;
             }
 
             if accumulate {
@@ -723,7 +724,7 @@ impl Builder {
     /// Build Decoder based on given options (if any).
     pub fn build<R: Read>(&self, reader: R) -> Decoder<R> {
         Decoder {
-            reader: reader,
+            reader,
             n: 0,
             cur: 0,
             crc16: Crc16::new(),
@@ -745,6 +746,12 @@ impl Builder {
             field_descriptions: Vec::new(),
             options: self.options,
         }
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -224,7 +224,7 @@ impl<W: Write + Seek> Encoder<W> {
         let size = self.n - self.last_file_header_pos;
         self.writer.seek(SeekFrom::Current(-size))?;
 
-        self.writer.write_all(&buf)?;
+        self.writer.write_all(buf)?;
 
         let n = buf.len() as i64;
         self.writer.seek(SeekFrom::Current(size - n))?;
@@ -258,7 +258,7 @@ impl<W: Write + Seek> Encoder<W> {
         buf.clear();
 
         marshal_append_message_definition(buf, mesg, self.options.endianness as u8);
-        let (local_mesg_num, is_new_mesg_def) = self.lru.put(&buf);
+        let (local_mesg_num, is_new_mesg_def) = self.lru.put(buf);
 
         buf[0] |= local_mesg_num;
         if mesg.header & Message::COMPRESSED_HEADER_MASK == Message::COMPRESSED_HEADER_MASK {
@@ -293,10 +293,10 @@ impl<W: Write + Seek> Encoder<W> {
 
     fn compress_timestamp_into_header(&mut self, mesg: &mut Message) {
         let mut timestamp = u32::MAX;
-        if let Some(field) = mesg.fields.iter().find(|f| f.num == Field::TIMESTAMP) {
-            if let Value::Uint32(v) = field.value {
-                timestamp = v;
-            }
+        if let Some(field) = mesg.fields.iter().find(|f| f.num == Field::TIMESTAMP)
+            && let Value::Uint32(v) = field.value
+        {
+            timestamp = v;
         }
 
         if timestamp == u32::MAX || timestamp < DateTime::MIN.0 {
@@ -409,7 +409,7 @@ impl Builder {
     /// Build Encoder based on given options (if any).
     pub fn build<W: Write + Seek>(&self, writer: W) -> Encoder<W> {
         Encoder {
-            writer: writer,
+            writer,
             n: 0,
             last_file_header_pos: 0,
             data_size: 0,
@@ -425,6 +425,12 @@ impl Builder {
             options: self.options,
             message_validator: MessageValidator::new(),
         }
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -292,12 +292,12 @@ impl<W: Write + Seek> Encoder<W> {
     }
 
     fn compress_timestamp_into_header(&mut self, mesg: &mut Message) {
-        let timestamp = mesg
-            .fields
-            .iter()
-            .find(|field| field.num == Field::TIMESTAMP)
-            .map(|field| field.value.as_u32())
-            .unwrap_or(u32::MAX);
+        let mut timestamp = u32::MAX;
+        if let Some(field) = mesg.fields.iter().find(|f| f.num == Field::TIMESTAMP) {
+            if let Value::Uint32(v) = field.value {
+                timestamp = v;
+            }
+        }
 
         if timestamp == u32::MAX || timestamp < DateTime::MIN.0 {
             return;

--- a/rustyfit/src/encoder/validator.rs
+++ b/rustyfit/src/encoder/validator.rs
@@ -146,10 +146,9 @@ impl MessageValidator {
                     .fields
                     .iter()
                     .find(|field| field.num == mesgdef::DeveloperDataId::DEVELOPER_DATA_INDEX)
+                    && let Value::Uint8(v) = field.value
                 {
-                    if let Value::Uint8(v) = field.value {
-                        self.developer_data_index_seen[(v as usize) >> 6] |= 1 << (v & 63)
-                    }
+                    self.developer_data_index_seen[(v as usize) >> 6] |= 1 << (v & 63)
                 }
             }
             MesgNum::FIELD_DESCRIPTION => self
@@ -223,10 +222,8 @@ impl MessageValidator {
         }
 
         match value {
-            Value::String(v) => {
-                if core::str::from_utf8(v.as_bytes()).is_err() {
-                    return Err(IntegrityError::InvalidUTF8String(v.clone()));
-                }
+            Value::String(v) if core::str::from_utf8(v.as_bytes()).is_err() => {
+                return Err(IntegrityError::InvalidUTF8String(v.clone()));
             }
             Value::VecString(v) => {
                 for x in v.iter() {

--- a/rustyfit/src/profile/mesgdef/bike_profile.rs
+++ b/rustyfit/src/profile/mesgdef/bike_profile.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -320,7 +321,7 @@ impl From<&Message> for BikeProfile {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            name: vals[0].to_string(),
+            name: vals[0].as_str().to_owned(),
             sport: typedef::Sport(vals[1].as_u8()),
             sub_sport: typedef::SubSport(vals[2].as_u8()),
             odometer: vals[3].as_u32(),

--- a/rustyfit/src/profile/mesgdef/cadence_zone.rs
+++ b/rustyfit/src/profile/mesgdef/cadence_zone.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -73,7 +74,7 @@ impl From<&Message> for CadenceZone {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             high_value: vals[0].as_u8(),
-            name: vals[1].to_string(),
+            name: vals[1].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/camera_event.rs
+++ b/rustyfit/src/profile/mesgdef/camera_event.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -83,7 +84,7 @@ impl From<&Message> for CameraEvent {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
             camera_event_type: typedef::CameraEventType(vals[1].as_u8()),
-            camera_file_uuid: vals[2].to_string(),
+            camera_file_uuid: vals[2].as_str().to_owned(),
             camera_orientation: typedef::CameraOrientationType(vals[3].as_u8()),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),

--- a/rustyfit/src/profile/mesgdef/connectivity.rs
+++ b/rustyfit/src/profile/mesgdef/connectivity.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -116,7 +117,7 @@ impl From<&Message> for Connectivity {
             bluetooth_enabled: typedef::Bool(vals[0].as_u8()),
             bluetooth_le_enabled: typedef::Bool(vals[1].as_u8()),
             ant_enabled: typedef::Bool(vals[2].as_u8()),
-            name: vals[3].to_string(),
+            name: vals[3].as_str().to_owned(),
             live_tracking_enabled: typedef::Bool(vals[4].as_u8()),
             weather_conditions_enabled: typedef::Bool(vals[5].as_u8()),
             weather_alerts_enabled: typedef::Bool(vals[6].as_u8()),

--- a/rustyfit/src/profile/mesgdef/course.rs
+++ b/rustyfit/src/profile/mesgdef/course.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -76,7 +77,7 @@ impl From<&Message> for Course {
 
         Self {
             sport: typedef::Sport(vals[4].as_u8()),
-            name: vals[5].to_string(),
+            name: vals[5].as_str().to_owned(),
             capabilities: typedef::CourseCapabilities(vals[6].as_u32z()),
             sub_sport: typedef::SubSport(vals[7].as_u8()),
             unknown_fields,

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -9,6 +9,7 @@
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use crate::semconv;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -129,7 +130,7 @@ impl From<&Message> for CoursePoint {
             position_long: vals[3].as_i32(),
             distance: vals[4].as_u32(),
             r#type: typedef::CoursePoint(vals[5].as_u8()),
-            name: vals[6].to_string(),
+            name: vals[6].as_str().to_owned(),
             favorite: typedef::Bool(vals[8].as_u8()),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),

--- a/rustyfit/src/profile/mesgdef/device_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_info.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -195,12 +196,12 @@ impl From<&Message> for DeviceInfo {
             battery_voltage: vals[10].as_u16(),
             battery_status: typedef::BatteryStatus(vals[11].as_u8()),
             sensor_position: typedef::BodyLocation(vals[18].as_u8()),
-            descriptor: vals[19].to_string(),
+            descriptor: vals[19].as_str().to_owned(),
             ant_transmission_type: vals[20].as_u8z(),
             ant_device_number: vals[21].as_u16z(),
             ant_network: typedef::AntNetwork(vals[22].as_u8()),
             source_type: typedef::SourceType(vals[25].as_u8()),
-            product_name: vals[27].to_string(),
+            product_name: vals[27].as_str().to_owned(),
             battery_level: vals[32].as_u8(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),

--- a/rustyfit/src/profile/mesgdef/dive_settings.rs
+++ b/rustyfit/src/profile/mesgdef/dive_settings.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -372,7 +373,7 @@ impl From<&Message> for DiveSettings {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            name: vals[0].to_string(),
+            name: vals[0].as_str().to_owned(),
             model: typedef::TissueModelType(vals[1].as_u8()),
             gf_low: vals[2].as_u8(),
             gf_high: vals[3].as_u8(),

--- a/rustyfit/src/profile/mesgdef/exercise_title.rs
+++ b/rustyfit/src/profile/mesgdef/exercise_title.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 

--- a/rustyfit/src/profile/mesgdef/field_description.rs
+++ b/rustyfit/src/profile/mesgdef/field_description.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -116,12 +117,12 @@ impl From<&Message> for FieldDescription {
             fit_base_type_id: typedef::FitBaseType(vals[2].as_u8()),
             field_name: vals[3].to_vec_string(),
             array: vals[4].as_u8(),
-            components: vals[5].to_string(),
+            components: vals[5].as_str().to_owned(),
             scale: vals[6].as_u8(),
             offset: vals[7].as_i8(),
             units: vals[8].to_vec_string(),
-            bits: vals[9].to_string(),
-            accumulate: vals[10].to_string(),
+            bits: vals[9].as_str().to_owned(),
+            accumulate: vals[10].as_str().to_owned(),
             fit_base_unit_id: typedef::FitBaseUnit(vals[13].as_u16()),
             native_mesg_num: typedef::MesgNum(vals[14].as_u16()),
             native_field_num: vals[15].as_u8(),

--- a/rustyfit/src/profile/mesgdef/file_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/file_capabilities.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -87,7 +88,7 @@ impl From<&Message> for FileCapabilities {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             r#type: typedef::File(vals[0].as_u8()),
             flags: typedef::FileFlags(vals[1].as_u8z()),
-            directory: vals[2].to_string(),
+            directory: vals[2].as_str().to_owned(),
             max_count: vals[3].as_u16(),
             max_size: vals[4].as_u32(),
             unknown_fields,

--- a/rustyfit/src/profile/mesgdef/file_id.rs
+++ b/rustyfit/src/profile/mesgdef/file_id.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -93,7 +94,7 @@ impl From<&Message> for FileId {
             serial_number: vals[3].as_u32z(),
             time_created: typedef::DateTime(vals[4].as_u32()),
             number: vals[5].as_u16(),
-            product_name: vals[8].to_string(),
+            product_name: vals[8].as_str().to_owned(),
             unknown_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hr_zone.rs
+++ b/rustyfit/src/profile/mesgdef/hr_zone.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -73,7 +74,7 @@ impl From<&Message> for HrZone {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             high_bpm: vals[1].as_u8(),
-            name: vals[2].to_string(),
+            name: vals[2].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/nmea_sentence.rs
+++ b/rustyfit/src/profile/mesgdef/nmea_sentence.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -75,7 +76,7 @@ impl From<&Message> for NmeaSentence {
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
             timestamp_ms: vals[0].as_u16(),
-            sentence: vals[1].to_string(),
+            sentence: vals[1].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/power_zone.rs
+++ b/rustyfit/src/profile/mesgdef/power_zone.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -73,7 +74,7 @@ impl From<&Message> for PowerZone {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             high_value: vals[1].as_u16(),
-            name: vals[2].to_string(),
+            name: vals[2].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/segment_file.rs
+++ b/rustyfit/src/profile/mesgdef/segment_file.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -103,7 +104,7 @@ impl From<&Message> for SegmentFile {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            file_uuid: vals[1].to_string(),
+            file_uuid: vals[1].as_str().to_owned(),
             enabled: typedef::Bool(vals[3].as_u8()),
             user_profile_primary_key: vals[4].as_u32(),
             leader_type: match &vals[7] {

--- a/rustyfit/src/profile/mesgdef/segment_id.rs
+++ b/rustyfit/src/profile/mesgdef/segment_id.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -103,8 +104,8 @@ impl From<&Message> for SegmentId {
         }
 
         Self {
-            name: vals[0].to_string(),
-            uuid: vals[1].to_string(),
+            name: vals[0].as_str().to_owned(),
+            uuid: vals[1].as_str().to_owned(),
             sport: typedef::Sport(vals[2].as_u8()),
             enabled: typedef::Bool(vals[3].as_u8()),
             user_profile_primary_key: vals[4].as_u32(),

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -9,6 +9,7 @@
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use crate::semconv;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -1489,7 +1490,7 @@ impl From<&Message> for SegmentLap {
             nec_long: vals[26].as_i32(),
             swc_lat: vals[27].as_i32(),
             swc_long: vals[28].as_i32(),
-            name: vals[29].to_string(),
+            name: vals[29].as_str().to_owned(),
             normalized_power: vals[30].as_u16(),
             left_right_balance: typedef::LeftRightBalance100(vals[31].as_u16()),
             sub_sport: typedef::SubSport(vals[32].as_u8()),
@@ -1525,7 +1526,7 @@ impl From<&Message> for SegmentLap {
             avg_right_pedal_smoothness: vals[62].as_u8(),
             avg_combined_pedal_smoothness: vals[63].as_u8(),
             status: typedef::SegmentLapStatus(vals[64].as_u8()),
-            uuid: vals[65].to_string(),
+            uuid: vals[65].as_str().to_owned(),
             avg_fractional_cadence: vals[66].as_u8(),
             max_fractional_cadence: vals[67].as_u8(),
             total_fractional_cycles: vals[68].as_u8(),

--- a/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
+++ b/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -112,12 +113,12 @@ impl From<&Message> for SegmentLeaderboardEntry {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            name: vals[0].to_string(),
+            name: vals[0].as_str().to_owned(),
             r#type: typedef::SegmentLeaderboardType(vals[1].as_u8()),
             group_primary_key: vals[2].as_u32(),
             activity_id: vals[3].as_u32(),
             segment_time: vals[4].as_u32(),
-            activity_id_string: vals[5].to_string(),
+            activity_id_string: vals[5].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -9,6 +9,7 @@
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use crate::semconv;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -2583,7 +2584,7 @@ impl From<&Message> for Session {
             active_time: vals[78].as_u32(),
             player_score: vals[82].as_u16(),
             opponent_score: vals[83].as_u16(),
-            opponent_name: vals[84].to_string(),
+            opponent_name: vals[84].as_str().to_owned(),
             stroke_count: vals[85].to_vec_u16(),
             zone_count: vals[86].to_vec_u16(),
             max_ball_speed: vals[87].as_u16(),
@@ -2605,7 +2606,7 @@ impl From<&Message> for Session {
             avg_left_pedal_smoothness: vals[103].as_u8(),
             avg_right_pedal_smoothness: vals[104].as_u8(),
             avg_combined_pedal_smoothness: vals[105].as_u8(),
-            sport_profile_name: vals[110].to_string(),
+            sport_profile_name: vals[110].as_str().to_owned(),
             sport_index: vals[111].as_u8(),
             time_standing: vals[112].as_u32(),
             stand_count: vals[113].as_u16(),

--- a/rustyfit/src/profile/mesgdef/software.rs
+++ b/rustyfit/src/profile/mesgdef/software.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -92,7 +93,7 @@ impl From<&Message> for Software {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             version: vals[3].as_u16(),
-            part_number: vals[5].to_string(),
+            part_number: vals[5].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/speed_zone.rs
+++ b/rustyfit/src/profile/mesgdef/speed_zone.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -92,7 +93,7 @@ impl From<&Message> for SpeedZone {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             high_value: vals[0].as_u16(),
-            name: vals[1].to_string(),
+            name: vals[1].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/sport.rs
+++ b/rustyfit/src/profile/mesgdef/sport.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -72,7 +73,7 @@ impl From<&Message> for Sport {
         Self {
             sport: typedef::Sport(vals[0].as_u8()),
             sub_sport: typedef::SubSport(vals[1].as_u8()),
-            name: vals[3].to_string(),
+            name: vals[3].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/user_profile.rs
+++ b/rustyfit/src/profile/mesgdef/user_profile.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -264,7 +265,7 @@ impl From<&Message> for UserProfile {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            friendly_name: vals[0].to_string(),
+            friendly_name: vals[0].as_str().to_owned(),
             gender: typedef::Gender(vals[1].as_u8()),
             age: vals[2].as_u8(),
             height: vals[3].as_u8(),

--- a/rustyfit/src/profile/mesgdef/video.rs
+++ b/rustyfit/src/profile/mesgdef/video.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -71,8 +72,8 @@ impl From<&Message> for Video {
         }
 
         Self {
-            url: vals[0].to_string(),
-            hosting_provider: vals[1].to_string(),
+            url: vals[0].as_str().to_owned(),
+            hosting_provider: vals[1].as_str().to_owned(),
             duration: vals[2].as_u32(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),

--- a/rustyfit/src/profile/mesgdef/video_description.rs
+++ b/rustyfit/src/profile/mesgdef/video_description.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -74,7 +75,7 @@ impl From<&Message> for VideoDescription {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             message_count: vals[0].as_u16(),
-            text: vals[1].to_string(),
+            text: vals[1].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/video_title.rs
+++ b/rustyfit/src/profile/mesgdef/video_title.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -74,7 +75,7 @@ impl From<&Message> for VideoTitle {
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
             message_count: vals[0].as_u16(),
-            text: vals[1].to_string(),
+            text: vals[1].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/weather_alert.rs
+++ b/rustyfit/src/profile/mesgdef/weather_alert.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -88,7 +89,7 @@ impl From<&Message> for WeatherAlert {
 
         Self {
             timestamp: typedef::DateTime(vals[253].as_u32()),
-            report_id: vals[0].to_string(),
+            report_id: vals[0].as_str().to_owned(),
             issue_time: typedef::DateTime(vals[1].as_u32()),
             expire_time: typedef::DateTime(vals[2].as_u32()),
             severity: typedef::WeatherSeverity(vals[3].as_u8()),

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -9,6 +9,7 @@
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use crate::semconv;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -174,7 +175,7 @@ impl From<&Message> for WeatherConditions {
             precipitation_probability: vals[5].as_u8(),
             temperature_feels_like: vals[6].as_i8(),
             relative_humidity: vals[7].as_u8(),
-            location: vals[8].to_string(),
+            location: vals[8].as_str().to_owned(),
             observed_at_time: typedef::DateTime(vals[9].as_u32()),
             observed_location_lat: vals[10].as_i32(),
             observed_location_long: vals[11].as_i32(),

--- a/rustyfit/src/profile/mesgdef/workout.rs
+++ b/rustyfit/src/profile/mesgdef/workout.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -121,11 +122,11 @@ impl From<&Message> for Workout {
             sport: typedef::Sport(vals[4].as_u8()),
             capabilities: typedef::WorkoutCapabilities(vals[5].as_u32z()),
             num_valid_steps: vals[6].as_u16(),
-            wkt_name: vals[8].to_string(),
+            wkt_name: vals[8].as_str().to_owned(),
             sub_sport: typedef::SubSport(vals[11].as_u8()),
             pool_length: vals[14].as_u16(),
             pool_length_unit: typedef::DisplayMeasure(vals[15].as_u8()),
-            wkt_description: vals[17].to_string(),
+            wkt_description: vals[17].as_str().to_owned(),
             unknown_fields,
             developer_fields: mesg.developer_fields.clone(),
         }

--- a/rustyfit/src/profile/mesgdef/workout_step.rs
+++ b/rustyfit/src/profile/mesgdef/workout_step.rs
@@ -8,6 +8,7 @@
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -155,7 +156,7 @@ impl From<&Message> for WorkoutStep {
 
         Self {
             message_index: typedef::MessageIndex(vals[254].as_u16()),
-            wkt_step_name: vals[0].to_string(),
+            wkt_step_name: vals[0].as_str().to_owned(),
             duration_type: typedef::WktStepDuration(vals[1].as_u8()),
             duration_value: vals[2].as_u32(),
             target_type: typedef::WktStepTarget(vals[3].as_u8()),
@@ -163,7 +164,7 @@ impl From<&Message> for WorkoutStep {
             custom_target_value_low: vals[5].as_u32(),
             custom_target_value_high: vals[6].as_u32(),
             intensity: typedef::Intensity(vals[7].as_u8()),
-            notes: vals[8].to_string(),
+            notes: vals[8].as_str().to_owned(),
             equipment: typedef::WorkoutEquipment(vals[9].as_u8()),
             exercise_category: typedef::ExerciseCategory(vals[10].as_u16()),
             exercise_name: vals[11].as_u16(),

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -748,12 +748,14 @@ impl Value {
         0
     }
 
-    /// Returns `String` by clone. Return empty string if it's not a `string` value.
-    pub(crate) fn to_string(&self) -> String {
+    /// Returns `&str`. Return empty string if it's not a `string` value.
+    ///
+    /// NOTE: Can not use `to_string()` since it is reserved for `fmt::Display`.
+    pub(crate) fn as_str(&self) -> &str {
         if let Value::String(v) = self {
-            return v.clone();
+            return v;
         }
-        String::new()
+        ""
     }
 
     /// Returns `f32` or its invalid value when it's not a `f32` value.


### PR DESCRIPTION
- Bump MSRV to v1.93 since we use `into_raw_parts` method which stabilize on that version.
- Fix clippy warnings and simplify some code.