### PR TITLE
refactor!: make it static-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,20 @@ At the moment, I can't make this library heapless without complicating the code.
 
 ## Usage
 
+> Note: Since the API is still evolving, usage may vary between versions. See [creates.io](https://crates.io/crates/rustyfit) for spesific version. 
+
 For [#![no_std]](https://docs.rust-embedded.org/book/intro/no-std.html), you need to provide [#[global_allocator]](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute) since this library requires allocation.
 
 For [std](https://doc.rust-lang.org/std), you need to wrap `std::io`'s [Read](https://doc.rust-lang.org/std/io/trait.Read.html) or [Write](https://doc.rust-lang.org/std/io/trait.Write.html) with [embedded_io_adapters::std:FromStd](https://docs.rs/embedded-io-adapters/0.7.0/embedded_io_adapters/std/struct.FromStd.html). We will provide examples in `std` for a broad audience and simplicity.
 
 ### Decoding
 
+Decoder is stateless and static-friendly. We can reuse it to decode multiple readers or decode same reader multiple times if the reader contains a chained FIT file.
+
 #### Decode
 
 Decoder's `decode` allows us to interact with FIT files directly through their original protocol messages' structure. 
 
-NOTE: First call will return either Ok(Some(fit)) or Err(err), never Ok(None).
-On next call, it may return Ok(None) to indicate that no more FIT sequence in the file.
 
 ```rust
 use embedded_io_adapters::std::FromStd;
@@ -35,13 +37,21 @@ use rustyfit::{Decoder, profile::{mesgdef, typedef}, proto::Value};
 use std::{error::Error, fs::File, io::BufReader};
 
 fn main() -> Result<(), Box<dyn Error>> {
+    let mut dec = Decoder::new();
+
     let name = "Activity.fit";
     let f = File::open(name)?;
     let br = BufReader::new(f);
-    let mut dec = Decoder::new(FromStd::new(br));
+    let mut reader = FromStd::new(br);
 
-    // SAFETY: First decode call is either Ok(Some(fit)) or Err(err), never Ok(None).
-    let fit = dec.decode()?.unwrap(); 
+    let fit = match dec.decode(&mut reader)? {
+        Some(fit) => fit,
+        None => {
+            // First decode call to reader should be `Ok` or `Err`.
+            // Except, reader is already empty to begin with.
+            return Err(Box::from("empty reader"));
+        }
+    };
 
     println!("file_header's data_size: {}", fit.file_header.data_size);
     println!("messages count: {}", fit.messages.len());
@@ -53,21 +63,22 @@ fn main() -> Result<(), Box<dyn Error>> {
             println!("file type: {}", typedef::File(v));
         }
     }
-    
+
     Ok(())
-    
+
     // # Output:
     // file_header's data_size: 94080
     // messages count: 3611
     // file type: activity
 }
+
 ```
 
 The `decode` method can be invoked multiple times to decode chained FIT file until it return Ok(None) or Err(err). 
 We can decode chained FIT file using `while let`, e.g:
 
 ```rust
-    while let Some(fit) = dec.decode()? {
+    while let Some(fit) = dec.decode(&mut reader)? {
         println!("file_header's data_size: {}", fit.file_header.data_size);
         println!("messages count: {}", fit.messages.len());
         for field in &fit.messages[0].fields {
@@ -92,12 +103,14 @@ use rustyfit::{Decoder, DecoderEvent, profile::{mesgdef, typedef}};
 use std::{error::Error, fs::File, io::BufReader};
 
 fn main() -> Result<(), Box<dyn Error>> {
+    let mut dec = Decoder::new();
+
     let name = "Activity.fit";
     let f = File::open(name)?;
     let br = BufReader::new(f);
-    let mut dec = Decoder::new(FromStd::new(br));
+    let mut reader = FromStd::new(br);
 
-    dec.decode_with(|event| match event {
+    dec.decode_with(&mut reader, |event| match event {
         DecoderEvent::FileHeader(_) => {},
         DecoderEvent::MessageDefinition(_) => {},
         DecoderEvent::Message(mesg) => {
@@ -126,7 +139,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 The `decode_with` method can be invoked multiple times to decode chained FIT file until it return Ok(false) or Err(err). 
 
 ```rust
-    while dec.decode_with(|event| {
+    while dec.decode_with(&mut reader, |event| {
         if let DecoderEvent::Message(mesg) = event {
             if mesg.num == typedef::MesgNum::SESSION {
                 // Convert mesg into Session struct
@@ -148,10 +161,12 @@ Create `Decoder` instance with options using `Decoder::builder()` or `DecoderBui
 let mut dec = Decoder::builder()
         .checksum(false)
         .expand_components(false)
-        .build(reader);
+        .build();
 ```
 
 ### Encoding
+
+Encoder is stateless and static-friendly. We can reuse it to encode one or multiple FITs into one or multiple writers.
 
 #### Encode
 
@@ -163,11 +178,6 @@ use rustyfit::{Encoder, profile::{ProfileType, mesgdef, typedef}, proto::{FIT, F
 use std::{error::Error, fs::File, io::{BufWriter, Write}};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let fout_name = "output.fit";
-    let fout = File::create(fout_name)?;
-    let mut bw = BufWriter::new(fout);
-    let mut enc = Encoder::new(FromStd::new(&mut bw));
-
     let mut fit = FIT {
         messages: vec![
             Message {
@@ -222,7 +232,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         ..Default::default()
     };
 
-    enc.encode(&mut fit)?;
+    let mut enc = Encoder::new();
+    
+    let fout_name = "output.fit";
+    let fout = File::create(fout_name)?;
+    let mut bw = BufWriter::new(fout);
+    let mut writer = FromStd::new(&mut bw);
+
+    enc.encode(&mut writer, &mut fit)?;
     bw.flush()?;
 
     Ok(())
@@ -239,11 +256,6 @@ use rustyfit::{Encoder, profile::{mesgdef, typedef}, proto::{FIT, Message}};
 use std::{error::Error, fs::File, io::{BufWriter, Write}};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let fout_name = "output.fit";
-    let fout = File::create(fout_name)?;
-    let mut bw = BufWriter::new(fout);
-    let mut enc = Encoder::new(FromStd::new(&mut bw));
-
     let mut fit = FIT {
         messages: vec![
             {
@@ -264,7 +276,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         ..Default::default()
     };
 
-    enc.encode(&mut fit)?;
+    let mut enc = Encoder::new();
+    
+    let fout_name = "output.fit";
+    let fout = File::create(fout_name)?;
+    let mut bw = BufWriter::new(fout);
+    let mut writer = FromStd::new(&mut bw);
+
+    enc.encode(&mut writer, &mut fit)?;
     bw.flush()?;
 
     Ok(())
@@ -280,7 +299,7 @@ let mut enc = Encoder::builder()
         .endianness(Endianness::BigEndian)
         .protocol_version(ProtocolVersion::V2)
         .header_option(HeaderOption::Compressed(3))
-        .build(writer);
+        .build();
 ```
 
 ## License

--- a/examples/no_std_decode/src/main.rs
+++ b/examples/no_std_decode/src/main.rs
@@ -8,6 +8,7 @@ use rustyfit::{
     Decoder, DecoderEvent,
     profile::{mesgdef, typedef},
 };
+use spinning_top::Spinlock;
 use talc::{DefaultBinning, source::Claim, sync::TalcLock};
 
 #[global_allocator]
@@ -18,6 +19,8 @@ static A: TalcLock<spinning_top::RawSpinlock, Claim, DefaultBinning> = TalcLock:
 });
 
 static FIT_FILE: &[u8] = include_bytes!("sample.fit"); // Embed file
+
+static DECODER: Spinlock<Decoder> = Spinlock::new(Decoder::new());
 
 macro_rules! printf {
     ($($arg:tt)*) => {
@@ -33,9 +36,9 @@ macro_rules! printf {
 fn _start() -> ! {
     printf!("Hello, world!\n");
 
-    let mut dec = Decoder::new(FIT_FILE);
+    let mut dec = DECODER.lock();
 
-    dec.decode_with(|e| match e {
+    dec.decode_with(FIT_FILE, |e| match e {
         DecoderEvent::Message(v) => {
             if v.num == typedef::MesgNum::SESSION {
                 let ses = mesgdef::Session::from(v);
@@ -60,6 +63,7 @@ fn _start() -> ! {
 #[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
+    printf!("{}\n", _info);
     loop {}
 }
 

--- a/rustyfit/benches/decoder.rs
+++ b/rustyfit/benches/decoder.rs
@@ -10,8 +10,9 @@ pub fn bench_decode(c: &mut Criterion) {
 
     c.bench_function("decode default", |b| {
         b.iter(|| {
-            let mut dec = Decoder::new(black_box(FromStd::new(Cursor::new(&file_bytes))));
-            dec.decode().unwrap();
+            let mut dec = Decoder::new();
+            let mut reader = black_box(FromStd::new(Cursor::new(&file_bytes)));
+            dec.decode(&mut reader).unwrap();
         })
     });
 
@@ -20,15 +21,17 @@ pub fn bench_decode(c: &mut Criterion) {
             let mut dec = Decoder::builder()
                 .checksum(false)
                 .expand_components(false)
-                .build(black_box(FromStd::new(Cursor::new(&file_bytes))));
-            dec.decode().unwrap();
+                .build();
+            let mut reader = black_box(FromStd::new(Cursor::new(&file_bytes)));
+            dec.decode(&mut reader).unwrap();
         })
     });
 
     c.bench_function("decode_with", |b| {
         b.iter(|| {
-            let mut dec = Decoder::new(black_box(FromStd::new(Cursor::new(&file_bytes))));
-            dec.decode_with(|_| {}).unwrap();
+            let mut dec = Decoder::new();
+            let mut reader = black_box(FromStd::new(Cursor::new(&file_bytes)));
+            dec.decode_with(&mut reader, |_| {}).unwrap();
         })
     });
 
@@ -37,8 +40,9 @@ pub fn bench_decode(c: &mut Criterion) {
             let mut dec = Decoder::builder()
                 .checksum(false)
                 .expand_components(false)
-                .build(black_box(FromStd::new(Cursor::new(&file_bytes))));
-            dec.decode_with(|_| {}).unwrap();
+                .build();
+            let mut reader = black_box(FromStd::new(Cursor::new(&file_bytes)));
+            dec.decode_with(&mut reader, |_| {}).unwrap();
         })
     });
 }

--- a/rustyfit/benches/encoder.rs
+++ b/rustyfit/benches/encoder.rs
@@ -6,16 +6,19 @@ use std::{hint::black_box, io::Cursor};
 const TEST_FILE: &str = "tests/data/large.fit";
 
 pub fn bench_encode(c: &mut Criterion) {
+    let mut dec = Decoder::new();
     let file_bytes = std::fs::read(TEST_FILE).unwrap();
-    let mut dec = Decoder::new(FromStd::new(Cursor::new(&file_bytes)));
+    let mut reader = FromStd::new(Cursor::new(&file_bytes));
+
     let mut buf = Vec::<u8>::with_capacity(5000 * 1024); // 5 MB, large enough to avoid realloc.
 
-    while let Some(fit) = &mut dec.decode().unwrap() {
+    while let Some(fit) = &mut dec.decode(&mut reader).unwrap() {
         c.bench_function("encode default", |b| {
             b.iter(|| {
                 let cur = Cursor::new(&mut buf);
-                let mut enc = Encoder::new(black_box(FromStd::new(cur)));
-                enc.encode(fit).unwrap();
+                let mut enc = Encoder::new();
+                let mut writer = black_box(FromStd::new(cur));
+                enc.encode(&mut writer, fit).unwrap();
                 buf.clear();
             })
         });
@@ -25,8 +28,9 @@ pub fn bench_encode(c: &mut Criterion) {
                 let cur = Cursor::new(&mut buf);
                 let mut enc = Encoder::builder()
                     .header_option(HeaderOption::Normal(15))
-                    .build(black_box(FromStd::new(cur)));
-                enc.encode(fit).unwrap();
+                    .build();
+                let mut writer = black_box(FromStd::new(cur));
+                enc.encode(&mut writer, fit).unwrap();
                 buf.clear();
             })
         });
@@ -36,8 +40,9 @@ pub fn bench_encode(c: &mut Criterion) {
                 let cur = Cursor::new(&mut buf);
                 let mut enc = Encoder::builder()
                     .header_option(HeaderOption::Compressed(3))
-                    .build(black_box(FromStd::new(cur)));
-                enc.encode(fit).unwrap();
+                    .build();
+                let mut writer = black_box(FromStd::new(cur));
+                enc.encode(&mut writer, fit).unwrap();
                 buf.clear();
             })
         });

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -98,10 +98,7 @@ struct Options {
 }
 
 /// Decoder for decoding FIT file.
-pub struct Decoder<R> {
-    reader: R,
-    /// Subsequence call to decode will be optional.
-    optional_sequence: bool,
+pub struct Decoder {
     cur: u32,
     crc16: Crc16,
     mesg_definitions: [MessageDefinition; 16],
@@ -113,31 +110,38 @@ pub struct Decoder<R> {
     options: Options,
 }
 
-impl<R: Read> Decoder<R> {
+impl Decoder {
     /// Create new Decoder for decoding FIT file.
     /// For more options, use `Decoder::builder()` to build the Decoder.
-    pub fn new(reader: R) -> Self {
-        Builder::new().build(reader)
+    pub const fn new() -> Self {
+        Builder::new().build()
+    }
+
+    /// Create new Decoder with options for decoding FIT file.
+    pub const fn builder() -> Builder {
+        Builder::new()
     }
 
     /// Decode return a single FIT sequence. If it's a chained FIT file, call this method multiple times.
-    /// First call will return either Ok(Some(fit)) or Err(err), never Ok(None).
-    /// On next call, it may return Ok(None) to indicate that no more FIT sequence in the file.
-    pub fn decode(&mut self) -> Result<Option<FIT>, Error<R::Error>> {
-        let file_header = match self.decode_file_header()? {
+    pub fn decode<R>(&mut self, mut reader: R) -> Result<Option<FIT>, Error<R::Error>>
+    where
+        R: Read,
+    {
+        self.reset();
+
+        let file_header = match self.decode_file_header(&mut reader)? {
             Some(file_header) => file_header,
             None => return Ok(None),
         };
 
         let mut messages = Vec::new();
-        self.decode_message_with(file_header.data_size, |event| {
+        self.decode_message_with(&mut reader, file_header.data_size, |event| {
             if let Event::Message(mesg) = event {
                 messages.push(mesg.clone())
             }
         })?;
 
-        let crc = self.decode_crc()?;
-        self.reset();
+        let crc = self.decode_crc(&mut reader)?;
         Ok(Some(FIT {
             file_header,
             messages,
@@ -146,43 +150,48 @@ impl<R: Read> Decoder<R> {
     }
 
     /// Similar to Decode but with a closure for retrieving DecoderEvent for the current FIT sequence.
-    pub fn decode_with<F>(&mut self, mut f: F) -> Result<bool, Error<R::Error>>
+    pub fn decode_with<R, F>(&mut self, mut reader: R, mut f: F) -> Result<bool, Error<R::Error>>
     where
+        R: Read,
         F: FnMut(Event),
     {
-        let file_header = match self.decode_file_header()? {
+        self.reset();
+
+        let file_header = match self.decode_file_header(&mut reader)? {
             Some(file_header) => file_header,
             None => return Ok(false),
         };
         f(Event::FileHeader(&file_header));
 
-        self.decode_message_with(file_header.data_size, &mut f)?;
+        self.decode_message_with(&mut reader, file_header.data_size, &mut f)?;
 
-        let crc = self.decode_crc()?;
+        let crc = self.decode_crc(&mut reader)?;
         f(Event::Crc(&crc));
 
-        self.reset();
         Ok(true)
     }
 
-    fn decode_file_header(&mut self) -> Result<Option<FileHeader>, Error<R::Error>> {
+    fn decode_file_header<R>(
+        &mut self,
+        reader: &mut R,
+    ) -> Result<Option<FileHeader>, Error<R::Error>>
+    where
+        R: Read,
+    {
         let mut arr = [0u8; 14];
-        if let Err(err) = self.reader.read_exact(&mut arr[..1]) {
-            if let ReadExactError::UnexpectedEof = err
-                && self.optional_sequence
-            {
+        if let Err(err) = reader.read_exact(&mut arr[..1]) {
+            if let ReadExactError::UnexpectedEof = err {
                 return Ok(None);
             }
             return Err(Error::from(err));
         };
-        self.optional_sequence = true;
 
         let n = arr[0] as usize;
         if n != 12 && n != 14 {
             return Err(Error::NotFITFile);
         }
 
-        self.reader.read_exact(&mut arr[1..n])?;
+        reader.read_exact(&mut arr[1..n])?;
 
         if &arr[8..12] != FileHeader::DATA_TYPE.as_bytes() {
             return Err(Error::NotFITFile);
@@ -215,8 +224,11 @@ impl<R: Read> Decoder<R> {
     }
 
     /// Reads the exact number of bytes required to fill buf, increment n read bytes and calculate checksum.
-    fn read_exact_inc(&mut self, buf: &mut [u8]) -> Result<(), Error<R::Error>> {
-        self.reader.read_exact(buf)?;
+    fn read_exact_inc<R>(&mut self, reader: &mut R, buf: &mut [u8]) -> Result<(), Error<R::Error>>
+    where
+        R: Read,
+    {
+        reader.read_exact(buf)?;
         self.cur += buf.len() as u32;
         if self.options.checksum {
             self.crc16.write(buf);
@@ -224,14 +236,20 @@ impl<R: Read> Decoder<R> {
         Ok(())
     }
 
-    fn decode_message_with<F>(&mut self, data_size: u32, mut f: F) -> Result<(), Error<R::Error>>
+    fn decode_message_with<R, F>(
+        &mut self,
+        reader: &mut R,
+        data_size: u32,
+        mut f: F,
+    ) -> Result<(), Error<R::Error>>
     where
+        R: Read,
         F: FnMut(Event),
     {
         let mut arr = [0u8; 1];
 
         while self.cur < data_size {
-            self.read_exact_inc(&mut arr)?;
+            self.read_exact_inc(reader, &mut arr)?;
 
             let header = arr[0];
 
@@ -240,7 +258,7 @@ impl<R: Read> Decoder<R> {
                 let mut mesg_def = mem::take(&mut self.mesg_definitions[local_mesg_num]);
                 mesg_def.header = header;
 
-                self.decode_message_definition(&mut mesg_def)?;
+                self.decode_message_definition(reader, &mut mesg_def)?;
 
                 f(Event::MessageDefinition(&mesg_def));
 
@@ -270,7 +288,7 @@ impl<R: Read> Decoder<R> {
                 developer_fields: mem::take(&mut self.buf_developer_fields),
             };
 
-            self.decode_message_data(&mut mesg, &mesg_def)?;
+            self.decode_message_data(reader, &mut mesg, &mesg_def)?;
 
             self.mesg_definitions[local_mesg_num as usize] = mesg_def;
 
@@ -283,12 +301,16 @@ impl<R: Read> Decoder<R> {
         Ok(())
     }
 
-    fn decode_message_definition(
+    fn decode_message_definition<R>(
         &mut self,
+        reader: &mut R,
         mesg_def: &mut MessageDefinition,
-    ) -> Result<(), Error<R::Error>> {
+    ) -> Result<(), Error<R::Error>>
+    where
+        R: Read,
+    {
         let mut arr = [0u8; 765];
-        self.read_exact_inc(&mut arr[..5])?;
+        self.read_exact_inc(reader, &mut arr[..5])?;
 
         mesg_def.reserved = arr[0];
         mesg_def.arch = arr[1];
@@ -300,7 +322,7 @@ impl<R: Read> Decoder<R> {
         mesg_def.developer_field_definitions.clear();
 
         let n = arr[4] as usize * 3;
-        self.read_exact_inc(&mut arr[..n])?;
+        self.read_exact_inc(reader, &mut arr[..n])?;
 
         mesg_def.field_definitions.reserve_exact(255);
 
@@ -313,10 +335,10 @@ impl<R: Read> Decoder<R> {
             }));
 
         if mesg_def.header & Message::DEV_DATA_MASK == Message::DEV_DATA_MASK {
-            self.read_exact_inc(&mut arr[..1])?;
+            self.read_exact_inc(reader, &mut arr[..1])?;
 
             let n = arr[0] as usize * 3;
-            self.read_exact_inc(&mut arr[..n])?;
+            self.read_exact_inc(reader, &mut arr[..n])?;
 
             mesg_def.developer_field_definitions.reserve_exact(255);
 
@@ -332,11 +354,15 @@ impl<R: Read> Decoder<R> {
         Ok(())
     }
 
-    fn decode_message_data(
+    fn decode_message_data<R>(
         &mut self,
+        reader: &mut R,
         mesg: &mut Message,
         mesg_def: &MessageDefinition,
-    ) -> Result<(), Error<R::Error>> {
+    ) -> Result<(), Error<R::Error>>
+    where
+        R: Read,
+    {
         if mesg.header & Message::COMPRESSED_HEADER_MASK == Message::COMPRESSED_HEADER_MASK {
             let last_time_offset = (self.timestamp & Message::COMPRESSED_TIME_MASK as u32) as u8;
             let time_offset = mesg.header & Message::COMPRESSED_TIME_MASK;
@@ -352,9 +378,9 @@ impl<R: Read> Decoder<R> {
             });
         }
 
-        self.decode_fields(mesg, mesg_def)?;
+        self.decode_fields(reader, mesg, mesg_def)?;
 
-        self.decode_developer_fields(mesg, mesg_def)?;
+        self.decode_developer_fields(reader, mesg, mesg_def)?;
 
         // Developer Data Lookup, currently we allow missing developer_data_id
         if mesg.num == MesgNum::FIELD_DESCRIPTION {
@@ -391,16 +417,20 @@ impl<R: Read> Decoder<R> {
         Ok(())
     }
 
-    fn decode_fields(
+    fn decode_fields<R>(
         &mut self,
+        reader: &mut R,
         mesg: &mut Message,
         mesg_def: &MessageDefinition,
-    ) -> Result<(), Error<R::Error>> {
+    ) -> Result<(), Error<R::Error>>
+    where
+        R: Read,
+    {
         let mut arr = [0u8; 255];
 
         for field_def in &mesg_def.field_definitions {
             let mut buf = &mut arr[..field_def.size as usize];
-            self.read_exact_inc(buf)?;
+            self.read_exact_inc(reader, buf)?;
 
             let num = field_def.num;
             let base_type: FitBaseType;
@@ -529,16 +559,20 @@ impl<R: Read> Decoder<R> {
         }
     }
 
-    fn decode_developer_fields(
+    fn decode_developer_fields<R>(
         &mut self,
+        reader: &mut R,
         mesg: &mut Message,
         mesg_def: &MessageDefinition,
-    ) -> Result<(), Error<R::Error>> {
+    ) -> Result<(), Error<R::Error>>
+    where
+        R: Read,
+    {
         let mut arr = [0u8; 255];
 
         for dev_field_def in &mesg_def.developer_field_definitions {
             let mut buf = &mut arr[..dev_field_def.size as usize];
-            self.read_exact_inc(buf)?;
+            self.read_exact_inc(reader, buf)?;
 
             let field_desc = match self.field_descriptions.iter().find(|v| {
                 v.developer_data_index == dev_field_def.developer_data_index
@@ -576,9 +610,12 @@ impl<R: Read> Decoder<R> {
         Ok(())
     }
 
-    fn decode_crc(&mut self) -> Result<u16, Error<R::Error>> {
+    fn decode_crc<R>(&mut self, reader: &mut R) -> Result<u16, Error<R::Error>>
+    where
+        R: Read,
+    {
         let mut arr = [0u8; 2];
-        self.reader.read_exact(&mut arr)?;
+        reader.read_exact(&mut arr)?;
 
         let found = u16::from_le_bytes(arr);
         let calculated = self.crc16.sum16();
@@ -592,12 +629,25 @@ impl<R: Read> Decoder<R> {
     fn reset(&mut self) {
         self.cur = 0;
         self.crc16.reset();
-        for mesg_def in &mut self.mesg_definitions {
-            mesg_def.header = 0;
-        }
         self.accumulator.reset();
         self.timestamp = 0;
         self.field_descriptions.clear();
+
+        for mesg_def in &mut self.mesg_definitions {
+            mesg_def.header = 0;
+        }
+
+        self.buf_fields.clear();
+        self.buf_fields.reserve_exact(255);
+
+        self.buf_developer_fields.clear();
+        self.buf_developer_fields.reserve_exact(255);
+    }
+}
+
+impl Default for Decoder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -681,13 +731,6 @@ fn push_value_to_vec(vec_value: &mut Value, value: &Value) {
     }
 }
 
-impl Decoder<()> {
-    /// Create new Decoder with options for decoding FIT file.
-    pub const fn builder() -> Builder {
-        Builder::new()
-    }
-}
-
 /// Build Decoder with some options.
 pub struct Builder {
     options: Options,
@@ -718,10 +761,8 @@ impl Builder {
     }
 
     /// Build Decoder based on given options (if any).
-    pub fn build<R: Read>(&self, reader: R) -> Decoder<R> {
+    pub const fn build(&self) -> Decoder {
         Decoder {
-            reader,
-            optional_sequence: false,
             cur: 0,
             crc16: Crc16::new(),
             mesg_definitions: [const {
@@ -736,8 +777,8 @@ impl Builder {
             }; 16],
             accumulator: Accumulator::new(),
             timestamp: 0,
-            buf_fields: Vec::with_capacity(255),
-            buf_developer_fields: Vec::with_capacity(255),
+            buf_fields: Vec::new(),
+            buf_developer_fields: Vec::new(),
             field_descriptions: Vec::new(),
             options: self.options,
         }
@@ -774,7 +815,7 @@ mod tests {
 
     #[test]
     fn test_decompress_timestamp_on_decode_message_data() {
-        let mut dec = Decoder::new(Empty {});
+        let mut dec = Decoder::new();
         let timestamp = 1000;
         dec.timestamp = timestamp;
         let mesg_def = MessageDefinition::default();
@@ -785,7 +826,9 @@ mod tests {
             ..Default::default()
         };
 
-        dec.decode_message_data(&mut mesg, &mesg_def).unwrap();
+        let mut empty = Empty {};
+        dec.decode_message_data(&mut empty, &mut mesg, &mesg_def)
+            .unwrap();
         assert_eq!(dec.timestamp, timestamp + 1, "time_offset {}", time_offset);
 
         let time_offset = (timestamp + 10 & Message::COMPRESSED_TIME_MASK as u32) as u8;
@@ -794,7 +837,8 @@ mod tests {
             ..Default::default()
         };
 
-        dec.decode_message_data(&mut mesg, &mesg_def).unwrap();
+        dec.decode_message_data(&mut empty, &mut mesg, &mesg_def)
+            .unwrap();
         assert_eq!(dec.timestamp, timestamp + 10, "time_offset {}", time_offset);
     }
 

--- a/rustyfit/src/encoder/lru.rs
+++ b/rustyfit/src/encoder/lru.rs
@@ -1,4 +1,4 @@
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 
 /// Lru is an opinionated `local_mesg_num` redefiner whose algorithm mimics
 /// an LRU cache. When storage is full, the least recently used item is
@@ -10,15 +10,17 @@ pub(super) struct Lru {
 }
 
 impl Lru {
-    pub(super) fn new(n: usize) -> Self {
+    pub(super) const fn new() -> Self {
         Self {
-            items: vec![Vec::new(); n],
-            bucket: Vec::with_capacity(n),
+            items: Vec::new(),
+            bucket: Vec::new(),
         }
     }
 
-    pub(super) fn reset(&mut self) {
+    pub(super) fn reset(&mut self, n: usize) {
         self.bucket.clear();
+        self.bucket.reserve_exact(n);
+        self.items.resize(n, Vec::new());
     }
 
     pub(super) fn put(&mut self, item: &[u8]) -> (u8, bool) {
@@ -111,7 +113,8 @@ mod tests {
     #[test]
     fn test_lru() {
         const SIZE: usize = 16;
-        let mut lru = Lru::new(SIZE);
+        let mut lru = Lru::new();
+        lru.reset(SIZE);
 
         assert_eq!(lru.bucket.len(), 0);
         assert_eq!(lru.bucket.capacity(), SIZE);
@@ -144,7 +147,7 @@ mod tests {
         // check index not exist
         assert!(lru.bucket_index(&[255, 255]).is_none());
 
-        lru.reset();
+        lru.reset(SIZE);
         assert_eq!(lru.bucket.len(), 0);
         assert_eq!(lru.items.len(), SIZE);
     }

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -90,8 +90,7 @@ struct Options {
 }
 
 /// Encoder for encoding FIT file.
-pub struct Encoder<W> {
-    writer: W,
+pub struct Encoder {
     n: i64,
     data_size: u32,
     crc16: Crc16,
@@ -102,29 +101,38 @@ pub struct Encoder<W> {
     message_validator: MessageValidator,
 }
 
-impl<W: Write + Seek> Encoder<W> {
+impl Encoder {
     /// Create new Encoder for encoding FIT file.
     /// For more options, use `Encoder::builder()` to build the Encoder.
-    pub fn new(writer: W) -> Encoder<W> {
-        Builder::new().build(writer)
+    pub const fn new() -> Encoder {
+        Builder::new().build()
+    }
+
+    /// Create new Encoder with options for encoding FIT file.
+    pub const fn builder() -> Builder {
+        Builder::new()
     }
 
     /// Encode the given `fit` to the writer.
-    pub fn encode(&mut self, fit: &mut FIT) -> Result<(), Error<W::Error>> {
-        self.select_protocol_version(&mut fit.file_header);
-        self.validate(fit)?;
+    pub fn encode<W>(&mut self, mut writer: W, fit: &mut FIT) -> Result<(), Error<W::Error>>
+    where
+        W: Write + Seek,
+    {
+        self.reset();
 
-        self.encode_file_header(&mut fit.file_header)?;
+        self.select_protocol_version(&mut fit.file_header);
+        self.validate::<W>(fit)?;
+
+        self.encode_file_header(&mut writer, &mut fit.file_header)?;
 
         for mesg in &mut fit.messages {
-            self.encode_message(mesg)?;
+            self.encode_message(&mut writer, mesg)?;
         }
 
         fit.crc = self.crc16.sum16();
-        self.encode_crc()?;
+        self.encode_crc(&mut writer)?;
 
-        self.update_file_header(&mut fit.file_header)?;
-        self.reset();
+        self.update_file_header(&mut writer, &mut fit.file_header)?;
 
         Ok(())
     }
@@ -137,7 +145,10 @@ impl<W: Write + Seek> Encoder<W> {
         }
     }
 
-    fn validate(&mut self, fit: &mut FIT) -> Result<(), Error<W::Error>> {
+    fn validate<W>(&mut self, fit: &mut FIT) -> Result<(), Error<W::Error>>
+    where
+        W: Write + Seek,
+    {
         if fit.messages.is_empty() {
             return Err(Error::EmptyMessages);
         }
@@ -155,7 +166,14 @@ impl<W: Write + Seek> Encoder<W> {
         Ok(())
     }
 
-    fn encode_file_header(&mut self, file_header: &mut FileHeader) -> Result<(), Error<W::Error>> {
+    fn encode_file_header<W>(
+        &mut self,
+        writer: &mut W,
+        file_header: &mut FileHeader,
+    ) -> Result<(), Error<W::Error>>
+    where
+        W: Write + Seek,
+    {
         if file_header.size != 12 {
             file_header.size = 14;
         }
@@ -169,13 +187,20 @@ impl<W: Write + Seek> Encoder<W> {
         self.buf.clear();
         write_file_header_to_vec(&mut self.buf, file_header);
 
-        self.writer.write_all(&self.buf)?;
+        writer.write_all(&self.buf)?;
         self.n += self.buf.len() as i64;
 
         Ok(())
     }
 
-    fn update_file_header(&mut self, file_header: &mut FileHeader) -> Result<(), Error<W::Error>> {
+    fn update_file_header<W>(
+        &mut self,
+        writer: &mut W,
+        file_header: &mut FileHeader,
+    ) -> Result<(), Error<W::Error>>
+    where
+        W: Write + Seek,
+    {
         file_header.data_size = self.data_size;
 
         self.buf.clear();
@@ -188,16 +213,23 @@ impl<W: Write + Seek> Encoder<W> {
             self.crc16.reset();
         }
 
-        self.writer.seek(SeekFrom::Current(-self.n))?;
+        writer.seek(SeekFrom::Current(-self.n))?;
 
-        self.writer.write_all(&self.buf)?;
+        writer.write_all(&self.buf)?;
 
         let n = self.buf.len() as i64;
-        self.writer.seek(SeekFrom::Current(self.n - n))?;
+        writer.seek(SeekFrom::Current(self.n - n))?;
         Ok(())
     }
 
-    fn encode_message(&mut self, mesg: &mut Message) -> Result<(), Error<W::Error>> {
+    fn encode_message<W>(
+        &mut self,
+        writer: &mut W,
+        mesg: &mut Message,
+    ) -> Result<(), Error<W::Error>>
+    where
+        W: Write + Seek,
+    {
         mesg.header = Message::NORMAL_HEADER_MASK;
 
         if let HeaderOption::Compressed(_) = self.options.header_option {
@@ -222,13 +254,13 @@ impl<W: Write + Seek> Encoder<W> {
         }
 
         if is_new_mesg_def {
-            self.writer.write_all(&self.buf)?;
+            writer.write_all(&self.buf)?;
             self.crc16.write(&self.buf);
             self.n += self.buf.len() as i64;
             self.data_size += self.buf.len() as u32;
         }
 
-        self.write_message_checksum(mesg, self.options.endianness as u8)?;
+        self.write_message_checksum(writer, mesg, self.options.endianness as u8)?;
 
         Ok(())
     }
@@ -257,8 +289,16 @@ impl<W: Write + Seek> Encoder<W> {
 
     /// Write message to the writer and calculate the checksum.
     /// This method writes one Value at a time. At most, we only use 255 bytes of buffer.
-    fn write_message_checksum(&mut self, mesg: &Message, arch: u8) -> Result<(), Error<W::Error>> {
-        self.writer.write_all(&[mesg.header])?;
+    fn write_message_checksum<W>(
+        &mut self,
+        writer: &mut W,
+        mesg: &Message,
+        arch: u8,
+    ) -> Result<(), Error<W::Error>>
+    where
+        W: Write + Seek,
+    {
+        writer.write_all(&[mesg.header])?;
         self.crc16.write(&[mesg.header]);
 
         self.n += 1;
@@ -268,7 +308,7 @@ impl<W: Write + Seek> Encoder<W> {
             self.buf.clear();
             write_value_to_vec(&mut self.buf, &field.value, arch);
 
-            self.writer.write_all(&self.buf)?;
+            writer.write_all(&self.buf)?;
             self.crc16.write(&self.buf);
 
             self.n += self.buf.len() as i64;
@@ -279,7 +319,7 @@ impl<W: Write + Seek> Encoder<W> {
             self.buf.clear();
             write_value_to_vec(&mut self.buf, &dev_field.value, arch);
 
-            self.writer.write_all(&self.buf)?;
+            writer.write_all(&self.buf)?;
             self.crc16.write(&self.buf);
 
             self.n += self.buf.len() as i64;
@@ -289,9 +329,12 @@ impl<W: Write + Seek> Encoder<W> {
         Ok(())
     }
 
-    fn encode_crc(&mut self) -> Result<(), Error<W::Error>> {
+    fn encode_crc<W>(&mut self, writer: &mut W) -> Result<(), Error<W::Error>>
+    where
+        W: Write + Seek,
+    {
         let crc = self.crc16.sum16();
-        self.writer.write_all(&crc.to_le_bytes())?;
+        writer.write_all(&crc.to_le_bytes())?;
         self.n += 2;
         self.crc16.reset();
         Ok(())
@@ -301,8 +344,23 @@ impl<W: Write + Seek> Encoder<W> {
         self.n = 0;
         self.timestamp_reference = 0;
         self.data_size = 0;
-        self.lru.reset();
         self.message_validator.reset();
+
+        self.buf.clear();
+        self.buf.reserve_exact(1537); // Never realloc. [5+1+(3*255)+1+(3*255) = 1537]
+
+        self.lru.reset(
+            match self.options.header_option {
+                HeaderOption::Normal(interleave) => interleave.min(15) as usize,
+                HeaderOption::Compressed(interleave) => interleave.min(3) as usize,
+            } + 1,
+        );
+    }
+}
+
+impl Default for Encoder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -439,13 +497,6 @@ fn write_value_to_vec(w: &mut Vec<u8>, value: &Value, arch: u8) {
     };
 }
 
-impl Encoder<()> {
-    /// Create new Encoder with options for encoding FIT file.
-    pub const fn builder() -> Builder {
-        Builder::new()
-    }
-}
-
 /// Build Encoder with some options.
 pub struct Builder {
     options: Options,
@@ -485,20 +536,13 @@ impl Builder {
     }
 
     /// Build Encoder based on given options (if any).
-    pub fn build<W: Write + Seek>(&self, writer: W) -> Encoder<W> {
+    pub const fn build(&self) -> Encoder {
         Encoder {
-            writer,
             n: 0,
             data_size: 0,
             crc16: Crc16::new(),
-            lru: Lru::new(
-                match self.options.header_option {
-                    HeaderOption::Normal(interleave) => interleave.min(15) as usize,
-                    HeaderOption::Compressed(interleave) => interleave.min(3) as usize,
-                } + 1,
-            ),
-            // Fixed capacity, never realloc. [5+1+(3*255)+1+(3*255) = 1537]
-            buf: Vec::with_capacity(1537),
+            lru: Lru::new(),
+            buf: Vec::new(),
             timestamp_reference: 0,
             options: self.options,
             message_validator: MessageValidator::new(),
@@ -522,27 +566,6 @@ mod tests {
     };
     use alloc::{borrow::ToOwned, vec, vec::Vec};
     use embedded_io::{ErrorKind, ErrorType, Seek, Write};
-
-    struct Sink;
-
-    impl ErrorType for Sink {
-        type Error = ErrorKind;
-    }
-
-    impl Write for Sink {
-        fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-            Ok(buf.len())
-        }
-        fn flush(&mut self) -> Result<(), Self::Error> {
-            Ok(())
-        }
-    }
-
-    impl Seek for Sink {
-        fn seek(&mut self, _: embedded_io::SeekFrom) -> Result<u64, Self::Error> {
-            Ok(0)
-        }
-    }
 
     #[test]
     fn compress_timestamp_into_header() {
@@ -603,7 +626,7 @@ mod tests {
             },
         ];
 
-        let mut enc = Encoder::new(Sink {});
+        let mut enc = Encoder::new();
         for mesg in mesgs.iter_mut() {
             enc.compress_timestamp_into_header(mesg);
         }
@@ -996,7 +1019,7 @@ mod tests {
         };
         let n = ws.buf.len();
 
-        let mut enc = Encoder::new(&mut ws);
+        let mut enc = Encoder::new();
         enc.n = n as i64;
         enc.data_size = 1;
 
@@ -1009,7 +1032,7 @@ mod tests {
             crc: 0,                                // [83, 147] updated
         };
 
-        enc.update_file_header(&mut file_header).unwrap();
+        enc.update_file_header(&mut ws, &mut file_header).unwrap();
         let pos = ws.buf.len();
 
         assert_eq!(

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -64,13 +64,16 @@ fn do_roudtrip_with_encoder_options(
     path: &PathBuf,
     encoder_builder: EncoderBuilder,
 ) -> Result<(), Box<dyn Error>> {
+    let mut dec = Decoder::new();
+
     let file = File::open(path).unwrap();
     let br = BufReader::new(file);
-    let mut dec = Decoder::new(FromStd::new(br));
+    let mut reader = FromStd::new(br);
+
     let buf = Vec::<u8>::with_capacity(5000 * 1024); // 5 MB, large enough to avoid realloc.
     let mut cursor = Cursor::new(buf);
 
-    'decode: while let Some(fit) = &mut match dec.decode() {
+    'decode: while let Some(fit) = &mut match dec.decode(&mut reader) {
         Ok(fit) => fit,
         Err(err) => {
             if let DecoderError::ChecksumMismatch { .. } = err {
@@ -89,18 +92,19 @@ fn do_roudtrip_with_encoder_options(
     } {
         cursor.seek(SeekFrom::Start(0)).unwrap();
 
-        let mut enc = encoder_builder.build(FromStd::new(&mut cursor));
+        let mut enc = encoder_builder.build();
 
         let expected_messages = fit.messages.clone(); // Must clone since encoder mutates the value.
 
-        if let Err(err) = enc.encode(fit) {
+        let mut writer = FromStd::new(&mut cursor);
+        if let Err(err) = enc.encode(&mut writer, fit) {
             return Err(format!("encode: {:?}", err).into());
         }
 
         cursor.seek(SeekFrom::Start(0)).unwrap();
 
-        let mut dec = Decoder::new(FromStd::new(&mut cursor));
-        let result_fit = match dec.decode() {
+        let mut dec = Decoder::new();
+        let result_fit = match dec.decode(&mut FromStd::new(&mut cursor)) {
             Ok(result_fit) => result_fit,
             Err(err) => {
                 return Err(format!("re-decode the encoded file: {:?}", err).into());


### PR DESCRIPTION
`Decoder` and `Encoder` are no longer holding `T` and each `decode/encode` call is now stateless. This will make them more flexible to be reused. That alone is not enough to make it static-friendly, we also need to make its constructor, `::new()` a `const fn`. 

Whether or not we will implement #79, I believe this move is still make sense to have. We can now instantiate them in static and get its reference in stack like this:

```rs
use rustyfit::Decoder;
use spinning_top::Spinlock;

static DECODER: Spinlock<Decoder> = Spinlock::new(Decoder::new());

#[unsafe(no_mangle)]
fn _start() -> ! {
    let mut dec = DECODER.lock();
    
    printf!(
        "size_of: DECODER: {}, dec: {}\n",
        size_of_val(&DECODER)
        size_of_val(&dec),
    );
    
    // Output:
    // size_of: DECODER: 1016, dec: 8
}
```

Full working example is in [examples/no_std_decode](https://github.com/muktihari/rustyfit/tree/master/examples/no_std_decode)
