### PR TITLE
feat: implement streaming encoder

### DIFF
--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -5,8 +5,7 @@ mod validator;
 
 use crate::{
     crc16::Crc16,
-    encoder::lru::Lru,
-    encoder::validator::MessageValidator,
+    encoder::{lru::Lru, validator::MessageValidator},
     profile::{PROFILE_VERSION, typedef::DateTime},
     proto::*,
 };
@@ -111,6 +110,20 @@ impl Encoder {
     /// Create new Encoder with options for encoding FIT file.
     pub const fn builder() -> Builder {
         Builder::new()
+    }
+
+    /// Creates a `Stream` from a mutably borrowed `Encoder` for streaming encoding of the given `writer`.
+    pub fn stream<'a, W>(&'a mut self, writer: W) -> Stream<'a, W>
+    where
+        W: Write + Seek,
+    {
+        self.reset();
+
+        Stream {
+            writer,
+            encoder: self,
+            counter: 0,
+        }
     }
 
     /// Encode the given `fit` to the writer.
@@ -556,16 +569,96 @@ impl Default for Builder {
     }
 }
 
+/// A `Stream` from a mutably borrowed `Encoder` for streaming encoding.
+pub struct Stream<'a, W> {
+    writer: W,
+    encoder: &'a mut Encoder,
+    counter: usize,
+}
+
+impl<'a, W: Write + Seek> Stream<'a, W> {
+    /// Write message to the `writer`. When done writing all messages,
+    /// call `finish()` to complete this FIT sequence.
+    pub fn write_message(&mut self, mesg: &mut Message) -> Result<(), Error<W::Error>> {
+        if self.counter == 0 {
+            self.writer.write_all(&[0u8; 14])?; // Reserve 14 bytes for FileHeader
+            self.encoder.n += 14;
+        }
+
+        if let Err(err) = self
+            .encoder
+            .message_validator
+            .validate_message(mesg, self.encoder.options.protocol_version)
+        {
+            return Err(Error::MessageValidation {
+                mesg_index: self.counter,
+                err,
+            });
+        }
+
+        self.encoder.encode_message(&mut self.writer, mesg)?;
+        self.counter += 1;
+
+        Ok(())
+    }
+
+    /// Finish the current FIT sequence by finalizing the correct FileHeader.
+    ///
+    /// Calling `write_message()` after this point will write message for the next
+    /// FIT sequence on the same `writer`, and `finish()` MUST be called again.
+    pub fn finish(&mut self) -> Result<(), Error<W::Error>> {
+        if self.counter == 0 {
+            return Err(Error::EmptyMessages);
+        }
+
+        self.encoder.encode_crc(&mut self.writer)?;
+
+        let mut protocol_version = self.encoder.options.protocol_version;
+        if protocol_version == ProtocolVersion(0) {
+            protocol_version = ProtocolVersion::V1;
+        }
+
+        let file_header = FileHeader {
+            size: 14,
+            protocol_version,
+            profile_version: PROFILE_VERSION,
+            data_size: self.encoder.data_size,
+            data_type: FileHeader::DATA_TYPE,
+            crc: 0, // calculated
+        };
+
+        self.encoder.buf.clear();
+        write_file_header_to_vec(&mut self.encoder.buf, &file_header);
+
+        self.encoder.crc16.write(&self.encoder.buf[..12]);
+        let crc = self.encoder.crc16.sum16();
+        self.encoder.buf[12..14].copy_from_slice(&crc.to_le_bytes());
+        self.encoder.crc16.reset();
+
+        self.writer.seek(SeekFrom::Current(-self.encoder.n))?;
+        self.writer.write_all(&self.encoder.buf)?;
+        self.writer.seek(SeekFrom::Current(self.encoder.n - 14))?;
+
+        self.counter = 0;
+        self.encoder.reset();
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use crate::{
         Encoder,
         encoder::write_value_to_vec,
         profile::{mesgdef, typedef},
-        proto::{FileHeader, Message, ProtocolVersion, Value},
+        proto::{FIT, FileHeader, Message, ProtocolVersion, Value},
     };
     use alloc::{borrow::ToOwned, vec, vec::Vec};
     use embedded_io::{ErrorKind, ErrorType, Seek, Write};
+    use embedded_io_adapters::std::FromStd;
 
     #[test]
     fn compress_timestamp_into_header() {
@@ -1042,5 +1135,50 @@ mod tests {
         );
 
         assert_eq!(pos, n, "should put offset back to its original position");
+    }
+
+    #[test]
+    fn test_compare_encoder_and_stream_result() {
+        let mut fit = FIT {
+            messages: vec![
+                {
+                    let mut file_id = mesgdef::FileId::new();
+                    file_id.manufacturer = typedef::Manufacturer::GARMIN;
+                    file_id.product = typedef::GarminProduct::FENIX8_SOLAR.0;
+                    file_id.r#type = typedef::File::ACTIVITY;
+                    Message::from(file_id)
+                },
+                {
+                    let mut record = mesgdef::Record::new();
+                    record.distance = 100 * 100; // 100 m
+                    record.heart_rate = 70; // 70 bpm
+                    record.speed = 2 * 1000; // 2 m/s
+                    Message::from(record)
+                },
+            ],
+            ..Default::default()
+        };
+
+        let mut enc_storage = Vec::<u8>::new();
+        let mut enc_writer = FromStd::new(Cursor::new(&mut enc_storage));
+
+        let mut enc = Encoder::new();
+        enc.encode(&mut enc_writer, &mut fit).unwrap();
+
+        let mut stream_storage = Vec::<u8>::new();
+        let mut stream_writer = FromStd::new(Cursor::new(&mut stream_storage));
+
+        let mut enc2 = Encoder::new();
+        let mut stream = enc2.stream(&mut stream_writer);
+
+        for mut mesg in fit.messages.iter_mut() {
+            stream.write_message(&mut mesg).unwrap();
+        }
+        stream.finish().unwrap();
+
+        assert_eq!(
+            enc_storage, stream_storage,
+            "Encoder and Stream should produce same result"
+        );
     }
 }

--- a/rustyfit/src/lib.rs
+++ b/rustyfit/src/lib.rs
@@ -22,6 +22,16 @@
 //!
 //! We will provide examples in `std` for simplicity and a wider audience, since `#![no_std]` is platform-dependent.
 //!
+//! - [Decoding](#decoding)
+//!   - [Streaming Decoding](#streaming-decoding)
+//!   - [DecoderBuilder](#decoderbuilder)
+//! - [Encoding](#encoding)
+//!   - [Encode using mesgdef module](#encode-using-mesgdef-module)
+//!   - [Streaming Encoding](#streaming-encoding)
+//!   - [EncoderBuilder](#encoderbuilder)
+//!
+//! ####
+//!
 //! ### Decoding
 //!
 //! `Decoder`'s `decode` method allows us to interact with FIT files directly through their original protocol messages' structure.
@@ -88,7 +98,7 @@
 //!     let mut reader = FromStd::new(br);
 //!
 //!     let mut dec = Decoder::new();              // stateless and static-friendly
-//!     let mut stream = dec.stream(&mut reader);  // stateful but small since it borrow Decoder.
+//!     let mut stream = dec.stream(&mut reader);  // stateful but small since it borrows Decoder.
 //!
 //!     while let Some(event) = stream.next() {
 //!         match event? {
@@ -163,6 +173,200 @@
 //!
 //! These associated functions and method are `const fn`, so we can use it to declare a static variable
 //! as long as we wrap it with a lock, e.g. `Mutex`. This is useful on microcrontrollers where RAM is only hundred KBs.
+//!
+//! ####
+//!
+//! ### Encoding
+//!
+//! Here is the example of manually encode FIT protocol using this library to give the idea how it works.
+//!
+//! ```
+//! use embedded_io_adapters::std::FromStd;
+//! use rustyfit::{Encoder, profile::{ProfileType, mesgdef, typedef}, proto::{FIT, Field, Message, Value}};
+//! use std::{error::Error, fs::File, io::{BufWriter, Write}};
+//!
+//! fn main() -> Result<(), Box<dyn Error>> {
+//!     let mut fit = FIT {
+//!         messages: vec![
+//!             Message {
+//!                 num: typedef::MesgNum::FILE_ID,
+//!                 fields: vec![
+//!                     Field {
+//!                         num: mesgdef::FileId::MANUFACTURER,
+//!                         profile_type: ProfileType::MANUFACTURER, // or ProfileType::UINT16 is also valid
+//!                         value: Value::Uint16(typedef::Manufacturer::GARMIN.0),
+//!                         is_expanded: false,
+//!                     },
+//!                     Field {
+//!                         num: mesgdef::FileId::PRODUCT,
+//!                         profile_type: ProfileType::UINT16,
+//!                         value: Value::Uint16(typedef::GarminProduct::FENIX8_SOLAR.0),
+//!                         is_expanded: false,
+//!                     },
+//!                     Field {
+//!                         num: mesgdef::FileId::TYPE,
+//!                         profile_type: ProfileType::UINT8,
+//!                         value: Value::Uint8(typedef::File::ACTIVITY.0),
+//!                         is_expanded: false,
+//!                     },
+//!                 ],
+//!                 ..Default::default()
+//!             },
+//!             Message {
+//!                 num: typedef::MesgNum::RECORD,
+//!                 fields: vec![
+//!                     Field {
+//!                         num: mesgdef::Record::DISTANCE,
+//!                         profile_type: ProfileType::UINT32,
+//!                         value: Value::Uint32(100 * 100), // 100 m
+//!                         is_expanded: false,
+//!                     },
+//!                     Field {
+//!                         num: mesgdef::Record::HEART_RATE,
+//!                         profile_type: ProfileType::UINT8,
+//!                         value: Value::Uint8(70), // 70 bpm
+//!                         is_expanded: false,
+//!                     },
+//!                     Field {
+//!                         num: mesgdef::Record::SPEED,
+//!                         profile_type: ProfileType::UINT16,
+//!                         value: Value::Uint16(2 * 1000), // 2 m/s
+//!                         is_expanded: false,
+//!                     },
+//!                 ],
+//!                 ..Default::default()
+//!             },
+//!         ],
+//!         ..Default::default()
+//!     };
+//!
+//!     let fout_name = "output.fit";
+//!     let fout = File::create(fout_name)?;
+//!     let mut bw = BufWriter::new(fout);
+//!     let mut writer = FromStd::new(&mut bw);
+//!
+//!     let mut enc = Encoder::new();
+//!     enc.encode(&mut writer, &mut fit)?;
+//!     bw.flush()?;
+//!     # let _ = std::fs::remove_file(fout_name);
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! #### Encode using mesgdef module
+//!
+//! Alternatively, users can create messages using the mesgdef module for convenience.
+//!
+//! ```
+//! use embedded_io_adapters::std::FromStd;
+//! use rustyfit::{Encoder, profile::{mesgdef, typedef}, proto::{FIT, Message}};
+//! use std::{error::Error, fs::File, io::{BufWriter, Write}};
+//!
+//! fn main() -> Result<(), Box<dyn Error>> {
+//!     let mut fit = FIT {
+//!         messages: vec![
+//!             {
+//!                 let mut file_id = mesgdef::FileId::new();
+//!                 file_id.manufacturer = typedef::Manufacturer::GARMIN;
+//!                 file_id.product = typedef::GarminProduct::FENIX8_SOLAR.0;
+//!                 file_id.r#type = typedef::File::ACTIVITY;
+//!                 Message::from(file_id)
+//!             },
+//!             {
+//!                 let mut record = mesgdef::Record::new();
+//!                 record.distance = 100 * 100; // 100 m
+//!                 record.heart_rate = 70; // 70 bpm
+//!                 record.speed = 2 * 1000; // 2 m/s
+//!                 Message::from(record)
+//!             },
+//!         ],
+//!         ..Default::default()
+//!     };
+//!     
+//!     let fout_name = "output.fit";
+//!     let fout = File::create(fout_name)?;
+//!     let mut bw = BufWriter::new(fout);
+//!     let mut writer = FromStd::new(&mut bw);
+//!
+//!     let mut enc = Encoder::new();
+//!     enc.encode(&mut writer, &mut fit)?;
+//!     bw.flush()?;
+//!     # let _ = std::fs::remove_file(fout_name);
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! #### Streaming Encoding
+//!
+//! `StreamEncoder` allows us to encode in streaming fashion. Write each message directly without retain them first in the memory.
+//! This is useful when the device is the one who produce the data such as smartwatch, cycling computer or other health devices.
+//!
+//!
+//! ```
+//! use embedded_io_adapters::std::FromStd;
+//! use rustyfit::{Encoder, profile::{mesgdef, typedef}, proto::Message};
+//! use std::{error::Error, fs::File, io::{BufWriter, Write}};
+//!
+//! fn main() -> Result<(), Box<dyn Error>> {
+//!     let fout_name = "output.fit";
+//!     let fout = File::create(fout_name)?;
+//!     let mut bw = BufWriter::new(fout);
+//!     let mut writer = FromStd::new(&mut bw);
+//!
+//!     let mut enc = Encoder::new();             // stateless and static-friendly
+//!     let mut stream = enc.stream(&mut writer); // stateful but small since it borrows Encoder.
+//!
+//!     stream.write_message(&mut {
+//!         let mut file_id = mesgdef::FileId::new();
+//!         file_id.manufacturer = typedef::Manufacturer::GARMIN;
+//!         file_id.product = typedef::GarminProduct::FENIX8_SOLAR.0;
+//!         file_id.r#type = typedef::File::ACTIVITY;
+//!         Message::from(file_id)
+//!     })?;
+//!
+//!     stream.write_message(&mut {
+//!         let mut record = mesgdef::Record::new();
+//!         record.distance = 100 * 100; // 100 m
+//!         record.heart_rate = 70; // 70 bpm
+//!         record.speed = 2 * 1000; // 2 m/s
+//!         Message::from(record)
+//!     })?;
+//!
+//!     stream.finish()?;
+//!     bw.flush()?;
+//!     # let _ = std::fs::remove_file(fout_name);
+//!
+//!     Ok(())
+//! }
+//!
+//! ```
+//!
+//! NOTE:
+//! - For `#![no_std]` on MCU with only few hundred KBs of RAM, we recommend allocating a Message once
+//! and reuse it instead of using these `mesgdef` building blocks which might yield few KBs stack memory.
+//! MCU may only has 2KB or less stack memory configuration.
+//!
+//! - For `std`, you don't need to worry about this, on Linux for example, stack can have a range from 2MB to 8MB,
+//! which is abundant.
+//!
+//! #### EncoderBuilder
+//!
+//! Create `Encoder` instance with options using `Encoder::builder()` or `EncoderBuilder::new()`.
+//!
+//! ```
+//! # use rustyfit::{Encoder, HeaderOption, Endianness};
+//! # use rustyfit::proto::ProtocolVersion;
+//! let mut enc = Encoder::builder()
+//!         .endianness(Endianness::BigEndian)
+//!         .protocol_version(ProtocolVersion::V2)
+//!         .header_option(HeaderOption::Compressed(3))
+//!         .build();
+//! ```
+//!
+//! These associated functions and method are `const fn`, so we can use it to declare a static variable
+//! as long as we wrap it with a lock, e.g. `Mutex`. This is useful on microcrontrollers where RAM is only hundred KBs.
 
 #![cfg_attr(not(test), no_std)]
 
@@ -174,7 +378,7 @@ pub use decoder::{
 };
 pub use encoder::{
     Builder as EncoderBuilder, Encoder, Endianness, Error as EncoderError, FieldValidationError,
-    HeaderOption, MessageValidationError,
+    HeaderOption, MessageValidationError, Stream as StreamEncoder,
 };
 
 /// The `profile` module represents FIT Global Profile containing types and messages generated from Profile.xlsx.


### PR DESCRIPTION
After we support `#![no_std]`, the need for having `Streaming Encoding` become more necessary. Embedded devices may only have few KBs of RAM, storing all messages in memory before writing them all is not possible in that situation. And for devices or programs which produce data in real time manner, writing per-message-basis is more natural for them.

This PR will solve #10 and supersede #11 