### PR TITLE
refactor!: implement streaming decoder

### DIFF
--- a/examples/no_std_decode/src/main.rs
+++ b/examples/no_std_decode/src/main.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 
 use alloc::format;
 use rustyfit::{
-    Decoder, DecoderEvent,
+    Decoder, DecoderEvent, StreamingIterator,
     profile::{mesgdef, typedef},
 };
 use spinning_top::Spinlock;
@@ -37,9 +37,10 @@ fn _start() -> ! {
     printf!("Hello, world!\n");
 
     let mut dec = DECODER.lock();
+    let mut stream = dec.stream(FIT_FILE);
 
-    dec.decode_with(FIT_FILE, |e| match e {
-        DecoderEvent::Message(v) => {
+    while let Some(event) = stream.next() {
+        if let DecoderEvent::Message(v) = event.unwrap() {
             if v.num == typedef::MesgNum::SESSION {
                 let ses = mesgdef::Session::from(v);
                 let sport = ses.sport;
@@ -47,9 +48,7 @@ fn _start() -> ! {
                 printf!("> sport: {sport:}, total_distance: {total_distance:.2} km\n");
             }
         }
-        _ => {}
-    })
-    .unwrap();
+    }
 
     printf!("Goodbye, world!\n");
     sys_exit(0);

--- a/rustyfit/benches/decoder.rs
+++ b/rustyfit/benches/decoder.rs
@@ -1,6 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use embedded_io_adapters::std::FromStd;
-use rustyfit::Decoder;
+use rustyfit::{Decoder, StreamingIterator};
 use std::{hint::black_box, io::Cursor};
 
 const TEST_FILE: &str = "tests/data/large.fit";
@@ -27,22 +27,28 @@ pub fn bench_decode(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("decode_with", |b| {
+    c.bench_function("decode stream", |b| {
         b.iter(|| {
             let mut dec = Decoder::new();
             let mut reader = black_box(FromStd::new(Cursor::new(&file_bytes)));
-            dec.decode_with(&mut reader, |_| {}).unwrap();
+            let mut stream = dec.stream(&mut reader);
+            while let Some(event) = stream.next() {
+                event.unwrap();
+            }
         })
     });
 
-    c.bench_function("decode_with no checksum no expand", |b| {
+    c.bench_function("decode stream no checksum no expand", |b| {
         b.iter(|| {
             let mut dec = Decoder::builder()
                 .checksum(false)
                 .expand_components(false)
                 .build();
             let mut reader = black_box(FromStd::new(Cursor::new(&file_bytes)));
-            dec.decode_with(&mut reader, |_| {}).unwrap();
+            let mut stream = dec.stream(&mut reader);
+            while let Some(event) = stream.next() {
+                event.unwrap();
+            }
         })
     });
 }

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -104,8 +104,7 @@ pub struct Decoder {
     mesg_definitions: [MessageDefinition; 16],
     accumulator: Accumulator,
     timestamp: u32,
-    buf_fields: Vec<Field>,
-    buf_developer_fields: Vec<DeveloperField>,
+    mesg: Message,
     field_descriptions: Vec<LocalFieldDescription>,
     options: Options,
 }
@@ -122,6 +121,32 @@ impl Decoder {
         Builder::new()
     }
 
+    /// Creates a `Stream` from a mutably borrowed `Decoder` for streaming decoding of the given `reader`.
+    ///
+    /// Example:
+    ///
+    /// ```ignore
+    /// // ...
+    /// let mut dec = Decoder::new();
+    /// let mut stream = dec.stream(&mut reader);
+    ///
+    /// while let Some(item) = stream.next() {
+    ///    // do something with the borrowed item
+    /// }
+    ///
+    /// ```
+    pub fn stream<'a, R>(&'a mut self, reader: R) -> Stream<'a, R> {
+        self.reset();
+
+        Stream {
+            reader,
+            decoder: self,
+            state: State::FileHeader,
+            file_header: FileHeader::default(),
+            crc: 0,
+        }
+    }
+
     /// Decode return a single FIT sequence. If it's a chained FIT file, call this method multiple times.
     pub fn decode<R>(&mut self, mut reader: R) -> Result<Option<FIT>, Error<R::Error>>
     where
@@ -135,40 +160,53 @@ impl Decoder {
         };
 
         let mut messages = Vec::new();
-        self.decode_message_with(&mut reader, file_header.data_size, |event| {
-            if let Event::Message(mesg) = event {
-                messages.push(mesg.clone())
+
+        while self.cur < file_header.data_size {
+            let mut arr = [0u8; 1];
+            self.read_exact_inc(&mut reader, &mut arr)?;
+
+            let header = arr[0];
+
+            if header & Message::HEADER_MASK == Message::DEFINITION_MASK {
+                let local_mesg_num = (header & Message::LOCAL_NUM_MASK) as usize;
+                let mut mesg_def = mem::take(&mut self.mesg_definitions[local_mesg_num]);
+
+                mesg_def.header = header;
+
+                let result = self.decode_message_definition(&mut reader, &mut mesg_def);
+                self.mesg_definitions[local_mesg_num] = mesg_def;
+                result?;
+
+                continue;
             }
-        })?;
+
+            let local_mesg_num = local_mesg_num_from_mesg_header(header);
+            if self.mesg_definitions[local_mesg_num].header == 0 {
+                return Err(Error::MissingMessageDefinition {
+                    local_mesg_num: local_mesg_num as u8,
+                });
+            }
+
+            let mesg_def = mem::take(&mut self.mesg_definitions[local_mesg_num]);
+            let mut mesg = mem::take(&mut self.mesg);
+
+            mesg.header = header;
+
+            let result = self.decode_message_data(&mut reader, &mut mesg, &mesg_def);
+            self.mesg_definitions[local_mesg_num] = mesg_def;
+            self.mesg = mesg;
+            result?;
+
+            messages.push(self.mesg.clone());
+        }
 
         let crc = self.decode_crc(&mut reader)?;
+
         Ok(Some(FIT {
             file_header,
             messages,
             crc,
         }))
-    }
-
-    /// Similar to Decode but with a closure for retrieving DecoderEvent for the current FIT sequence.
-    pub fn decode_with<R, F>(&mut self, mut reader: R, mut f: F) -> Result<bool, Error<R::Error>>
-    where
-        R: Read,
-        F: FnMut(Event),
-    {
-        self.reset();
-
-        let file_header = match self.decode_file_header(&mut reader)? {
-            Some(file_header) => file_header,
-            None => return Ok(false),
-        };
-        f(Event::FileHeader(&file_header));
-
-        self.decode_message_with(&mut reader, file_header.data_size, &mut f)?;
-
-        let crc = self.decode_crc(&mut reader)?;
-        f(Event::Crc(&crc));
-
-        Ok(true)
     }
 
     fn decode_file_header<R>(
@@ -236,71 +274,6 @@ impl Decoder {
         Ok(())
     }
 
-    fn decode_message_with<R, F>(
-        &mut self,
-        reader: &mut R,
-        data_size: u32,
-        mut f: F,
-    ) -> Result<(), Error<R::Error>>
-    where
-        R: Read,
-        F: FnMut(Event),
-    {
-        let mut arr = [0u8; 1];
-
-        while self.cur < data_size {
-            self.read_exact_inc(reader, &mut arr)?;
-
-            let header = arr[0];
-
-            if header & Message::HEADER_MASK == Message::DEFINITION_MASK {
-                let local_mesg_num = (header & Message::LOCAL_NUM_MASK) as usize;
-                let mut mesg_def = mem::take(&mut self.mesg_definitions[local_mesg_num]);
-                mesg_def.header = header;
-
-                self.decode_message_definition(reader, &mut mesg_def)?;
-
-                f(Event::MessageDefinition(&mesg_def));
-
-                self.mesg_definitions[local_mesg_num] = mesg_def;
-                continue;
-            }
-
-            let local_mesg_num = match header & Message::COMPRESSED_HEADER_MASK {
-                Message::COMPRESSED_HEADER_MASK => {
-                    (header & Message::COMPRESSED_LOCAL_NUM_MASK) >> Message::COMPRESSED_BIT_SHIFT
-                }
-                _ => header,
-            } & Message::LOCAL_NUM_MASK;
-
-            let mesg_def = mem::take(&mut self.mesg_definitions[local_mesg_num as usize]);
-            if mesg_def.header == 0 {
-                return Err(Error::MissingMessageDefinition { local_mesg_num });
-            }
-
-            self.buf_fields.clear();
-            self.buf_developer_fields.clear();
-
-            let mut mesg = Message {
-                header,
-                num: mesg_def.mesg_num,
-                fields: mem::take(&mut self.buf_fields),
-                developer_fields: mem::take(&mut self.buf_developer_fields),
-            };
-
-            self.decode_message_data(reader, &mut mesg, &mesg_def)?;
-
-            self.mesg_definitions[local_mesg_num as usize] = mesg_def;
-
-            f(Event::Message(&mesg));
-
-            self.buf_fields = mesg.fields;
-            self.buf_developer_fields = mesg.developer_fields;
-        }
-
-        Ok(())
-    }
-
     fn decode_message_definition<R>(
         &mut self,
         reader: &mut R,
@@ -363,6 +336,10 @@ impl Decoder {
     where
         R: Read,
     {
+        mesg.num = mesg_def.mesg_num;
+        mesg.fields.clear();
+        mesg.developer_fields.clear();
+
         if mesg.header & Message::COMPRESSED_HEADER_MASK == Message::COMPRESSED_HEADER_MASK {
             let last_time_offset = (self.timestamp & Message::COMPRESSED_TIME_MASK as u32) as u8;
             let time_offset = mesg.header & Message::COMPRESSED_TIME_MASK;
@@ -639,11 +616,11 @@ impl Decoder {
             mesg_def.header = 0;
         }
 
-        self.buf_fields.clear();
-        self.buf_fields.reserve_exact(255);
+        self.mesg.fields.clear();
+        self.mesg.fields.reserve_exact(255);
 
-        self.buf_developer_fields.clear();
-        self.buf_developer_fields.reserve_exact(255);
+        self.mesg.developer_fields.clear();
+        self.mesg.developer_fields.reserve_exact(255);
     }
 }
 
@@ -651,6 +628,15 @@ impl Default for Decoder {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn local_mesg_num_from_mesg_header(header: u8) -> usize {
+    (match header & Message::COMPRESSED_HEADER_MASK {
+        Message::COMPRESSED_HEADER_MASK => {
+            (header & Message::COMPRESSED_LOCAL_NUM_MASK) >> Message::COMPRESSED_BIT_SHIFT
+        }
+        _ => header,
+    } & Message::LOCAL_NUM_MASK) as usize
 }
 
 fn slice_buffer_to_match_type_size(
@@ -779,8 +765,12 @@ impl Builder {
             }; 16],
             accumulator: Accumulator::new(),
             timestamp: 0,
-            buf_fields: Vec::new(),
-            buf_developer_fields: Vec::new(),
+            mesg: Message {
+                header: 0,
+                num: MesgNum(0),
+                fields: Vec::new(),
+                developer_fields: Vec::new(),
+            },
             field_descriptions: Vec::new(),
             options: self.options,
         }
@@ -793,27 +783,156 @@ impl Default for Builder {
     }
 }
 
+enum State {
+    FileHeader,
+    Message,
+    Crc,
+}
+
+/// Creates a `Stream` from a mutably borrowed `Decoder` for streaming decoding.
+pub struct Stream<'a, R> {
+    reader: R,
+    decoder: &'a mut Decoder,
+    state: State,
+    file_header: FileHeader,
+    crc: u16,
+}
+
+impl<'a, R: Read> Stream<'a, R> {
+    /// Discard this current sequence and make `Stream` pointing to the next sequence.
+    pub fn discard(&mut self) -> Result<(), Error<R::Error>> {
+        let mut arr = [0u8; 256];
+        while self.decoder.cur < self.file_header.data_size {
+            let n = self.file_header.data_size - self.decoder.cur;
+            self.reader.read_exact(&mut arr[..n.min(256) as usize])?;
+            self.decoder.cur += n;
+        }
+
+        self.reader.read_exact(&mut arr[..2])?;
+        self.decoder.reset();
+        self.state = State::FileHeader;
+
+        Ok(())
+    }
+}
+
+/// An Iterator-like trait that return borrowed Item rather than owned Item.
+/// StreamingIterator is lazy and do nothing unless `next()` is called.
+pub trait StreamingIterator {
+    /// The type of the elements being iterated over.
+    type Item<'a>
+    where
+        Self: 'a;
+
+    /// Advances the iterator and returns the next value.
+    /// Returns [`None`] when iteration is finished.
+    fn next(&mut self) -> Option<Self::Item<'_>>;
+}
+
+impl<'a, R: Read> StreamingIterator for Stream<'a, R> {
+    type Item<'b>
+        = Result<Event<'b>, Error<R::Error>>
+    where
+        Self: 'b;
+
+    /// Decode next `DecoderEvent` until it returns `None` indicating no more data is available from the `reader`.
+    /// Since this is lazily evaluated, users can decide when to stop without required to read the whole reader.
+    fn next(&mut self) -> Option<Result<Event<'_>, Error<R::Error>>> {
+        match self.state {
+            State::FileHeader => {
+                self.file_header = match self.decoder.decode_file_header(&mut self.reader) {
+                    Ok(file_header) => file_header,
+                    Err(err) => return Some(Err(err)),
+                }?;
+                self.state = State::Message;
+                Some(Ok(Event::FileHeader(&self.file_header)))
+            }
+            State::Message => {
+                let mut arr = [0u8; 1];
+                if let Err(err) = self.decoder.read_exact_inc(&mut self.reader, &mut arr) {
+                    return Some(Err(err));
+                }
+
+                let header = arr[0];
+
+                if header & Message::HEADER_MASK == Message::DEFINITION_MASK {
+                    let local_mesg_num = (header & Message::LOCAL_NUM_MASK) as usize;
+                    let mut mesg_def =
+                        mem::take(&mut self.decoder.mesg_definitions[local_mesg_num]);
+
+                    mesg_def.header = header;
+
+                    let result = self
+                        .decoder
+                        .decode_message_definition(&mut self.reader, &mut mesg_def);
+
+                    self.decoder.mesg_definitions[local_mesg_num] = mesg_def;
+
+                    if let Err(err) = result {
+                        return Some(Err(err));
+                    }
+
+                    return Some(Ok(Event::MessageDefinition(
+                        &self.decoder.mesg_definitions[local_mesg_num],
+                    )));
+                }
+
+                let local_mesg_num = local_mesg_num_from_mesg_header(header);
+                if self.decoder.mesg_definitions[local_mesg_num].header == 0 {
+                    return Some(Err(Error::MissingMessageDefinition {
+                        local_mesg_num: local_mesg_num as u8,
+                    }));
+                }
+
+                let mesg_def = mem::take(&mut self.decoder.mesg_definitions[local_mesg_num]);
+                let mut mesg = mem::take(&mut self.decoder.mesg);
+
+                mesg.header = header;
+
+                let result =
+                    self.decoder
+                        .decode_message_data(&mut self.reader, &mut mesg, &mesg_def);
+
+                self.decoder.mesg_definitions[local_mesg_num] = mesg_def;
+                self.decoder.mesg = mesg;
+
+                if let Err(err) = result {
+                    return Some(Err(err));
+                }
+
+                if self.decoder.cur >= self.file_header.data_size {
+                    self.state = State::Crc;
+                }
+
+                Some(Ok(Event::Message(&self.decoder.mesg)))
+            }
+            State::Crc => {
+                self.crc = match self.decoder.decode_crc(&mut self.reader) {
+                    Ok(crc) => crc,
+                    Err(err) => return Some(Err(err)),
+                };
+                self.decoder.reset();
+                self.state = State::FileHeader;
+                Some(Ok(Event::Crc(&self.crc)))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::{
+        fs::File,
+        io::{BufReader, empty},
+    };
+
     use crate::{
-        Decoder,
+        Decoder, StreamingIterator,
         decoder::convert_u64_to_value,
         profile::typedef::FitBaseType,
         proto::{Message, MessageDefinition, Value},
     };
-    use embedded_io::{ErrorKind, ErrorType, Read};
-
-    struct Empty;
-
-    impl ErrorType for Empty {
-        type Error = ErrorKind;
-    }
-
-    impl Read for Empty {
-        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-            Ok(buf.len())
-        }
-    }
+    use embedded_io_adapters::std::FromStd;
 
     #[test]
     fn test_decompress_timestamp_on_decode_message_data() {
@@ -828,7 +947,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut empty = Empty {};
+        let mut empty = FromStd::new(empty());
         dec.decode_message_data(&mut empty, &mut mesg, &mesg_def)
             .unwrap();
         assert_eq!(dec.timestamp, timestamp + 1, "time_offset {}", time_offset);
@@ -870,6 +989,20 @@ mod tests {
         for tc in tt {
             let val = convert_u64_to_value(input, tc.0);
             assert_eq!(tc.1, val, "input: {:?}", tc);
+        }
+    }
+
+    #[test]
+    fn test_stream() {
+        let file = File::open("tests/data/large.fit").unwrap();
+        let br = BufReader::new(file);
+        let mut reader = FromStd::new(br);
+
+        let mut dec = Decoder::new();
+        let mut stream = dec.stream(&mut reader);
+
+        while let Some(event) = stream.next() {
+            event.unwrap();
         }
     }
 }

--- a/rustyfit/src/lib.rs
+++ b/rustyfit/src/lib.rs
@@ -1,9 +1,176 @@
-#![no_std]
+//! A stateless and static-friendly [`#![no_std]`](https://docs.rust-embedded.org/book/intro/no-std.html)
+//! library to decode and encode Garmin FIT files, supporting FIT Protocol V2.
+//!
+//! [The Flexible and Interoperable Data Transfer (FIT) Protocol](https://developer.garmin.com/fit)
+//! is a protocol developed by Garmin for storing and sharing data originating from sports, fitness,
+//! and health devices. Activities recorded using devices such as smartwatch and cycling computer
+//! are now mostly in a FIT file format (\*.fit).
+//!
+//! This library is a rewrite of [FIT SDK for Go](https://github.com/muktihari/fit) and is designed to run on
+//! baremetal Rust, where performance and memory efficiency is carefully considered.
+//!
+//! ## Usage
+//!
+//! For [`#![no_std]`](https://docs.rust-embedded.org/book/intro/no-std.html), you need to provide
+//! [`#[global_allocator]`](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute)
+//! since this library requires allocation.
+//!
+//! For [`std`](https://doc.rust-lang.org/std), you need to wrap `std::io`'s
+//! [Read](https://doc.rust-lang.org/std/io/trait.Read.html) or
+//! [Write](https://doc.rust-lang.org/std/io/trait.Write.html) with
+//! [embedded_io_adapters::std:FromStd](https://docs.rs/embedded-io-adapters/0.7.0/embedded_io_adapters/std/struct.FromStd.html).
+//!
+//! We will provide examples in `std` for simplicity and a wider audience, since `#![no_std]` is platform-dependent.
+//!
+//! ### Decoding
+//!
+//! `Decoder`'s `decode` method allows us to interact with FIT files directly through their original protocol messages' structure.
+//! This method can be invoked multiple times to decode chained FIT file until it return Ok(None) or Err(err).
+//!
+//! ```
+//! use embedded_io_adapters::std::FromStd;
+//! use rustyfit::{Decoder, profile::{mesgdef, typedef}, proto::Value};
+//! use std::{error::Error, fs::File, io::BufReader};
+//!
+//! fn main() -> Result<(), Box<dyn Error>> {
+//!     let name = "tests/data/from_official_sdk/Activity.fit";
+//!     let f = File::open(name)?;
+//!     let br = BufReader::new(f);
+//!     let mut reader = FromStd::new(br);
+//!
+//!     let mut dec = Decoder::new();
+//!
+//!     let fit = match dec.decode(&mut reader)? {
+//!         Some(fit) => fit,
+//!         None => {
+//!             // First decode call to reader should be `Ok` or `Err`.
+//!             // Except, reader is already empty to begin with.
+//!             return Err(Box::from("empty reader"));
+//!         }
+//!     };
+//!
+//!     println!("file_header's data_size: {}", fit.file_header.data_size);
+//!     println!("messages count: {}", fit.messages.len());
+//!     for field in &fit.messages[0].fields {
+//!         // first message: file_id
+//!         if field.num == mesgdef::FileId::TYPE
+//!             && let Value::Uint8(v) = field.value
+//!         {
+//!             println!("file type: {}", typedef::File(v));
+//!         }
+//!     }
+//!
+//!     Ok(())
+//!
+//!     // # Output:
+//!     // file_header's data_size: 94080
+//!     // messages count: 3611
+//!     // file type: activity
+//! }
+//!
+//! ```
+//!
+//! #### Streaming Decoding
+//!
+//! `StreamDecoder` allows us to retrieve event data (`FileHeader`, `MessageDefinition`, `Message`, `CRC`) as soon as it is being decoded.
+//! This way, users can have fine-grained control on how to interact with the data efficiently. And since this is lazily evaluated, users can
+//! decide when to stop without required to read the whole reader.
+//!
+//! ```
+//! use embedded_io_adapters::std::FromStd;
+//! use rustyfit::{Decoder, DecoderEvent, StreamingIterator, profile::{mesgdef, typedef}};
+//! use std::{error::Error, fs::File, io::BufReader};
+//!
+//! fn main() -> Result<(), Box<dyn Error>> {
+//!     let name = "tests/data/from_official_sdk/Activity.fit";
+//!     let f = File::open(name)?;
+//!     let br = BufReader::new(f);
+//!     let mut reader = FromStd::new(br);
+//!
+//!     let mut dec = Decoder::new();              // stateless and static-friendly
+//!     let mut stream = dec.stream(&mut reader);  // stateful but small since it borrow Decoder.
+//!
+//!     while let Some(event) = stream.next() {
+//!         match event? {
+//!             DecoderEvent::FileHeader(_) => {},
+//!             DecoderEvent::MessageDefinition(_) => {},
+//!             DecoderEvent::Message(mesg) => {
+//!                 if mesg.num == typedef::MesgNum::SESSION {
+//!                     // Convert mesg into Session struct
+//!                     let ses = mesgdef::Session::from(mesg);
+//!                     println!(
+//!                         "session:\n start_time: {}\n sport: {}\n num_laps: {}",
+//!                         ses.start_time.0, ses.sport, ses.num_laps
+//!                     );
+//!                 }
+//!             }
+//!             DecoderEvent::Crc(_) => {}
+//!         }
+//!     }
+//!     
+//!     Ok(())
+//!
+//!     // # Output
+//!     // session:
+//!     //  start_time: 995749880
+//!     //  sport: stand_up_paddleboarding
+//!     //  num_laps: 1
+//! }
+//! ```
+//!
+//! Users can also use `discard()` to discard this current FIT sequence and direct the `StreamDecoder`
+//! to point to next FIT sequence in the reader. If desired, users can also stop the process entirely.
+//!
+//! ```
+//! # use std::{error::Error, fs::File, io::BufReader};
+//! # use embedded_io_adapters::std::FromStd;
+//! # use rustyfit::{Decoder, DecoderEvent, StreamingIterator, profile::{mesgdef, typedef}};
+//! # fn main() -> Result<(), Box<dyn Error>> {
+//!     # let name = "tests/data/from_official_sdk/Activity.fit";
+//!     # let f = File::open(name)?;
+//!     # let br = BufReader::new(f);
+//!     # let mut reader = FromStd::new(br);
+//!     # let mut dec = Decoder::new();
+//!     # let mut stream = dec.stream(&mut reader);
+//!     while let Some(event) = stream.next() {
+//!         if let DecoderEvent::Message(mesg) = event? {
+//!             if mesg.num == typedef::MesgNum::FILE_ID {
+//!                 // Let's say we just want to decode Activity file,
+//!                 let file_id = mesgdef::FileId::from(mesg);
+//!                 if file_id.r#type != typedef::File::ACTIVITY {
+//!                     stream.discard()?; // discard this sequence
+//!                     continue;
+//!                 }
+//!             }
+//!             // It's an Activity File!
+//!         }
+//!     }
+//!     # Ok(())
+//! # }
+//! ```
+//!
+//! #### DecoderBuilder
+//!
+//! Create `Decoder` instance with options using `Decoder::builder()` or `DecoderBuilder::new()`.
+//!
+//! ```
+//! # use rustyfit::Decoder;
+//! let mut dec = Decoder::builder()
+//!         .checksum(false)
+//!         .expand_components(false)
+//!         .build();
+//! ```
+//!
+//! These associated functions and method are `const fn`, so we can use it to declare a static variable
+//! as long as we wrap it with a lock, e.g. `Mutex`. This is useful on microcrontrollers where RAM is only hundred KBs.
+
+#![cfg_attr(not(test), no_std)]
 
 extern crate alloc;
 
 pub use decoder::{
     Builder as DecoderBuilder, Decoder, Error as DecoderError, Event as DecoderEvent,
+    Stream as StreamDecoder, StreamingIterator,
 };
 pub use encoder::{
     Builder as EncoderBuilder, Encoder, Endianness, Error as EncoderError, FieldValidationError,


### PR DESCRIPTION
Decoder's `decode_with` is useful when we want to retrieve the whole data. But if we want to stop in the middle of the process, we can not. This new `StreamingIterator` implementation allow us to lazily process each event and enable us to stop in the middle of a process. This behave similarly with `decode_with` which the data is borrowed instead of owned with similar performance when measured.

Also included in this PR
- Remove no_std restriction on test, it will make testing easier.
- Usage documentation is gradually moved into rustdoc. We will remove usage in readme when everything is done.