### PR TITLE
fix: mesgdef array to vec conversion

### DIFF
--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -427,7 +427,7 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 		value = fmt.Sprintf(`match &vals[%d] {
 			Value::Vec%s(v) => {
 				let mut arr: [%s; %d] = %s;
-				for (i, x) in v.iter().enumerate() {
+				for (i, x) in v.iter().take(%d).enumerate() {
 					arr[i] = %s;
 				}
 				arr
@@ -437,6 +437,7 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 			num,
 			valueEnumType,
 			rustType, fixedArraySize, arrayValue,
+			fixedArraySize,
 			rshValue,
 			arrayValue,
 		)

--- a/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
@@ -125,7 +125,7 @@ impl From<&Message> for ExdDataFieldConfiguration {
             title: match &vals[5] {
                 Value::VecString(v) => {
                     let mut arr: [String; 32] = Default::default();
-                    for (i, x) in v.iter().enumerate() {
+                    for (i, x) in v.iter().take(32).enumerate() {
                         arr[i] = x.to_owned();
                     }
                     arr

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -206,7 +206,7 @@ impl From<&Message> for GpsMetadata {
             velocity: match &vals[7] {
                 Value::VecInt16(v) => {
                     let mut arr: [i16; 3] = [i16::MAX; 3];
-                    for (i, x) in v.iter().enumerate() {
+                    for (i, x) in v.iter().take(3).enumerate() {
                         arr[i] = *x;
                     }
                     arr

--- a/rustyfit/src/profile/mesgdef/monitoring.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring.rs
@@ -422,7 +422,7 @@ impl From<&Message> for Monitoring {
             activity_time: match &vals[16] {
                 Value::VecUint16(v) => {
                     let mut arr: [u16; 8] = [u16::MAX; 8];
-                    for (i, x) in v.iter().enumerate() {
+                    for (i, x) in v.iter().take(8).enumerate() {
                         arr[i] = *x;
                     }
                     arr

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -1481,7 +1481,7 @@ impl From<&Message> for Record {
             compressed_speed_distance: match &vals[8] {
                 Value::VecUint8(v) => {
                     let mut arr: [u8; 3] = [u8::MAX; 3];
-                    for (i, x) in v.iter().enumerate() {
+                    for (i, x) in v.iter().take(3).enumerate() {
                         arr[i] = *x;
                     }
                     arr

--- a/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
@@ -125,7 +125,7 @@ impl From<&Message> for ThreeDSensorCalibration {
             offset_cal: match &vals[4] {
                 Value::VecInt32(v) => {
                     let mut arr: [i32; 3] = [i32::MAX; 3];
-                    for (i, x) in v.iter().enumerate() {
+                    for (i, x) in v.iter().take(3).enumerate() {
                         arr[i] = *x;
                     }
                     arr
@@ -135,7 +135,7 @@ impl From<&Message> for ThreeDSensorCalibration {
             orientation_matrix: match &vals[5] {
                 Value::VecInt32(v) => {
                     let mut arr: [i32; 9] = [i32::MAX; 9];
-                    for (i, x) in v.iter().enumerate() {
+                    for (i, x) in v.iter().take(9).enumerate() {
                         arr[i] = *x;
                     }
                     arr

--- a/rustyfit/src/profile/mesgdef/user_profile.rs
+++ b/rustyfit/src/profile/mesgdef/user_profile.rs
@@ -288,7 +288,7 @@ impl From<&Message> for UserProfile {
             global_id: match &vals[23] {
                 Value::VecUint8(v) => {
                     let mut arr: [u8; 6] = [u8::MAX; 6];
-                    for (i, x) in v.iter().enumerate() {
+                    for (i, x) in v.iter().take(6).enumerate() {
                         arr[i] = *x;
                     }
                     arr


### PR DESCRIPTION
Limit iterator to match the array size to avoid panic when the vector is bigger than the array.