### PR TITLE
chore: remove README.md from cargo include

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,4 @@ include = [
     "Cargo.lock",
     "src/**/*",
     "LICENSE*",
-    "README.md",
 ]


### PR DESCRIPTION
README.md is already included. This include cause `benches/README.md` to be included as well. To prevent this unexpected behaviour in the future, we must run this following command to check:
```sh
cargo package --list
```

Ref: https://doc.rust-lang.org/cargo/reference/manifest.html