### PR TITLE
perf: field_descriptions init size to prevent reallocation

### DIFF
--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -631,7 +631,9 @@ impl Decoder {
         self.crc16.reset();
         self.accumulator.reset();
         self.timestamp = 0;
+
         self.field_descriptions.clear();
+        self.field_descriptions.reserve_exact(32);
 
         for mesg_def in &mut self.mesg_definitions {
             mesg_def.header = 0;

--- a/rustyfit/src/encoder/validator.rs
+++ b/rustyfit/src/encoder/validator.rs
@@ -274,5 +274,6 @@ impl MessageValidator {
     pub(super) fn reset(&mut self) {
         self.developer_data_index_seen.fill(0);
         self.field_descriptions.clear();
+        self.field_descriptions.reserve_exact(32);
     }
 }


### PR DESCRIPTION
The only thing that I can find related `field_descriptions` is what `Suunto` describes in their developer website, https://apizone.suunto.com/fit-description. At this time, they have 16 numbers. Let's accommodate double of it, 32, in case the number is increasing. This way, we prevent immediate reallocation when we encounter up to 32 field descriptions. I believe this is sufficient for now, we can update it later if we found more data about it.

I think this will benefit baremetal in case we stay using alloc and we can't accommodate heapless #79 