### PR TITLE
refactor!: encoder validation related items

### DIFF
--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -6,15 +6,13 @@ mod validator;
 use crate::{
     crc16::Crc16,
     encoder::lru::Lru,
-    encoder::validator::{MessageValidator, MessageValidatorError},
-    profile::{
-        PROFILE_VERSION,
-        typedef::{DateTime, MesgNum},
-    },
-    proto::{Error as ProtocolError, *},
+    encoder::validator::MessageValidator,
+    profile::{PROFILE_VERSION, typedef::DateTime},
+    proto::*,
 };
 use alloc::vec::Vec;
 use embedded_io::{Seek, SeekFrom, Write};
+pub use validator::{FieldValidationError, MessageValidationError};
 
 /// Encoder Error
 #[derive(Debug)]
@@ -26,23 +24,12 @@ pub enum Error<E> {
     },
     /// Empty messages, no data to be encoded.
     EmptyMessages,
-    /// Protocol violation related error.
-    Protocol {
-        /// Message index
-        mesg_index: usize,
-        /// Message number
-        mesg_num: MesgNum,
-        /// Protocol error
-        err: ProtocolError,
-    },
     /// Message validation related error.
     MessageValidation {
         /// Message index
         mesg_index: usize,
-        /// Message number
-        mesg_num: MesgNum,
-        /// Message Validator error
-        err: MessageValidatorError,
+        /// Message validation error
+        err: MessageValidationError,
     },
 }
 
@@ -54,17 +41,9 @@ where
         match &self {
             Self::Io { err } => write!(f, "io error: {}", err),
             Self::EmptyMessages => write!(f, "messages is empty"),
-            Self::Protocol {
-                mesg_index,
-                mesg_num,
-                err,
-            } => write!(f, "mesg: index: {}, num: {}: {}", mesg_index, mesg_num, err),
-
-            Self::MessageValidation {
-                mesg_index,
-                mesg_num,
-                err,
-            } => write!(f, "mesg: index: {}, num: {}: {}", mesg_index, mesg_num, err),
+            Self::MessageValidation { mesg_index, err } => {
+                write!(f, "message validation: mesg_index {}: {}", mesg_index, err)
+            }
         }
     }
 }
@@ -137,13 +116,17 @@ impl<W: Write + Seek> Encoder<W> {
         self.validate(fit)?;
 
         self.encode_file_header(&mut fit.file_header)?;
-        self.encode_messages(&mut fit.messages)?;
+
+        for mesg in &mut fit.messages {
+            self.encode_message(mesg)?;
+        }
 
         fit.crc = self.crc16.sum16();
         self.encode_crc()?;
 
         self.update_file_header(&mut fit.file_header)?;
         self.reset();
+
         Ok(())
     }
 
@@ -159,25 +142,17 @@ impl<W: Write + Seek> Encoder<W> {
         if fit.messages.is_empty() {
             return Err(Error::EmptyMessages);
         }
+
         let protocol_version = fit.file_header.protocol_version;
         for (i, mesg) in fit.messages.iter_mut().enumerate() {
-            if let Err(err) = protocol_version.validate_message(mesg) {
-                return Err(Error::Protocol {
-                    mesg_index: i,
-                    mesg_num: mesg.num,
-                    err,
-                });
+            if let Err(err) = self
+                .message_validator
+                .validate_message(mesg, protocol_version)
+            {
+                return Err(Error::MessageValidation { mesg_index: i, err });
             }
         }
-        for (i, mesg) in fit.messages.iter_mut().enumerate() {
-            if let Err(err) = self.message_validator.validate_message(mesg) {
-                return Err(Error::MessageValidation {
-                    mesg_index: i,
-                    mesg_num: mesg.num,
-                    err,
-                });
-            }
-        }
+
         Ok(())
     }
 
@@ -193,15 +168,12 @@ impl<W: Write + Seek> Encoder<W> {
         }
 
         file_header.data_type = FileHeader::DATA_TYPE;
-        file_header.crc = 0; // recalculated
 
-        let buf = &mut self.buf;
-        buf.clear();
+        self.buf.clear();
+        write_file_header_to_vec(&mut self.buf, file_header);
 
-        write_file_header_to_vec(buf, file_header);
-
-        self.writer.write_all(buf)?;
-        self.n += buf.len() as i64;
+        self.writer.write_all(&self.buf)?;
+        self.n += self.buf.len() as i64;
 
         Ok(())
     }
@@ -226,13 +198,6 @@ impl<W: Write + Seek> Encoder<W> {
 
         let n = self.buf.len() as i64;
         self.writer.seek(SeekFrom::Current(size - n))?;
-        Ok(())
-    }
-
-    fn encode_messages(&mut self, messages: &mut [Message]) -> Result<(), Error<W::Error>> {
-        for mesg in messages {
-            self.encode_message(mesg)?;
-        }
         Ok(())
     }
 
@@ -371,7 +336,7 @@ fn write_message_definition_to_vec(buf: &mut Vec<u8>, mesg: &Message, arch: u8) 
     for field in &mesg.fields {
         buf.push(field.num);
         buf.push(field.value.size() as u8);
-        buf.push(field.profile_type.base_type().0)
+        buf.push(field.profile_type.base_type().0);
     }
 
     if mesg.developer_fields.is_empty() {

--- a/rustyfit/src/encoder/validator.rs
+++ b/rustyfit/src/encoder/validator.rs
@@ -5,45 +5,65 @@ use crate::{
         mesgdef,
         typedef::{FitBaseType, MesgNum},
     },
-    proto::{LocalFieldDescription, Message, Value},
+    proto::{LocalFieldDescription, Message, ProtocolVersion, Value},
 };
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 
+/// Error occurs during message validation
 #[derive(Debug)]
-pub enum MessageValidatorError {
-    /// Message has no fields.
-    NoFields,
-    /// Field value integrity
-    FieldValueIntegrity {
+#[allow(missing_docs)]
+pub enum MessageValidationError {
+    /// Message has zero fields and zero developer fields.
+    EmptyMessageData,
+    /// Developer data is unsupported in protocol v1.
+    UnsupportedDeveloperData,
+    /// Some base types are unsupported in protocol v1.
+    UnsupportedFitBaseType {
         field_index: usize,
-        err: IntegrityError,
+        base_type: FitBaseType,
     },
-    /// Developer field value integrity
-    DeveloperFieldValueIntegrity {
+    /// Field contains invalid data.
+    FieldValidation {
+        field_index: usize,
+        err: FieldValidationError,
+    },
+    /// DeveloperField contains invalid data.
+    DeveloperFieldValidation {
         developer_field_index: usize,
-        err: IntegrityError,
+        err: FieldValidationError,
     },
-    /// Missing developer data id
+    /// Developer fields must have prior DeveloperDataId message.
     MissingDeveloperDataId { developer_field_index: usize },
-    /// Missing field description
+    /// Developer fields must have prior FieldDescription message.
     MissingFieldDescription { developer_field_index: usize },
 }
 
-impl core::fmt::Display for MessageValidatorError {
+impl core::fmt::Display for MessageValidationError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
-            Self::NoFields => write!(f, "no fields"),
-            Self::FieldValueIntegrity { field_index, err } => write!(
+            Self::EmptyMessageData => {
+                write!(f, "message has zero fields and zero developer fields")
+            }
+            Self::UnsupportedDeveloperData => {
+                write!(f, "developer data is unsupported for protocol v1")
+            }
+            Self::UnsupportedFitBaseType {
+                field_index,
+                base_type,
+            } => write!(
                 f,
-                "value integrity: field index {}, err: {}",
-                field_index, err
+                "fit base type {} on field index {} is unsupported for protocol v1",
+                base_type, field_index
             ),
-            Self::DeveloperFieldValueIntegrity {
+            Self::FieldValidation { field_index, err } => {
+                write!(f, "field validation: field index {}: {}", field_index, err)
+            }
+            Self::DeveloperFieldValidation {
                 developer_field_index,
                 err,
             } => write!(
                 f,
-                "value integrity: developer field index {}, err: {}",
+                "developer field validation: developer field index {}: {}",
                 developer_field_index, err
             ),
             Self::MissingDeveloperDataId {
@@ -64,34 +84,35 @@ impl core::fmt::Display for MessageValidatorError {
     }
 }
 
+impl core::error::Error for MessageValidationError {}
+
+/// Error occurs during value `fields` or `developer_fields` validation.
+/// The context depends on where the validation takes place.
 #[derive(Debug)]
-pub enum IntegrityError {
-    /// Value and base type is not align
-    ValueBaseTypeNotAlign {
-        value: Value,
-        base_type: FitBaseType,
-    },
-    /// Invalid UTF-8 string in a value.
-    InvalidUTF8String(String),
-    /// Value size exceed maximum limit (255 bytes)
-    ValueSizeExceedLimit,
+#[allow(missing_docs)]
+pub enum FieldValidationError {
+    ValueTypeInvalid,
+    StringValueInvalid,
+    ValueSizeLimitExceeded,
+    FieldLimitExceeded,
 }
 
-impl core::fmt::Display for IntegrityError {
+impl core::fmt::Display for FieldValidationError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
-            Self::ValueBaseTypeNotAlign { value, base_type } => {
-                write!(
-                    f,
-                    "value {:?} is not align with base type {}",
-                    value, base_type
-                )
+            Self::ValueTypeInvalid => write!(f, "value type is invalid"),
+            Self::StringValueInvalid => write!(f, "string value contains invalid UTF-8 characters"),
+            Self::ValueSizeLimitExceeded => {
+                write!(f, "value's size in bytes exceeds 255 bytes limit")
             }
-            Self::InvalidUTF8String(value) => write!(f, "invalid UTF-8 string: {:?}", value),
-            Self::ValueSizeExceedLimit => write!(f, "value's size exceed limit"),
+            Self::FieldLimitExceeded => {
+                write!(f, "fields or developer_fields exceeds 255 items limit")
+            }
         }
     }
 }
+
+impl core::error::Error for FieldValidationError {}
 
 pub(super) struct MessageValidator {
     developer_data_index_seen: [u64; 4],
@@ -109,7 +130,26 @@ impl MessageValidator {
     pub(super) fn validate_message(
         &mut self,
         mesg: &mut Message,
-    ) -> Result<(), MessageValidatorError> {
+        protocol_version: ProtocolVersion,
+    ) -> Result<(), MessageValidationError> {
+        // Some data are unsupported on protocol v1
+        if protocol_version == ProtocolVersion::V1 {
+            if !mesg.developer_fields.is_empty() {
+                return Err(MessageValidationError::UnsupportedDeveloperData);
+            }
+
+            for (i, field) in mesg.fields.iter().enumerate() {
+                if field.profile_type.base_type().0 & FitBaseType::NUM_MASK
+                    > FitBaseType::BYTE.0 & FitBaseType::NUM_MASK
+                {
+                    return Err(MessageValidationError::UnsupportedFitBaseType {
+                        base_type: field.profile_type.base_type(),
+                        field_index: i,
+                    });
+                }
+            }
+        }
+
         let mut valid = 0usize;
         for i in 0..mesg.fields.len() {
             let field = &mesg.fields[i];
@@ -117,17 +157,17 @@ impl MessageValidator {
                 continue;
             }
 
-            if let Err(err) = self.value_integrity(&field.value, field.profile_type.base_type()) {
-                return Err(MessageValidatorError::FieldValueIntegrity {
+            if let Err(err) = self.validate_field(&field.value, field.profile_type.base_type()) {
+                return Err(MessageValidationError::FieldValidation {
                     field_index: i,
                     err,
                 });
             }
 
             if valid == 255 {
-                return Err(MessageValidatorError::FieldValueIntegrity {
+                return Err(MessageValidationError::FieldValidation {
                     field_index: i,
-                    err: IntegrityError::ValueSizeExceedLimit,
+                    err: FieldValidationError::FieldLimitExceeded,
                 });
             }
 
@@ -157,13 +197,12 @@ impl MessageValidator {
             _ => {}
         };
 
-        valid = 0;
         for i in 0..mesg.developer_fields.len() {
             let dev_field = &mesg.developer_fields[i];
 
             let x = dev_field.developer_data_index;
             if (self.developer_data_index_seen[(x as usize) >> 6] >> (x & 63)) & 1 == 0 {
-                return Err(MessageValidatorError::MissingDeveloperDataId {
+                return Err(MessageValidationError::MissingDeveloperDataId {
                     developer_field_index: i,
                 });
             }
@@ -173,71 +212,60 @@ impl MessageValidator {
                     && v.field_definition_number == dev_field.num
             }) {
                 Some(v) => {
-                    if !dev_field.value.is_valid(v.fit_base_type_id) {
-                        continue;
-                    }
-                    if let Err(err) = self.value_integrity(&dev_field.value, v.fit_base_type_id) {
-                        return Err(MessageValidatorError::DeveloperFieldValueIntegrity {
+                    if let Err(err) = self.validate_field(&dev_field.value, v.fit_base_type_id) {
+                        return Err(MessageValidationError::DeveloperFieldValidation {
                             developer_field_index: i,
                             err,
                         });
                     }
                 }
                 None => {
-                    return Err(MessageValidatorError::MissingFieldDescription {
+                    return Err(MessageValidationError::MissingFieldDescription {
                         developer_field_index: i,
                     });
                 }
             };
 
-            if valid == 255 {
-                return Err(MessageValidatorError::DeveloperFieldValueIntegrity {
+            if i == 255 {
+                return Err(MessageValidationError::DeveloperFieldValidation {
                     developer_field_index: i,
-                    err: IntegrityError::ValueSizeExceedLimit,
+                    err: FieldValidationError::FieldLimitExceeded,
                 });
             }
-
-            if i != valid {
-                mesg.developer_fields.swap(i, valid);
-            }
-
-            valid += 1;
         }
 
-        mesg.developer_fields.truncate(valid);
-
         if mesg.fields.is_empty() && mesg.developer_fields.is_empty() {
-            return Err(MessageValidatorError::NoFields);
+            return Err(MessageValidationError::EmptyMessageData);
         }
 
         Ok(())
     }
 
-    fn value_integrity(&self, value: &Value, base_type: FitBaseType) -> Result<(), IntegrityError> {
+    fn validate_field(
+        &self,
+        value: &Value,
+        base_type: FitBaseType,
+    ) -> Result<(), FieldValidationError> {
         if !value.is_align(base_type) {
-            return Err(IntegrityError::ValueBaseTypeNotAlign {
-                value: value.clone(),
-                base_type,
-            });
+            return Err(FieldValidationError::ValueTypeInvalid);
         }
 
         match value {
             Value::String(v) if core::str::from_utf8(v.as_bytes()).is_err() => {
-                return Err(IntegrityError::InvalidUTF8String(v.clone()));
+                return Err(FieldValidationError::StringValueInvalid);
             }
             Value::VecString(v) => {
                 for x in v.iter() {
                     if core::str::from_utf8(x.as_bytes()).is_err() {
-                        return Err(IntegrityError::InvalidUTF8String(x.clone()));
+                        return Err(FieldValidationError::StringValueInvalid);
                     }
                 }
             }
             _ => {}
         };
 
-        let size = value.size();
-        if size > 255 {
-            return Err(IntegrityError::ValueSizeExceedLimit);
+        if value.size() > 255 {
+            return Err(FieldValidationError::ValueSizeLimitExceeded);
         }
 
         Ok(())

--- a/rustyfit/src/lib.rs
+++ b/rustyfit/src/lib.rs
@@ -6,7 +6,8 @@ pub use decoder::{
     Builder as DecoderBuilder, Decoder, Error as DecoderError, Event as DecoderEvent,
 };
 pub use encoder::{
-    Builder as EncoderBuilder, Encoder, Endianness, Error as EncoderError, HeaderOption,
+    Builder as EncoderBuilder, Encoder, Endianness, Error as EncoderError, FieldValidationError,
+    HeaderOption, MessageValidationError,
 };
 
 /// The `profile` module represents FIT Global Profile containing types and messages generated from Profile.xlsx.

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -6,34 +6,6 @@ use crate::profile::{
 };
 use alloc::{string::String, vec::Vec};
 
-/// Defined errors returned from proto module.
-#[cfg_attr(test, derive(PartialEq))]
-#[derive(Debug)]
-pub enum Error {
-    /// Protocol Validator's error when Protocol Version 1.0 constains developer data.
-    ProtocolViolationDeveloperData,
-    /// Protocol Validator's error when Protocol Version 1.0 has base_type number more than byte number.
-    ProtocolViolationUnsupportedBaseType(FitBaseType),
-    /// Marshal error when Value is invalid.
-    InvalidValue,
-}
-
-impl core::fmt::Display for Error {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::ProtocolViolationDeveloperData => {
-                write!(f, "protocol version 1.0 do not support developer data")
-            }
-            Self::ProtocolViolationUnsupportedBaseType(base_type) => {
-                write!(f, "protocol version 1.0 do not support type {}", base_type)
-            }
-            Self::InvalidValue => write!(f, "invalid proto::Value"),
-        }
-    }
-}
-
-impl core::error::Error for Error {}
-
 /// FIT is FIT protocol data representative.
 #[derive(Debug, Default)]
 pub struct FIT {
@@ -953,27 +925,6 @@ impl ProtocolVersion {
     /// Returns minor version.
     pub fn minor(self) -> u8 {
         self.0 | ((1 << 4) - 1)
-    }
-}
-
-impl ProtocolVersion {
-    /// Validates whether the message contains unsupported data for the targeted protocol version.
-    pub(crate) fn validate_message(self, mesg: &Message) -> Result<(), Error> {
-        if self == ProtocolVersion::V1 {
-            if !mesg.developer_fields.is_empty() {
-                return Err(Error::ProtocolViolationDeveloperData);
-            }
-            for field in &mesg.fields {
-                if field.profile_type.base_type().0 & FitBaseType::NUM_MASK
-                    > FitBaseType::BYTE.0 & FitBaseType::NUM_MASK
-                {
-                    return Err(Error::ProtocolViolationUnsupportedBaseType(
-                        field.profile_type.base_type(),
-                    ));
-                }
-            }
-        }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
- We group validation related items in one place in `encoder::validator`, as a result, `ProtocolError` is now removed, its items are merged into `MessageValidationError` instead.
- `MessageValidatorError` is renamed to `MessageValidationError` and it's no longer allocate when validating string, the field index is returned anyway so if users want to take a look at the value, they can still locate it or they can just print/display the error.
- Encoder's Error is restructured for more concise items.
- Various chore: `fn encode_messages` is inlined and clean up some code.
- `MessageValidationError` and `FieldValidationError` are now exported so user can pattern-matched it.