### PR TITLE
perf: optimize encoder's lru memory efficiency

### DIFF
--- a/rustyfit/src/encoder/lru.rs
+++ b/rustyfit/src/encoder/lru.rs
@@ -1,8 +1,12 @@
 use alloc::{vec, vec::Vec};
 
+/// Lru is an opinionated `local_mesg_num` redefiner whose algorithm mimics
+/// an LRU cache. When storage is full, the least recently used item is
+/// replaced with a new item, which is then marked as the most recently used item.
+/// This way, interleaving between `message definitions` is optimized.
 pub(super) struct Lru {
     items: Vec<Vec<u8>>,
-    bucket: Vec<usize>,
+    bucket: Vec<u8>,
 }
 
 impl Lru {
@@ -30,8 +34,9 @@ impl Lru {
     fn store(&mut self, item: &[u8]) -> u8 {
         let item_index = self.bucket.len();
         self.items[item_index].clear();
+        reserve_with_capacity_tiers(&mut self.items[item_index], item.len());
         self.items[item_index].extend_from_slice(item);
-        self.bucket.push(item_index);
+        self.bucket.push(item_index as u8);
         item_index as u8
     }
 
@@ -39,21 +44,22 @@ impl Lru {
         let item_index = self.bucket[bucket_index];
         self.bucket.remove(bucket_index);
         self.bucket.push(item_index);
-        item_index as u8
+        item_index
     }
 
     fn replace_least_recently_used(&mut self, item: &[u8]) -> u8 {
-        let item_index = self.bucket[0];
+        let item_index = self.bucket[0] as usize;
         self.bucket.remove(0);
-        self.bucket.push(item_index);
+        self.bucket.push(item_index as u8);
         self.items[item_index].clear();
+        reserve_with_capacity_tiers(&mut self.items[item_index], item.len());
         self.items[item_index].extend_from_slice(item);
         item_index as u8
     }
 
     fn bucket_index(&self, item: &[u8]) -> Option<usize> {
         for i in (0..self.bucket.len()).rev() {
-            let cur = self.bucket[i];
+            let cur = self.bucket[i] as usize;
             if self.items[cur] == item {
                 return Some(i);
             }
@@ -62,10 +68,45 @@ impl Lru {
     }
 }
 
+/// Prevent vector for growing more than 1537 bytes while also reducing
+/// frequency of reallocation by reserving capacity in fixed-size tiers.
+///
+/// NOTE: Clear vector before passing.
+fn reserve_with_capacity_tiers(v: &mut Vec<u8>, mut n: usize) {
+    if n < v.capacity() {
+        return;
+    }
+
+    const RESERVED: usize = 7; // header, mesg_num, etc.
+    const FULL: usize = 1537 - RESERVED;
+    const THREE_QUARTER: usize = FULL * 3 / 4;
+    const HALF: usize = FULL / 2;
+    const QUARTER: usize = FULL / 4;
+
+    n = n.saturating_sub(RESERVED);
+
+    // Start at QUARTER because in practice, encountering more than 127 entries,
+    // combination of fields and developer fields, is already rare. (127 * 3 = 381 bytes).
+    // Session message has approx. 158 known fields, not all are used at the same time.
+    // We probably never reallocate.
+    let target = if n <= QUARTER {
+        QUARTER
+    } else if n <= HALF {
+        HALF
+    } else if n <= THREE_QUARTER {
+        THREE_QUARTER
+    } else {
+        FULL
+    };
+
+    // Note that allocator may still give more space than requested.
+    v.reserve_exact(RESERVED + target);
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::encoder::Lru;
-    use alloc::vec;
+    use crate::encoder::{Lru, lru::reserve_with_capacity_tiers};
+    use alloc::{vec, vec::Vec};
 
     #[test]
     fn test_lru() {
@@ -91,11 +132,14 @@ mod tests {
             let item = lru.items[i].clone();
             let (local_mesg_num, _) = lru.put(&item);
             assert_eq!(local_mesg_num, i as u8);
-            assert_eq!(lru.bucket[SIZE - 1], i);
+            assert_eq!(lru.bucket[SIZE - 1], i as u8);
         }
 
         // check index exist
-        assert_eq!(lru.bucket_index(&lru.items[lru.bucket[1]]), Some(1));
+        assert_eq!(
+            lru.bucket_index(&lru.items[lru.bucket[1] as usize]),
+            Some(1)
+        );
 
         // check index not exist
         assert!(lru.bucket_index(&[255, 255]).is_none());
@@ -103,5 +147,25 @@ mod tests {
         lru.reset();
         assert_eq!(lru.bucket.len(), 0);
         assert_eq!(lru.items.len(), SIZE);
+    }
+
+    #[test]
+    fn test_reserve_with_capacity_tiers() {
+        let mut v = Vec::<u8>::new();
+
+        reserve_with_capacity_tiers(&mut v, 10);
+        assert_eq!(v.capacity(), 389);
+
+        reserve_with_capacity_tiers(&mut v, 256);
+        assert_eq!(v.capacity(), 389);
+
+        reserve_with_capacity_tiers(&mut v, 510);
+        assert_eq!(v.capacity(), 772);
+
+        reserve_with_capacity_tiers(&mut v, 1000);
+        assert_eq!(v.capacity(), 1154);
+
+        reserve_with_capacity_tiers(&mut v, 1200);
+        assert_eq!(v.capacity(), 1537);
     }
 }


### PR DESCRIPTION
Allocator usually allocate double the size and it depends on the size of the current items which make it not deterministic. This fixed-size capacity tiers make the `Lru` behave slightly deterministic. 