### PR TITLE
perf: improve mesgdef memory efficiency

### DIFF
--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -46,6 +46,9 @@ func NewBuilder(path string, lookup *lookup.Lookup, message []parser.Message, ty
 					return strconv.FormatFloat(f, 'g', -1, 64)
 				},
 				"hasSuffix": strings.HasSuffix,
+				"sub": func(v, sub int) int {
+					return v - sub
+				},
 			}).
 			ParseFiles(filepath.Join(cd, "mesgdef.tmpl"))),
 		templateExec: "mesgdef",
@@ -70,15 +73,11 @@ func (b *Builder) Build() ([]generator.Data, error) {
 		}
 		var (
 			knownNums     [4]uint64
-			maxFieldNum   byte
 			dynamicFields []DynamicField
 			fields        = make([]Field, 0, len(mesg.Fields))
 		)
 		for _, parserField := range mesg.Fields {
 			knownNums[parserField.Num>>6] |= 1 << (parserField.Num & 63)
-			if parserField.Num > maxFieldNum {
-				maxFieldNum = parserField.Num
-			}
 
 			var fixedArraySize uint8
 			if len(parserField.Array) > 1 && parserField.Array[1] != 'N' {
@@ -122,7 +121,7 @@ func (b *Builder) Build() ([]generator.Data, error) {
 					return fmt.Sprintf("%s::MAX", rustType)
 				}(),
 				Type:           b.transformType(parserField.Type, parserField.Array, fixedArraySize),
-				TypedValue:     b.transformTypedValue(parserField.Num, parserField.Type, parserField.Array, fixedArraySize),
+				TypedValue:     b.transformTypedValue(parserField.Type, parserField.Array, fixedArraySize),
 				ProtoValue:     b.transformToProtoValue(strutil.ToNonRustIdent(parserField.Name), parserField.Type, parserField.Array, fixedArraySize),
 				InvalidValue:   b.invalidValueOf(parserField.Type, parserField.Array, fixedArraySize),
 				Comment:        parserField.Comment,
@@ -145,9 +144,11 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			}
 
 			field.IfSelfEqualInvalid = fmt.Sprintf("self.%s == %s", field.Name, field.InvalidValue)
+			field.IfSelfNotEqualInvalid = fmt.Sprintf("self.%s != %s", field.Name, field.InvalidValue)
 			field.IfNotEqualInvalid = fmt.Sprintf("m.%s != %s", field.Name, field.InvalidValue)
 			if parserField.Array == "[N]" || (field.BaseType == "STRING" && parserField.Array == "") {
 				field.IfSelfEqualInvalid = fmt.Sprintf("self.%s.is_empty()", field.Name)
+				field.IfSelfNotEqualInvalid = fmt.Sprintf("!self.%s.is_empty()", field.Name)
 				field.IfNotEqualInvalid = fmt.Sprintf("!m.%s.is_empty()", field.Name)
 			}
 
@@ -182,7 +183,6 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			DynamicFields:     dynamicFields,
 			KnownNums:         knownNums,
 			StateSize:         (maxFieldExpandNum + 8) / 8,
-			MaxFieldNum:       maxFieldNum + 1,
 			MaxFieldExpandNum: maxFieldExpandNum + 1,
 			Imports:           imports,
 		})
@@ -393,7 +393,7 @@ func (b *Builder) transformToProtoValue(fieldName, fieldType, array string, fixe
 	return fmt.Sprintf("Value::%s(m.%s)", valueEnum, fieldName)
 }
 
-func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedArraySize uint8) string {
+func (b *Builder) transformTypedValue(fieldType, array string, fixedArraySize uint8) string {
 	baseType := b.lookup.BaseType(fieldType).String()
 	baseTypeTitleCase := strutil.ToTitle(baseType)
 	valueEnumType := baseTypeToValueEnumReplacer.Replace(baseTypeTitleCase)
@@ -408,12 +408,12 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 	var value string
 	if array == "" {
 		if rustAsType == "string" {
-			value = fmt.Sprintf(`vals[%d].as_str().to_owned()`, num)
+			value = "field.value.as_str().to_owned()"
 		} else {
-			value = fmt.Sprintf(`vals[%d].as_%s()`, num, rustAsType)
+			value = fmt.Sprintf(`field.value.as_%s()`, rustAsType)
 		}
 	} else if fixedArraySize == 0 { // vector
-		value = fmt.Sprintf(`vals[%d].to_vec_%s()`, num, strings.TrimSuffix(rustAsType, "z"))
+		value = fmt.Sprintf(`field.value.to_vec_%s()`, strings.TrimSuffix(rustAsType, "z"))
 	} else { // array
 		rustType := baseTypeToRustTypeReplacer.Replace(baseType)
 		arrayValue := fmt.Sprintf("[%s::MAX; %d]", rustType, fixedArraySize)
@@ -424,7 +424,7 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 			rshValue = "x.to_owned()"
 		}
 
-		value = fmt.Sprintf(`match &vals[%d] {
+		value = fmt.Sprintf(`match &field.value {
 			Value::Vec%s(v) => {
 				let mut arr = %s;
 				for (i, x) in v.iter().take(%d).enumerate() {
@@ -434,7 +434,6 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 			},
 			_ => %s,
 		}`,
-			num,
 			valueEnumType,
 			arrayValue,
 			fixedArraySize,
@@ -453,14 +452,14 @@ func (b *Builder) transformTypedValue(num byte, fieldType, array string, fixedAr
 		return fmt.Sprintf("%s(%s)", typdef, value)
 	}
 
-	return fmt.Sprintf(`match &vals[%d] {
+	return fmt.Sprintf(`match &field.value {
 		Value::Vec%s(v) => {
 			let mut vs = Vec::with_capacity(v.len());
 			vs.extend(v.iter().map(|&x|%s(x)));
 			vs
 		},
 		_ => Vec::new(),
-	}`, num, strings.TrimSuffix(valueEnumType, "z"), typdef)
+	}`, strings.TrimSuffix(valueEnumType, "z"), typdef)
 }
 
 func (b *Builder) invalidValueOf(fieldType, array string, fixedArraySize byte) string {

--- a/fitgen/internal/profile/mesgdef/data.go
+++ b/fitgen/internal/profile/mesgdef/data.go
@@ -21,38 +21,38 @@ type Message struct {
 	DynamicFields     []DynamicField
 	KnownNums         [4]uint64
 	StateSize         byte
-	MaxFieldNum       byte
 	MaxFieldExpandNum byte
 	Imports           map[string]struct{}
 }
 
 type Field struct {
-	Num                byte
-	Name               string
-	Name0              string // Name but with .0 if it's typedef
-	NameUpperCase      string
-	String             string
-	ProfileType        string
-	BaseType           string
-	BaseType0          string // Underlying base_type, typedef::Weight -> u16
-	BaseType0Invalid   string // Invalid value of the underlying base type.
-	MaxValue           string // Only if numeric
-	Size               byte
-	Type               string
-	TypedValue         string
-	PrimitiveValue     string
-	ProtoValue         string
-	IsValidValue       string
-	ComparableValue    string
-	InvalidValue       string
-	Comment            string
-	Units              string
-	Scale              float64
-	Offset             float64
-	Array              bool
-	CanExpand          bool
-	IfSelfEqualInvalid string
-	IfNotEqualInvalid  string
+	Num                   byte
+	Name                  string
+	Name0                 string // Name but with .0 if it's typedef
+	NameUpperCase         string
+	String                string
+	ProfileType           string
+	BaseType              string
+	BaseType0             string // Underlying base_type, typedef::Weight -> u16
+	BaseType0Invalid      string // Invalid value of the underlying base type.
+	MaxValue              string // Only if numeric
+	Size                  byte
+	Type                  string
+	TypedValue            string
+	PrimitiveValue        string
+	ProtoValue            string
+	IsValidValue          string
+	ComparableValue       string
+	InvalidValue          string
+	Comment               string
+	Units                 string
+	Scale                 float64
+	Offset                float64
+	Array                 bool
+	CanExpand             bool
+	IfSelfEqualInvalid    string
+	IfSelfNotEqualInvalid string
+	IfNotEqualInvalid     string
 
 	FixedArraySize          byte
 	InvalidArrayValueScaled string

--- a/fitgen/internal/profile/mesgdef/mesgdef.tmpl
+++ b/fitgen/internal/profile/mesgdef/mesgdef.tmpl
@@ -189,6 +189,12 @@ impl {{ .Name }} {
         is_expanded(&self.state, num)
     }
     {{ end }}
+
+    fn count_valid_fields(&self) -> usize {
+    	{{ range $i, $v := .Fields -}}
+     		({{ .IfSelfNotEqualInvalid }}) as usize {{ if lt $i (sub (len $.Fields) 1) }} + {{ end }}
+     	{{ end }}
+    }
 }
 
 impl Default for {{ .Name }} {
@@ -200,81 +206,65 @@ impl Default for {{ .Name }} {
 impl From<&Message> for {{ .Name }} {
     /// from creates new {{ .Name }} struct based on given mesg. 
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; {{ .MaxFieldNum }}];
-        {{ if gt .MaxFieldExpandNum 1 -}}
-		let mut state = [0u8; {{ .StateSize }}];
-		{{ end }}
-		
         {{/* 256 bits flags for indicating known Field Number declared in Profile.xslx */ -}}
         const KNOWN_NUMS: [u64; 4] = [{{- range $_, $v := .KnownNums }} {{ $v -}}, {{ end -}}];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize>>6]>>(field.num&63))&1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        {{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
+        v.developer_fields= mesg.developer_fields.clone();
+        {{ end }}
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize>>6]>>(field.num&63))&1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-			{{ if gt .MaxFieldExpandNum 1 -}}
+			match field.num {	
+				{{ range .Fields -}}
+	            {{ .Num }} => v.{{ .Name }} = {{ .TypedValue }} ,
+	            {{ end -}}
+                {{ if gt .MaxFieldExpandNum 1 -}}
+            	_ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                },
+                {{ else -}}
+                _ => v.unknown_fields.push(field.clone()),
+                {{ end }}
+        	};
+            {{ if gt .MaxFieldExpandNum 1 -}}
 			if field.is_expanded && field.num < {{ .MaxFieldExpandNum }} {
-				state[field.num as usize >> 3] |= 1 << (field.num & 7)
+				v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
 			}
 			{{ end -}}
-			vals[field.num as usize] = &field.value;
 		}
 
-        Self {
-            {{ range .Fields -}}
-                {{ .Name }}: {{ .TypedValue }},
-            {{ end -}}
-            {{ if gt .MaxFieldExpandNum 1 -}}
-            state,
-            {{ end -}}
-            unknown_fields,
-            {{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
-            developer_fields: mesg.developer_fields.clone(),
-            {{ end }}
-        }
+        v
     }
 }
 
 impl From<{{ .Name }}> for Message {
     fn from(m: {{ .Name }}) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; {{ len .Fields }}];
-        let mut len = 0usize;
-        {{ if gt .MaxFieldExpandNum 1 -}} let state = m.state; {{ end }}
+        let mut fields = Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         {{ range .Fields -}}
         if {{ .IfNotEqualInvalid }} {
-            arr[len] = Field {
+            fields.push(Field {
                 num: {{ .Num }},
                 profile_type: {{ .ProfileType }},
                 value: {{ .ProtoValue }},
-                {{ if .CanExpand }} is_expanded: is_expanded(&state, {{ .Num }}), {{ else }} is_expanded: false, {{ end }}
-            };
-            len += 1;
-        }
+                {{ if .CanExpand }} is_expanded: is_expanded(&m.state, {{ .Num }}), {{ else }} is_expanded: false, {{ end }}
+            });
+        };
         {{- end }}
+        
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::{{ .Num }},
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             {{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
             developer_fields: m.developer_fields, {{ else }} developer_fields: Vec::new(),
             {{ end }}

--- a/rustyfit/benches/mesgdef.rs
+++ b/rustyfit/benches/mesgdef.rs
@@ -36,6 +36,23 @@ pub fn bench_from(c: &mut Criterion) {
             let _ = Record::from(black_box(&mesg));
         })
     });
+
+    c.bench_function("mesgdef From<Record>", |b| {
+        b.iter(|| {
+            let mut record = Record::new();
+            record.distance = 1000;
+            record.speed = 1000;
+            record.power = 1000;
+            record.temperature = 29;
+            record.position_lat = 0;
+            record.position_long = 0;
+            record.altitude = 6000;
+
+            let mesg = Message::from(record);
+            assert_eq!(mesg.fields.len(), 7);
+            assert_eq!(mesg.fields.capacity(), 7);
+        })
+    });
 }
 
 pub fn bench_new(c: &mut Criterion) {

--- a/rustyfit/src/profile/mesgdef/aad_accel_features.rs
+++ b/rustyfit/src/profile/mesgdef/aad_accel_features.rs
@@ -76,6 +76,15 @@ impl AadAccelFeatures {
         self.time_above_threshold = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.time != u16::MAX) as usize
+            + (self.energy_total != u32::MAX) as usize
+            + (self.zero_cross_cnt != u16::MAX) as usize
+            + (self.instance != u8::MAX) as usize
+            + (self.time_above_threshold != u16::MAX) as usize
+    }
 }
 
 impl Default for AadAccelFeatures {
@@ -87,112 +96,92 @@ impl Default for AadAccelFeatures {
 impl From<&Message> for AadAccelFeatures {
     /// from creates new AadAccelFeatures struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.time = field.value.as_u16(),
+                1 => v.energy_total = field.value.as_u32(),
+                2 => v.zero_cross_cnt = field.value.as_u16(),
+                3 => v.instance = field.value.as_u8(),
+                4 => v.time_above_threshold = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            time: vals[0].as_u16(),
-            energy_total: vals[1].as_u32(),
-            zero_cross_cnt: vals[2].as_u16(),
-            instance: vals[3].as_u8(),
-            time_above_threshold: vals[4].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<AadAccelFeatures> for Message {
     fn from(m: AadAccelFeatures) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.energy_total != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.energy_total),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.zero_cross_cnt != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.zero_cross_cnt),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.instance != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.instance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time_above_threshold != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.time_above_threshold),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::AAD_ACCEL_FEATURES,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/accelerometer_data.rs
@@ -88,6 +88,21 @@ impl AccelerometerData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (!self.sample_time_offset.is_empty()) as usize
+            + (!self.accel_x.is_empty()) as usize
+            + (!self.accel_y.is_empty()) as usize
+            + (!self.accel_z.is_empty()) as usize
+            + (!self.calibrated_accel_x.is_empty()) as usize
+            + (!self.calibrated_accel_y.is_empty()) as usize
+            + (!self.calibrated_accel_z.is_empty()) as usize
+            + (!self.compressed_calibrated_accel_x.is_empty()) as usize
+            + (!self.compressed_calibrated_accel_y.is_empty()) as usize
+            + (!self.compressed_calibrated_accel_z.is_empty()) as usize
+    }
 }
 
 impl Default for AccelerometerData {
@@ -99,172 +114,146 @@ impl Default for AccelerometerData {
 impl From<&Message> for AccelerometerData {
     /// from creates new AccelerometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [2047, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.sample_time_offset = field.value.to_vec_u16(),
+                2 => v.accel_x = field.value.to_vec_u16(),
+                3 => v.accel_y = field.value.to_vec_u16(),
+                4 => v.accel_z = field.value.to_vec_u16(),
+                5 => v.calibrated_accel_x = field.value.to_vec_f32(),
+                6 => v.calibrated_accel_y = field.value.to_vec_f32(),
+                7 => v.calibrated_accel_z = field.value.to_vec_f32(),
+                8 => v.compressed_calibrated_accel_x = field.value.to_vec_i16(),
+                9 => v.compressed_calibrated_accel_y = field.value.to_vec_i16(),
+                10 => v.compressed_calibrated_accel_z = field.value.to_vec_i16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            sample_time_offset: vals[1].to_vec_u16(),
-            accel_x: vals[2].to_vec_u16(),
-            accel_y: vals[3].to_vec_u16(),
-            accel_z: vals[4].to_vec_u16(),
-            calibrated_accel_x: vals[5].to_vec_f32(),
-            calibrated_accel_y: vals[6].to_vec_f32(),
-            calibrated_accel_z: vals[7].to_vec_f32(),
-            compressed_calibrated_accel_x: vals[8].to_vec_i16(),
-            compressed_calibrated_accel_y: vals[9].to_vec_i16(),
-            compressed_calibrated_accel_z: vals[10].to_vec_i16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<AccelerometerData> for Message {
     fn from(m: AccelerometerData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 12];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.sample_time_offset.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.sample_time_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.accel_x.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.accel_x),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.accel_y.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.accel_y),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.accel_z.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.accel_z),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.calibrated_accel_x.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::VecFloat32(m.calibrated_accel_x),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.calibrated_accel_y.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::VecFloat32(m.calibrated_accel_y),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.calibrated_accel_z.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::VecFloat32(m.calibrated_accel_z),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.compressed_calibrated_accel_x.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.compressed_calibrated_accel_x),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.compressed_calibrated_accel_y.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.compressed_calibrated_accel_y),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.compressed_calibrated_accel_z.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.compressed_calibrated_accel_z),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::ACCELEROMETER_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/activity.rs
+++ b/rustyfit/src/profile/mesgdef/activity.rs
@@ -81,6 +81,17 @@ impl Activity {
         self.total_timer_time = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.total_timer_time != u32::MAX) as usize
+            + (self.num_sessions != u16::MAX) as usize
+            + (self.r#type != typedef::Activity(u8::MAX)) as usize
+            + (self.event != typedef::Event(u8::MAX)) as usize
+            + (self.event_type != typedef::EventType(u8::MAX)) as usize
+            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+            + (self.event_group != u8::MAX) as usize
+    }
 }
 
 impl Default for Activity {
@@ -92,132 +103,110 @@ impl Default for Activity {
 impl From<&Message> for Activity {
     /// from creates new Activity struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.total_timer_time = field.value.as_u32(),
+                1 => v.num_sessions = field.value.as_u16(),
+                2 => v.r#type = typedef::Activity(field.value.as_u8()),
+                3 => v.event = typedef::Event(field.value.as_u8()),
+                4 => v.event_type = typedef::EventType(field.value.as_u8()),
+                5 => v.local_timestamp = typedef::LocalDateTime(field.value.as_u32()),
+                6 => v.event_group = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            total_timer_time: vals[0].as_u32(),
-            num_sessions: vals[1].as_u16(),
-            r#type: typedef::Activity(vals[2].as_u8()),
-            event: typedef::Event(vals[3].as_u8()),
-            event_type: typedef::EventType(vals[4].as_u8()),
-            local_timestamp: typedef::LocalDateTime(vals[5].as_u32()),
-            event_group: vals[6].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Activity> for Message {
     fn from(m: Activity) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 8];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_timer_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_timer_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.num_sessions != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.num_sessions),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.r#type != typedef::Activity(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::ACTIVITY,
                 value: Value::Uint8(m.r#type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event != typedef::Event(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::EVENT,
                 value: Value::Uint8(m.event.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_type != typedef::EventType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::EVENT_TYPE,
                 value: Value::Uint8(m.event_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::LOCAL_DATE_TIME,
                 value: Value::Uint32(m.local_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_group != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.event_group),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::ACTIVITY,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/ant_channel_id.rs
+++ b/rustyfit/src/profile/mesgdef/ant_channel_id.rs
@@ -51,6 +51,14 @@ impl AntChannelId {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.channel_number != u8::MAX) as usize
+            + (self.device_type != u8::MIN) as usize
+            + (self.device_number != u16::MIN) as usize
+            + (self.transmission_type != u8::MIN) as usize
+            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+    }
 }
 
 impl Default for AntChannelId {
@@ -62,102 +70,83 @@ impl Default for AntChannelId {
 impl From<&Message> for AntChannelId {
     /// from creates new AntChannelId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 5];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.channel_number = field.value.as_u8(),
+                1 => v.device_type = field.value.as_u8z(),
+                2 => v.device_number = field.value.as_u16z(),
+                3 => v.transmission_type = field.value.as_u8z(),
+                4 => v.device_index = typedef::DeviceIndex(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            channel_number: vals[0].as_u8(),
-            device_type: vals[1].as_u8z(),
-            device_number: vals[2].as_u16z(),
-            transmission_type: vals[3].as_u8z(),
-            device_index: typedef::DeviceIndex(vals[4].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<AntChannelId> for Message {
     fn from(m: AntChannelId) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.channel_number != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.channel_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.device_type != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.device_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.device_number != u16::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16Z,
                 value: Value::Uint16(m.device_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.transmission_type != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.transmission_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.device_index != typedef::DeviceIndex(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::DEVICE_INDEX,
                 value: Value::Uint8(m.device_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::ANT_CHANNEL_ID,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/ant_rx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_rx.rs
@@ -102,6 +102,15 @@ impl AntRx {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.fractional_timestamp != u16::MAX) as usize
+            + (self.mesg_id != u8::MAX) as usize
+            + (!self.mesg_data.is_empty()) as usize
+            + (self.channel_number != u8::MAX) as usize
+            + (!self.data.is_empty()) as usize
+    }
 }
 
 impl Default for AntRx {
@@ -113,118 +122,98 @@ impl Default for AntRx {
 impl From<&Message> for AntRx {
     /// from creates new AntRx struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-        let mut state = [0u8; 1];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.fractional_timestamp = field.value.as_u16(),
+                1 => v.mesg_id = field.value.as_u8(),
+                2 => v.mesg_data = field.value.to_vec_u8(),
+                3 => v.channel_number = field.value.as_u8(),
+                4 => v.data = field.value.to_vec_u8(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 5 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            fractional_timestamp: vals[0].as_u16(),
-            mesg_id: vals[1].as_u8(),
-            mesg_data: vals[2].to_vec_u8(),
-            channel_number: vals[3].as_u8(),
-            data: vals[4].to_vec_u8(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<AntRx> for Message {
     fn from(m: AntRx) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.fractional_timestamp != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.fractional_timestamp),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mesg_id != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::BYTE,
                 value: Value::Uint8(m.mesg_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.mesg_data.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.mesg_data),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.channel_number != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.channel_number),
-                is_expanded: is_expanded(&state, 3),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 3),
+            });
+        };
         if !m.data.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.data),
-                is_expanded: is_expanded(&state, 4),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 4),
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::ANT_RX,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/ant_tx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_tx.rs
@@ -102,6 +102,15 @@ impl AntTx {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.fractional_timestamp != u16::MAX) as usize
+            + (self.mesg_id != u8::MAX) as usize
+            + (!self.mesg_data.is_empty()) as usize
+            + (self.channel_number != u8::MAX) as usize
+            + (!self.data.is_empty()) as usize
+    }
 }
 
 impl Default for AntTx {
@@ -113,118 +122,98 @@ impl Default for AntTx {
 impl From<&Message> for AntTx {
     /// from creates new AntTx struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-        let mut state = [0u8; 1];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.fractional_timestamp = field.value.as_u16(),
+                1 => v.mesg_id = field.value.as_u8(),
+                2 => v.mesg_data = field.value.to_vec_u8(),
+                3 => v.channel_number = field.value.as_u8(),
+                4 => v.data = field.value.to_vec_u8(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 5 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            fractional_timestamp: vals[0].as_u16(),
-            mesg_id: vals[1].as_u8(),
-            mesg_data: vals[2].to_vec_u8(),
-            channel_number: vals[3].as_u8(),
-            data: vals[4].to_vec_u8(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<AntTx> for Message {
     fn from(m: AntTx) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.fractional_timestamp != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.fractional_timestamp),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mesg_id != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::BYTE,
                 value: Value::Uint8(m.mesg_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.mesg_data.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.mesg_data),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.channel_number != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.channel_number),
-                is_expanded: is_expanded(&state, 3),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 3),
+            });
+        };
         if !m.data.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.data),
-                is_expanded: is_expanded(&state, 4),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 4),
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::ANT_TX,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/aviation_attitude.rs
+++ b/rustyfit/src/profile/mesgdef/aviation_attitude.rs
@@ -266,6 +266,21 @@ impl AviationAttitude {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (!self.system_time.is_empty()) as usize
+            + (!self.pitch.is_empty()) as usize
+            + (!self.roll.is_empty()) as usize
+            + (!self.accel_lateral.is_empty()) as usize
+            + (!self.accel_normal.is_empty()) as usize
+            + (!self.turn_rate.is_empty()) as usize
+            + (!self.stage.is_empty()) as usize
+            + (!self.attitude_stage_complete.is_empty()) as usize
+            + (!self.track.is_empty()) as usize
+            + (!self.validity.is_empty()) as usize
+    }
 }
 
 impl Default for AviationAttitude {
@@ -277,142 +292,127 @@ impl Default for AviationAttitude {
 impl From<&Message> for AviationAttitude {
     /// from creates new AviationAttitude struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [2047, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.system_time = field.value.to_vec_u32(),
+                2 => v.pitch = field.value.to_vec_i16(),
+                3 => v.roll = field.value.to_vec_i16(),
+                4 => v.accel_lateral = field.value.to_vec_i16(),
+                5 => v.accel_normal = field.value.to_vec_i16(),
+                6 => v.turn_rate = field.value.to_vec_i16(),
+                7 => {
+                    v.stage = match &field.value {
+                        Value::VecUint8(v) => {
+                            let mut vs = Vec::with_capacity(v.len());
+                            vs.extend(v.iter().map(|&x| typedef::AttitudeStage(x)));
+                            vs
+                        }
+                        _ => Vec::new(),
+                    }
+                }
+                8 => v.attitude_stage_complete = field.value.to_vec_u8(),
+                9 => v.track = field.value.to_vec_u16(),
+                10 => {
+                    v.validity = match &field.value {
+                        Value::VecUint16(v) => {
+                            let mut vs = Vec::with_capacity(v.len());
+                            vs.extend(v.iter().map(|&x| typedef::AttitudeValidity(x)));
+                            vs
+                        }
+                        _ => Vec::new(),
+                    }
+                }
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            system_time: vals[1].to_vec_u32(),
-            pitch: vals[2].to_vec_i16(),
-            roll: vals[3].to_vec_i16(),
-            accel_lateral: vals[4].to_vec_i16(),
-            accel_normal: vals[5].to_vec_i16(),
-            turn_rate: vals[6].to_vec_i16(),
-            stage: match &vals[7] {
-                Value::VecUint8(v) => {
-                    let mut vs = Vec::with_capacity(v.len());
-                    vs.extend(v.iter().map(|&x| typedef::AttitudeStage(x)));
-                    vs
-                }
-                _ => Vec::new(),
-            },
-            attitude_stage_complete: vals[8].to_vec_u8(),
-            track: vals[9].to_vec_u16(),
-            validity: match &vals[10] {
-                Value::VecUint16(v) => {
-                    let mut vs = Vec::with_capacity(v.len());
-                    vs.extend(v.iter().map(|&x| typedef::AttitudeValidity(x)));
-                    vs
-                }
-                _ => Vec::new(),
-            },
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<AviationAttitude> for Message {
     fn from(m: AviationAttitude) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 12];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.system_time.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.system_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.pitch.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.pitch),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.roll.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.roll),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.accel_lateral.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.accel_lateral),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.accel_normal.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.accel_normal),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.turn_rate.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.turn_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.stage.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::ATTITUDE_STAGE,
                 value: Value::VecUint8({
@@ -420,29 +420,26 @@ impl From<AviationAttitude> for Message {
                     unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.attitude_stage_complete.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.attitude_stage_complete),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.track.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.track),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.validity.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::ATTITUDE_VALIDITY,
                 value: Value::VecUint16({
@@ -450,19 +447,15 @@ impl From<AviationAttitude> for Message {
                     unsafe { Vec::from_raw_parts(ptr.cast::<u16>(), len, capacity) }
                 }),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::AVIATION_ATTITUDE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/barometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/barometer_data.rs
@@ -48,6 +48,13 @@ impl BarometerData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (!self.sample_time_offset.is_empty()) as usize
+            + (!self.baro_pres.is_empty()) as usize
+    }
 }
 
 impl Default for BarometerData {
@@ -59,92 +66,74 @@ impl Default for BarometerData {
 impl From<&Message> for BarometerData {
     /// from creates new BarometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.sample_time_offset = field.value.to_vec_u16(),
+                2 => v.baro_pres = field.value.to_vec_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            sample_time_offset: vals[1].to_vec_u16(),
-            baro_pres: vals[2].to_vec_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<BarometerData> for Message {
     fn from(m: BarometerData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.sample_time_offset.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.sample_time_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.baro_pres.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.baro_pres),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::BAROMETER_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/beat_intervals.rs
+++ b/rustyfit/src/profile/mesgdef/beat_intervals.rs
@@ -42,6 +42,12 @@ impl BeatIntervals {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (!self.time.is_empty()) as usize
+    }
 }
 
 impl Default for BeatIntervals {
@@ -53,82 +59,65 @@ impl Default for BeatIntervals {
 impl From<&Message> for BeatIntervals {
     /// from creates new BeatIntervals struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.time = field.value.to_vec_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            time: vals[1].to_vec_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<BeatIntervals> for Message {
     fn from(m: BeatIntervals) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::BEAT_INTERVALS,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/bike_profile.rs
+++ b/rustyfit/src/profile/mesgdef/bike_profile.rs
@@ -291,6 +291,41 @@ impl BikeProfile {
         self.crank_length = unscaled as u8;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (!self.name.is_empty()) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.odometer != u32::MAX) as usize
+            + (self.bike_spd_ant_id != u16::MIN) as usize
+            + (self.bike_cad_ant_id != u16::MIN) as usize
+            + (self.bike_spdcad_ant_id != u16::MIN) as usize
+            + (self.bike_power_ant_id != u16::MIN) as usize
+            + (self.custom_wheelsize != u16::MAX) as usize
+            + (self.auto_wheelsize != u16::MAX) as usize
+            + (self.bike_weight != u16::MAX) as usize
+            + (self.power_cal_factor != u16::MAX) as usize
+            + (self.auto_wheel_cal != typedef::Bool(u8::MAX)) as usize
+            + (self.auto_power_zero != typedef::Bool(u8::MAX)) as usize
+            + (self.id != u8::MAX) as usize
+            + (self.spd_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.cad_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.spdcad_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.power_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.crank_length != u8::MAX) as usize
+            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.bike_spd_ant_id_trans_type != u8::MIN) as usize
+            + (self.bike_cad_ant_id_trans_type != u8::MIN) as usize
+            + (self.bike_spdcad_ant_id_trans_type != u8::MIN) as usize
+            + (self.bike_power_ant_id_trans_type != u8::MIN) as usize
+            + (self.odometer_rollover != u8::MAX) as usize
+            + (self.front_gear_num != u8::MIN) as usize
+            + (!self.front_gear.is_empty()) as usize
+            + (self.rear_gear_num != u8::MIN) as usize
+            + (!self.rear_gear.is_empty()) as usize
+            + (self.shimano_di2_enabled != typedef::Bool(u8::MAX)) as usize
+    }
 }
 
 impl Default for BikeProfile {
@@ -302,372 +337,326 @@ impl Default for BikeProfile {
 impl From<&Message> for BikeProfile {
     /// from creates new BikeProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [21852827156479, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.name = field.value.as_str().to_owned(),
+                1 => v.sport = typedef::Sport(field.value.as_u8()),
+                2 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                3 => v.odometer = field.value.as_u32(),
+                4 => v.bike_spd_ant_id = field.value.as_u16z(),
+                5 => v.bike_cad_ant_id = field.value.as_u16z(),
+                6 => v.bike_spdcad_ant_id = field.value.as_u16z(),
+                7 => v.bike_power_ant_id = field.value.as_u16z(),
+                8 => v.custom_wheelsize = field.value.as_u16(),
+                9 => v.auto_wheelsize = field.value.as_u16(),
+                10 => v.bike_weight = field.value.as_u16(),
+                11 => v.power_cal_factor = field.value.as_u16(),
+                12 => v.auto_wheel_cal = typedef::Bool(field.value.as_u8()),
+                13 => v.auto_power_zero = typedef::Bool(field.value.as_u8()),
+                14 => v.id = field.value.as_u8(),
+                15 => v.spd_enabled = typedef::Bool(field.value.as_u8()),
+                16 => v.cad_enabled = typedef::Bool(field.value.as_u8()),
+                17 => v.spdcad_enabled = typedef::Bool(field.value.as_u8()),
+                18 => v.power_enabled = typedef::Bool(field.value.as_u8()),
+                19 => v.crank_length = field.value.as_u8(),
+                20 => v.enabled = typedef::Bool(field.value.as_u8()),
+                21 => v.bike_spd_ant_id_trans_type = field.value.as_u8z(),
+                22 => v.bike_cad_ant_id_trans_type = field.value.as_u8z(),
+                23 => v.bike_spdcad_ant_id_trans_type = field.value.as_u8z(),
+                24 => v.bike_power_ant_id_trans_type = field.value.as_u8z(),
+                37 => v.odometer_rollover = field.value.as_u8(),
+                38 => v.front_gear_num = field.value.as_u8z(),
+                39 => v.front_gear = field.value.to_vec_u8(),
+                40 => v.rear_gear_num = field.value.as_u8z(),
+                41 => v.rear_gear = field.value.to_vec_u8(),
+                44 => v.shimano_di2_enabled = typedef::Bool(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            name: vals[0].as_str().to_owned(),
-            sport: typedef::Sport(vals[1].as_u8()),
-            sub_sport: typedef::SubSport(vals[2].as_u8()),
-            odometer: vals[3].as_u32(),
-            bike_spd_ant_id: vals[4].as_u16z(),
-            bike_cad_ant_id: vals[5].as_u16z(),
-            bike_spdcad_ant_id: vals[6].as_u16z(),
-            bike_power_ant_id: vals[7].as_u16z(),
-            custom_wheelsize: vals[8].as_u16(),
-            auto_wheelsize: vals[9].as_u16(),
-            bike_weight: vals[10].as_u16(),
-            power_cal_factor: vals[11].as_u16(),
-            auto_wheel_cal: typedef::Bool(vals[12].as_u8()),
-            auto_power_zero: typedef::Bool(vals[13].as_u8()),
-            id: vals[14].as_u8(),
-            spd_enabled: typedef::Bool(vals[15].as_u8()),
-            cad_enabled: typedef::Bool(vals[16].as_u8()),
-            spdcad_enabled: typedef::Bool(vals[17].as_u8()),
-            power_enabled: typedef::Bool(vals[18].as_u8()),
-            crank_length: vals[19].as_u8(),
-            enabled: typedef::Bool(vals[20].as_u8()),
-            bike_spd_ant_id_trans_type: vals[21].as_u8z(),
-            bike_cad_ant_id_trans_type: vals[22].as_u8z(),
-            bike_spdcad_ant_id_trans_type: vals[23].as_u8z(),
-            bike_power_ant_id_trans_type: vals[24].as_u8z(),
-            odometer_rollover: vals[37].as_u8(),
-            front_gear_num: vals[38].as_u8z(),
-            front_gear: vals[39].to_vec_u8(),
-            rear_gear_num: vals[40].as_u8z(),
-            rear_gear: vals[41].to_vec_u8(),
-            shimano_di2_enabled: typedef::Bool(vals[44].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<BikeProfile> for Message {
     fn from(m: BikeProfile) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 32];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.odometer != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.odometer),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bike_spd_ant_id != u16::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16Z,
                 value: Value::Uint16(m.bike_spd_ant_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bike_cad_ant_id != u16::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16Z,
                 value: Value::Uint16(m.bike_cad_ant_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bike_spdcad_ant_id != u16::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT16Z,
                 value: Value::Uint16(m.bike_spdcad_ant_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bike_power_ant_id != u16::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT16Z,
                 value: Value::Uint16(m.bike_power_ant_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.custom_wheelsize != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.custom_wheelsize),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.auto_wheelsize != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.auto_wheelsize),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bike_weight != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.bike_weight),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.power_cal_factor != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.power_cal_factor),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.auto_wheel_cal != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.auto_wheel_cal.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.auto_power_zero != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.auto_power_zero.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.id != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.spd_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.spd_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cad_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.cad_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.spdcad_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.spdcad_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.power_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.power_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.crank_length != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.crank_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 20,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bike_spd_ant_id_trans_type != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.bike_spd_ant_id_trans_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bike_cad_ant_id_trans_type != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.bike_cad_ant_id_trans_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bike_spdcad_ant_id_trans_type != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.bike_spdcad_ant_id_trans_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bike_power_ant_id_trans_type != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.bike_power_ant_id_trans_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.odometer_rollover != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 37,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.odometer_rollover),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.front_gear_num != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 38,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.front_gear_num),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.front_gear.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 39,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::VecUint8(m.front_gear),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.rear_gear_num != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 40,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.rear_gear_num),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.rear_gear.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 41,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::VecUint8(m.rear_gear),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.shimano_di2_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 44,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.shimano_di2_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::BIKE_PROFILE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/blood_pressure.rs
+++ b/rustyfit/src/profile/mesgdef/blood_pressure.rs
@@ -81,6 +81,20 @@ impl BloodPressure {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.systolic_pressure != u16::MAX) as usize
+            + (self.diastolic_pressure != u16::MAX) as usize
+            + (self.mean_arterial_pressure != u16::MAX) as usize
+            + (self.map_3_sample_mean != u16::MAX) as usize
+            + (self.map_morning_values != u16::MAX) as usize
+            + (self.map_evening_values != u16::MAX) as usize
+            + (self.heart_rate != u8::MAX) as usize
+            + (self.heart_rate_type != typedef::HrType(u8::MAX)) as usize
+            + (self.status != typedef::BpStatus(u8::MAX)) as usize
+            + (self.user_profile_index != typedef::MessageIndex(u16::MAX)) as usize
+    }
 }
 
 impl Default for BloodPressure {
@@ -92,162 +106,137 @@ impl Default for BloodPressure {
 impl From<&Message> for BloodPressure {
     /// from creates new BloodPressure struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [1023, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.systolic_pressure = field.value.as_u16(),
+                1 => v.diastolic_pressure = field.value.as_u16(),
+                2 => v.mean_arterial_pressure = field.value.as_u16(),
+                3 => v.map_3_sample_mean = field.value.as_u16(),
+                4 => v.map_morning_values = field.value.as_u16(),
+                5 => v.map_evening_values = field.value.as_u16(),
+                6 => v.heart_rate = field.value.as_u8(),
+                7 => v.heart_rate_type = typedef::HrType(field.value.as_u8()),
+                8 => v.status = typedef::BpStatus(field.value.as_u8()),
+                9 => v.user_profile_index = typedef::MessageIndex(field.value.as_u16()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            systolic_pressure: vals[0].as_u16(),
-            diastolic_pressure: vals[1].as_u16(),
-            mean_arterial_pressure: vals[2].as_u16(),
-            map_3_sample_mean: vals[3].as_u16(),
-            map_morning_values: vals[4].as_u16(),
-            map_evening_values: vals[5].as_u16(),
-            heart_rate: vals[6].as_u8(),
-            heart_rate_type: typedef::HrType(vals[7].as_u8()),
-            status: typedef::BpStatus(vals[8].as_u8()),
-            user_profile_index: typedef::MessageIndex(vals[9].as_u16()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<BloodPressure> for Message {
     fn from(m: BloodPressure) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 11];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.systolic_pressure != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.systolic_pressure),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.diastolic_pressure != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.diastolic_pressure),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mean_arterial_pressure != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.mean_arterial_pressure),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.map_3_sample_mean != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.map_3_sample_mean),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.map_morning_values != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.map_morning_values),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.map_evening_values != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.map_evening_values),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.heart_rate_type != typedef::HrType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::HR_TYPE,
                 value: Value::Uint8(m.heart_rate_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.status != typedef::BpStatus(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BP_STATUS,
                 value: Value::Uint8(m.status.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.user_profile_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.user_profile_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::BLOOD_PRESSURE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/cadence_zone.rs
+++ b/rustyfit/src/profile/mesgdef/cadence_zone.rs
@@ -43,6 +43,12 @@ impl CadenceZone {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.high_value != u8::MAX) as usize
+            + (!self.name.is_empty()) as usize
+    }
 }
 
 impl Default for CadenceZone {
@@ -54,82 +60,65 @@ impl Default for CadenceZone {
 impl From<&Message> for CadenceZone {
     /// from creates new CadenceZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.high_value = field.value.as_u8(),
+                1 => v.name = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            high_value: vals[0].as_u8(),
-            name: vals[1].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<CadenceZone> for Message {
     fn from(m: CadenceZone) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.high_value != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.high_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::CADENCE_ZONE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/camera_event.rs
+++ b/rustyfit/src/profile/mesgdef/camera_event.rs
@@ -52,6 +52,14 @@ impl CameraEvent {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (self.camera_event_type != typedef::CameraEventType(u8::MAX)) as usize
+            + (!self.camera_file_uuid.is_empty()) as usize
+            + (self.camera_orientation != typedef::CameraOrientationType(u8::MAX)) as usize
+    }
 }
 
 impl Default for CameraEvent {
@@ -63,102 +71,83 @@ impl Default for CameraEvent {
 impl From<&Message> for CameraEvent {
     /// from creates new CameraEvent struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.camera_event_type = typedef::CameraEventType(field.value.as_u8()),
+                2 => v.camera_file_uuid = field.value.as_str().to_owned(),
+                3 => v.camera_orientation = typedef::CameraOrientationType(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            camera_event_type: typedef::CameraEventType(vals[1].as_u8()),
-            camera_file_uuid: vals[2].as_str().to_owned(),
-            camera_orientation: typedef::CameraOrientationType(vals[3].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<CameraEvent> for Message {
     fn from(m: CameraEvent) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.camera_event_type != typedef::CameraEventType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::CAMERA_EVENT_TYPE,
                 value: Value::Uint8(m.camera_event_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.camera_file_uuid.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.camera_file_uuid),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.camera_orientation != typedef::CameraOrientationType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::CAMERA_ORIENTATION_TYPE,
                 value: Value::Uint8(m.camera_orientation.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::CAMERA_EVENT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/capabilities.rs
@@ -48,6 +48,13 @@ impl Capabilities {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (!self.languages.is_empty()) as usize
+            + (!self.sports.is_empty()) as usize
+            + (self.workouts_supported != typedef::WorkoutCapabilities(u32::MIN)) as usize
+            + (self.connectivity_supported != typedef::ConnectivityCapabilities(u32::MIN)) as usize
+    }
 }
 
 impl Default for Capabilities {
@@ -59,64 +66,57 @@ impl Default for Capabilities {
 impl From<&Message> for Capabilities {
     /// from creates new Capabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 24];
-
         const KNOWN_NUMS: [u64; 4] = [10485763, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.languages = field.value.to_vec_u8(),
+                1 => {
+                    v.sports = match &field.value {
+                        Value::VecUint8(v) => {
+                            let mut vs = Vec::with_capacity(v.len());
+                            vs.extend(v.iter().map(|&x| typedef::SportBits0(x)));
+                            vs
+                        }
+                        _ => Vec::new(),
+                    }
+                }
+                21 => v.workouts_supported = typedef::WorkoutCapabilities(field.value.as_u32z()),
+                23 => {
+                    v.connectivity_supported =
+                        typedef::ConnectivityCapabilities(field.value.as_u32z())
+                }
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            languages: vals[0].to_vec_u8(),
-            sports: match &vals[1] {
-                Value::VecUint8(v) => {
-                    let mut vs = Vec::with_capacity(v.len());
-                    vs.extend(v.iter().map(|&x| typedef::SportBits0(x)));
-                    vs
-                }
-                _ => Vec::new(),
-            },
-            workouts_supported: typedef::WorkoutCapabilities(vals[21].as_u32z()),
-            connectivity_supported: typedef::ConnectivityCapabilities(vals[23].as_u32z()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Capabilities> for Message {
     fn from(m: Capabilities) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if !m.languages.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::VecUint8(m.languages),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.sports.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SPORT_BITS_0,
                 value: Value::VecUint8({
@@ -124,37 +124,31 @@ impl From<Capabilities> for Message {
                     unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.workouts_supported != typedef::WorkoutCapabilities(u32::MIN) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::WORKOUT_CAPABILITIES,
                 value: Value::Uint32(m.workouts_supported.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.connectivity_supported != typedef::ConnectivityCapabilities(u32::MIN) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::CONNECTIVITY_CAPABILITIES,
                 value: Value::Uint32(m.connectivity_supported.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::CAPABILITIES,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
@@ -60,6 +60,12 @@ impl ChronoShotData {
         self.shot_speed = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.shot_speed != u32::MAX) as usize
+            + (self.shot_num != u16::MAX) as usize
+    }
 }
 
 impl Default for ChronoShotData {
@@ -71,82 +77,65 @@ impl Default for ChronoShotData {
 impl From<&Message> for ChronoShotData {
     /// from creates new ChronoShotData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.shot_speed = field.value.as_u32(),
+                1 => v.shot_num = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            shot_speed: vals[0].as_u32(),
-            shot_num: vals[1].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ChronoShotData> for Message {
     fn from(m: ChronoShotData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.shot_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.shot_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.shot_num != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.shot_num),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::CHRONO_SHOT_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
@@ -160,6 +160,17 @@ impl ChronoShotSession {
         self.standard_deviation = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.min_speed != u32::MAX) as usize
+            + (self.max_speed != u32::MAX) as usize
+            + (self.avg_speed != u32::MAX) as usize
+            + (self.shot_count != u16::MAX) as usize
+            + (self.projectile_type != typedef::ProjectileType(u8::MAX)) as usize
+            + (self.grain_weight != u32::MAX) as usize
+            + (self.standard_deviation != u32::MAX) as usize
+    }
 }
 
 impl Default for ChronoShotSession {
@@ -171,132 +182,110 @@ impl Default for ChronoShotSession {
 impl From<&Message> for ChronoShotSession {
     /// from creates new ChronoShotSession struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.min_speed = field.value.as_u32(),
+                1 => v.max_speed = field.value.as_u32(),
+                2 => v.avg_speed = field.value.as_u32(),
+                3 => v.shot_count = field.value.as_u16(),
+                4 => v.projectile_type = typedef::ProjectileType(field.value.as_u8()),
+                5 => v.grain_weight = field.value.as_u32(),
+                6 => v.standard_deviation = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            min_speed: vals[0].as_u32(),
-            max_speed: vals[1].as_u32(),
-            avg_speed: vals[2].as_u32(),
-            shot_count: vals[3].as_u16(),
-            projectile_type: typedef::ProjectileType(vals[4].as_u8()),
-            grain_weight: vals[5].as_u32(),
-            standard_deviation: vals[6].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ChronoShotSession> for Message {
     fn from(m: ChronoShotSession) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 8];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.min_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.max_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.avg_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.shot_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.shot_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.projectile_type != typedef::ProjectileType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::PROJECTILE_TYPE,
                 value: Value::Uint8(m.projectile_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.grain_weight != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.grain_weight),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.standard_deviation != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.standard_deviation),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::CHRONO_SHOT_SESSION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/climb_pro.rs
+++ b/rustyfit/src/profile/mesgdef/climb_pro.rs
@@ -71,6 +71,16 @@ impl ClimbPro {
     pub fn position_long_degrees(&self) -> f64 {
         semconv::to_degrees(self.position_long)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.position_lat != i32::MAX) as usize
+            + (self.position_long != i32::MAX) as usize
+            + (self.climb_pro_event != typedef::ClimbProEvent(u8::MAX)) as usize
+            + (self.climb_number != u16::MAX) as usize
+            + (self.climb_category != u8::MAX) as usize
+            + (self.current_dist != f32::MAX) as usize
+    }
 }
 
 impl Default for ClimbPro {
@@ -82,122 +92,101 @@ impl Default for ClimbPro {
 impl From<&Message> for ClimbPro {
     /// from creates new ClimbPro struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.position_lat = field.value.as_i32(),
+                1 => v.position_long = field.value.as_i32(),
+                2 => v.climb_pro_event = typedef::ClimbProEvent(field.value.as_u8()),
+                3 => v.climb_number = field.value.as_u16(),
+                4 => v.climb_category = field.value.as_u8(),
+                5 => v.current_dist = field.value.as_f32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            position_lat: vals[0].as_i32(),
-            position_long: vals[1].as_i32(),
-            climb_pro_event: typedef::ClimbProEvent(vals[2].as_u8()),
-            climb_number: vals[3].as_u16(),
-            climb_category: vals[4].as_u8(),
-            current_dist: vals[5].as_f32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ClimbPro> for Message {
     fn from(m: ClimbPro) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.climb_pro_event != typedef::ClimbProEvent(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::CLIMB_PRO_EVENT,
                 value: Value::Uint8(m.climb_pro_event.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.climb_number != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.climb_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.climb_category != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.climb_category),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.current_dist != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.current_dist),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::CLIMB_PRO,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/connectivity.rs
+++ b/rustyfit/src/profile/mesgdef/connectivity.rs
@@ -85,6 +85,22 @@ impl Connectivity {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.bluetooth_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.bluetooth_le_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.ant_enabled != typedef::Bool(u8::MAX)) as usize
+            + (!self.name.is_empty()) as usize
+            + (self.live_tracking_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.weather_conditions_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.weather_alerts_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.auto_activity_upload_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.course_download_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.workout_download_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.gps_ephemeris_download_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.incident_detection_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.grouptrack_enabled != typedef::Bool(u8::MAX)) as usize
+    }
 }
 
 impl Default for Connectivity {
@@ -96,182 +112,155 @@ impl Default for Connectivity {
 impl From<&Message> for Connectivity {
     /// from creates new Connectivity struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 13];
-
         const KNOWN_NUMS: [u64; 4] = [8191, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.bluetooth_enabled = typedef::Bool(field.value.as_u8()),
+                1 => v.bluetooth_le_enabled = typedef::Bool(field.value.as_u8()),
+                2 => v.ant_enabled = typedef::Bool(field.value.as_u8()),
+                3 => v.name = field.value.as_str().to_owned(),
+                4 => v.live_tracking_enabled = typedef::Bool(field.value.as_u8()),
+                5 => v.weather_conditions_enabled = typedef::Bool(field.value.as_u8()),
+                6 => v.weather_alerts_enabled = typedef::Bool(field.value.as_u8()),
+                7 => v.auto_activity_upload_enabled = typedef::Bool(field.value.as_u8()),
+                8 => v.course_download_enabled = typedef::Bool(field.value.as_u8()),
+                9 => v.workout_download_enabled = typedef::Bool(field.value.as_u8()),
+                10 => v.gps_ephemeris_download_enabled = typedef::Bool(field.value.as_u8()),
+                11 => v.incident_detection_enabled = typedef::Bool(field.value.as_u8()),
+                12 => v.grouptrack_enabled = typedef::Bool(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            bluetooth_enabled: typedef::Bool(vals[0].as_u8()),
-            bluetooth_le_enabled: typedef::Bool(vals[1].as_u8()),
-            ant_enabled: typedef::Bool(vals[2].as_u8()),
-            name: vals[3].as_str().to_owned(),
-            live_tracking_enabled: typedef::Bool(vals[4].as_u8()),
-            weather_conditions_enabled: typedef::Bool(vals[5].as_u8()),
-            weather_alerts_enabled: typedef::Bool(vals[6].as_u8()),
-            auto_activity_upload_enabled: typedef::Bool(vals[7].as_u8()),
-            course_download_enabled: typedef::Bool(vals[8].as_u8()),
-            workout_download_enabled: typedef::Bool(vals[9].as_u8()),
-            gps_ephemeris_download_enabled: typedef::Bool(vals[10].as_u8()),
-            incident_detection_enabled: typedef::Bool(vals[11].as_u8()),
-            grouptrack_enabled: typedef::Bool(vals[12].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Connectivity> for Message {
     fn from(m: Connectivity) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 13];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.bluetooth_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.bluetooth_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bluetooth_le_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.bluetooth_le_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ant_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.ant_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.live_tracking_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.live_tracking_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weather_conditions_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.weather_conditions_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weather_alerts_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.weather_alerts_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.auto_activity_upload_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.auto_activity_upload_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.course_download_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.course_download_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.workout_download_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.workout_download_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.gps_ephemeris_download_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.gps_ephemeris_download_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.incident_detection_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.incident_detection_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.grouptrack_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.grouptrack_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::CONNECTIVITY,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/course.rs
+++ b/rustyfit/src/profile/mesgdef/course.rs
@@ -47,6 +47,13 @@ impl Course {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (!self.name.is_empty()) as usize
+            + (self.capabilities != typedef::CourseCapabilities(u32::MIN)) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+    }
 }
 
 impl Default for Course {
@@ -58,92 +65,74 @@ impl Default for Course {
 impl From<&Message> for Course {
     /// from creates new Course struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 8];
-
         const KNOWN_NUMS: [u64; 4] = [240, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                4 => v.sport = typedef::Sport(field.value.as_u8()),
+                5 => v.name = field.value.as_str().to_owned(),
+                6 => v.capabilities = typedef::CourseCapabilities(field.value.as_u32z()),
+                7 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            sport: typedef::Sport(vals[4].as_u8()),
-            name: vals[5].as_str().to_owned(),
-            capabilities: typedef::CourseCapabilities(vals[6].as_u32z()),
-            sub_sport: typedef::SubSport(vals[7].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Course> for Message {
     fn from(m: Course) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.capabilities != typedef::CourseCapabilities(u32::MIN) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::COURSE_CAPABILITIES,
                 value: Value::Uint32(m.capabilities.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::COURSE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -95,6 +95,17 @@ impl CoursePoint {
         self.distance = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.position_lat != i32::MAX) as usize
+            + (self.position_long != i32::MAX) as usize
+            + (self.distance != u32::MAX) as usize
+            + (self.r#type != typedef::CoursePoint(u8::MAX)) as usize
+            + (!self.name.is_empty()) as usize
+            + (self.favorite != typedef::Bool(u8::MAX)) as usize
+    }
 }
 
 impl Default for CoursePoint {
@@ -106,132 +117,110 @@ impl Default for CoursePoint {
 impl From<&Message> for CoursePoint {
     /// from creates new CoursePoint struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [382, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                1 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                2 => v.position_lat = field.value.as_i32(),
+                3 => v.position_long = field.value.as_i32(),
+                4 => v.distance = field.value.as_u32(),
+                5 => v.r#type = typedef::CoursePoint(field.value.as_u8()),
+                6 => v.name = field.value.as_str().to_owned(),
+                8 => v.favorite = typedef::Bool(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            timestamp: typedef::DateTime(vals[1].as_u32()),
-            position_lat: vals[2].as_i32(),
-            position_long: vals[3].as_i32(),
-            distance: vals[4].as_u32(),
-            r#type: typedef::CoursePoint(vals[5].as_u8()),
-            name: vals[6].as_str().to_owned(),
-            favorite: typedef::Bool(vals[8].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<CoursePoint> for Message {
     fn from(m: CoursePoint) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 8];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.r#type != typedef::CoursePoint(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::COURSE_POINT,
                 value: Value::Uint8(m.r#type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.favorite != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.favorite.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::COURSE_POINT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/developer_data_id.rs
+++ b/rustyfit/src/profile/mesgdef/developer_data_id.rs
@@ -45,6 +45,14 @@ impl DeveloperDataId {
             unknown_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (!self.developer_id.is_empty()) as usize
+            + (!self.application_id.is_empty()) as usize
+            + (self.manufacturer_id != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.developer_data_index != u8::MAX) as usize
+            + (self.application_version != u32::MAX) as usize
+    }
 }
 
 impl Default for DeveloperDataId {
@@ -56,101 +64,82 @@ impl Default for DeveloperDataId {
 impl From<&Message> for DeveloperDataId {
     /// from creates new DeveloperDataId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 5];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.developer_id = field.value.to_vec_u8(),
+                1 => v.application_id = field.value.to_vec_u8(),
+                2 => v.manufacturer_id = typedef::Manufacturer(field.value.as_u16()),
+                3 => v.developer_data_index = field.value.as_u8(),
+                4 => v.application_version = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            developer_id: vals[0].to_vec_u8(),
-            application_id: vals[1].to_vec_u8(),
-            manufacturer_id: typedef::Manufacturer(vals[2].as_u16()),
-            developer_data_index: vals[3].as_u8(),
-            application_version: vals[4].as_u32(),
-            unknown_fields,
-        }
+        v
     }
 }
 
 impl From<DeveloperDataId> for Message {
     fn from(m: DeveloperDataId) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if !m.developer_id.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.developer_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.application_id.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.application_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.manufacturer_id != typedef::Manufacturer(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::MANUFACTURER,
                 value: Value::Uint16(m.manufacturer_id.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.developer_data_index != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.developer_data_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.application_version != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.application_version),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::DEVELOPER_DATA_ID,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: Vec::new(),
         }
     }

--- a/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
@@ -68,6 +68,14 @@ impl DeviceAuxBatteryInfo {
         self.battery_voltage = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+            + (self.battery_voltage != u16::MAX) as usize
+            + (self.battery_status != typedef::BatteryStatus(u8::MAX)) as usize
+            + (self.battery_identifier != u8::MAX) as usize
+    }
 }
 
 impl Default for DeviceAuxBatteryInfo {
@@ -79,102 +87,83 @@ impl Default for DeviceAuxBatteryInfo {
 impl From<&Message> for DeviceAuxBatteryInfo {
     /// from creates new DeviceAuxBatteryInfo struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.device_index = typedef::DeviceIndex(field.value.as_u8()),
+                1 => v.battery_voltage = field.value.as_u16(),
+                2 => v.battery_status = typedef::BatteryStatus(field.value.as_u8()),
+                3 => v.battery_identifier = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            device_index: typedef::DeviceIndex(vals[0].as_u8()),
-            battery_voltage: vals[1].as_u16(),
-            battery_status: typedef::BatteryStatus(vals[2].as_u8()),
-            battery_identifier: vals[3].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<DeviceAuxBatteryInfo> for Message {
     fn from(m: DeviceAuxBatteryInfo) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.device_index != typedef::DeviceIndex(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DEVICE_INDEX,
                 value: Value::Uint8(m.device_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.battery_voltage != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.battery_voltage),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.battery_status != typedef::BatteryStatus(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BATTERY_STATUS,
                 value: Value::Uint8(m.battery_status.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.battery_identifier != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.battery_identifier),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::DEVICE_AUX_BATTERY_INFO,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/device_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_info.rs
@@ -155,6 +155,28 @@ impl DeviceInfo {
         self.battery_voltage = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+            + (self.device_type != u8::MAX) as usize
+            + (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.serial_number != u32::MIN) as usize
+            + (self.product != u16::MAX) as usize
+            + (self.software_version != u16::MAX) as usize
+            + (self.hardware_version != u8::MAX) as usize
+            + (self.cum_operating_time != u32::MAX) as usize
+            + (self.battery_voltage != u16::MAX) as usize
+            + (self.battery_status != typedef::BatteryStatus(u8::MAX)) as usize
+            + (self.sensor_position != typedef::BodyLocation(u8::MAX)) as usize
+            + (!self.descriptor.is_empty()) as usize
+            + (self.ant_transmission_type != u8::MIN) as usize
+            + (self.ant_device_number != u16::MIN) as usize
+            + (self.ant_network != typedef::AntNetwork(u8::MAX)) as usize
+            + (self.source_type != typedef::SourceType(u8::MAX)) as usize
+            + (!self.product_name.is_empty()) as usize
+            + (self.battery_level != u8::MAX) as usize
+    }
 }
 
 impl Default for DeviceInfo {
@@ -166,242 +188,209 @@ impl Default for DeviceInfo {
 impl From<&Message> for DeviceInfo {
     /// from creates new DeviceInfo struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [4470869247, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.device_index = typedef::DeviceIndex(field.value.as_u8()),
+                1 => v.device_type = field.value.as_u8(),
+                2 => v.manufacturer = typedef::Manufacturer(field.value.as_u16()),
+                3 => v.serial_number = field.value.as_u32z(),
+                4 => v.product = field.value.as_u16(),
+                5 => v.software_version = field.value.as_u16(),
+                6 => v.hardware_version = field.value.as_u8(),
+                7 => v.cum_operating_time = field.value.as_u32(),
+                10 => v.battery_voltage = field.value.as_u16(),
+                11 => v.battery_status = typedef::BatteryStatus(field.value.as_u8()),
+                18 => v.sensor_position = typedef::BodyLocation(field.value.as_u8()),
+                19 => v.descriptor = field.value.as_str().to_owned(),
+                20 => v.ant_transmission_type = field.value.as_u8z(),
+                21 => v.ant_device_number = field.value.as_u16z(),
+                22 => v.ant_network = typedef::AntNetwork(field.value.as_u8()),
+                25 => v.source_type = typedef::SourceType(field.value.as_u8()),
+                27 => v.product_name = field.value.as_str().to_owned(),
+                32 => v.battery_level = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            device_index: typedef::DeviceIndex(vals[0].as_u8()),
-            device_type: vals[1].as_u8(),
-            manufacturer: typedef::Manufacturer(vals[2].as_u16()),
-            serial_number: vals[3].as_u32z(),
-            product: vals[4].as_u16(),
-            software_version: vals[5].as_u16(),
-            hardware_version: vals[6].as_u8(),
-            cum_operating_time: vals[7].as_u32(),
-            battery_voltage: vals[10].as_u16(),
-            battery_status: typedef::BatteryStatus(vals[11].as_u8()),
-            sensor_position: typedef::BodyLocation(vals[18].as_u8()),
-            descriptor: vals[19].as_str().to_owned(),
-            ant_transmission_type: vals[20].as_u8z(),
-            ant_device_number: vals[21].as_u16z(),
-            ant_network: typedef::AntNetwork(vals[22].as_u8()),
-            source_type: typedef::SourceType(vals[25].as_u8()),
-            product_name: vals[27].as_str().to_owned(),
-            battery_level: vals[32].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<DeviceInfo> for Message {
     fn from(m: DeviceInfo) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 19];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.device_index != typedef::DeviceIndex(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DEVICE_INDEX,
                 value: Value::Uint8(m.device_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.device_type != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.device_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.manufacturer != typedef::Manufacturer(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::MANUFACTURER,
                 value: Value::Uint16(m.manufacturer.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.serial_number != u32::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32Z,
                 value: Value::Uint32(m.serial_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.product != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.product),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.software_version != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.software_version),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hardware_version != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.hardware_version),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cum_operating_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.cum_operating_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.battery_voltage != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.battery_voltage),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.battery_status != typedef::BatteryStatus(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::BATTERY_STATUS,
                 value: Value::Uint8(m.battery_status.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sensor_position != typedef::BodyLocation(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::BODY_LOCATION,
                 value: Value::Uint8(m.sensor_position.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.descriptor.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.descriptor),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ant_transmission_type != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 20,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.ant_transmission_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ant_device_number != u16::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::UINT16Z,
                 value: Value::Uint16(m.ant_device_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ant_network != typedef::AntNetwork(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::ANT_NETWORK,
                 value: Value::Uint8(m.ant_network.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.source_type != typedef::SourceType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::SOURCE_TYPE,
                 value: Value::Uint8(m.source_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.product_name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 27,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.product_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.battery_level != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 32,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.battery_level),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::DEVICE_INFO,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/device_settings.rs
+++ b/rustyfit/src/profile/mesgdef/device_settings.rs
@@ -175,6 +175,34 @@ impl DeviceSettings {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.active_time_zone != u8::MAX) as usize
+            + (self.utc_offset != u32::MAX) as usize
+            + (!self.time_offset.is_empty()) as usize
+            + (!self.time_mode.is_empty()) as usize
+            + (!self.time_zone_offset.is_empty()) as usize
+            + (self.backlight_mode != typedef::BacklightMode(u8::MAX)) as usize
+            + (self.activity_tracker_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.clock_time != typedef::DateTime(u32::MAX)) as usize
+            + (!self.pages_enabled.is_empty()) as usize
+            + (self.move_alert_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.date_mode != typedef::DateMode(u8::MAX)) as usize
+            + (self.display_orientation != typedef::DisplayOrientation(u8::MAX)) as usize
+            + (self.mounting_side != typedef::Side(u8::MAX)) as usize
+            + (!self.default_page.is_empty()) as usize
+            + (self.autosync_min_steps != u16::MAX) as usize
+            + (self.autosync_min_time != u16::MAX) as usize
+            + (self.lactate_threshold_autodetect_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.ble_auto_upload_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.auto_sync_frequency != typedef::AutoSyncFrequency(u8::MAX)) as usize
+            + (self.auto_activity_detect != typedef::AutoActivityDetect(u32::MAX)) as usize
+            + (self.number_of_screens != u8::MAX) as usize
+            + (self.smart_notification_display_orientation != typedef::DisplayOrientation(u8::MAX))
+                as usize
+            + (self.tap_interface != typedef::Switch(u8::MAX)) as usize
+            + (self.tap_sensitivity != typedef::TapSensitivity(u8::MAX)) as usize
+    }
 }
 
 impl Default for DeviceSettings {
@@ -186,102 +214,93 @@ impl Default for DeviceSettings {
 impl From<&Message> for DeviceSettings {
     /// from creates new DeviceSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 175];
-
         const KNOWN_NUMS: [u64; 4] = [1117105531807338551, 3326148608, 70368744177728, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.active_time_zone = field.value.as_u8(),
+                1 => v.utc_offset = field.value.as_u32(),
+                2 => v.time_offset = field.value.to_vec_u32(),
+                4 => {
+                    v.time_mode = match &field.value {
+                        Value::VecUint8(v) => {
+                            let mut vs = Vec::with_capacity(v.len());
+                            vs.extend(v.iter().map(|&x| typedef::TimeMode(x)));
+                            vs
+                        }
+                        _ => Vec::new(),
+                    }
+                }
+                5 => v.time_zone_offset = field.value.to_vec_i8(),
+                12 => v.backlight_mode = typedef::BacklightMode(field.value.as_u8()),
+                36 => v.activity_tracker_enabled = typedef::Bool(field.value.as_u8()),
+                39 => v.clock_time = typedef::DateTime(field.value.as_u32()),
+                40 => v.pages_enabled = field.value.to_vec_u16(),
+                46 => v.move_alert_enabled = typedef::Bool(field.value.as_u8()),
+                47 => v.date_mode = typedef::DateMode(field.value.as_u8()),
+                55 => v.display_orientation = typedef::DisplayOrientation(field.value.as_u8()),
+                56 => v.mounting_side = typedef::Side(field.value.as_u8()),
+                57 => v.default_page = field.value.to_vec_u16(),
+                58 => v.autosync_min_steps = field.value.as_u16(),
+                59 => v.autosync_min_time = field.value.as_u16(),
+                80 => v.lactate_threshold_autodetect_enabled = typedef::Bool(field.value.as_u8()),
+                86 => v.ble_auto_upload_enabled = typedef::Bool(field.value.as_u8()),
+                89 => v.auto_sync_frequency = typedef::AutoSyncFrequency(field.value.as_u8()),
+                90 => v.auto_activity_detect = typedef::AutoActivityDetect(field.value.as_u32()),
+                94 => v.number_of_screens = field.value.as_u8(),
+                95 => {
+                    v.smart_notification_display_orientation =
+                        typedef::DisplayOrientation(field.value.as_u8())
+                }
+                134 => v.tap_interface = typedef::Switch(field.value.as_u8()),
+                174 => v.tap_sensitivity = typedef::TapSensitivity(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            active_time_zone: vals[0].as_u8(),
-            utc_offset: vals[1].as_u32(),
-            time_offset: vals[2].to_vec_u32(),
-            time_mode: match &vals[4] {
-                Value::VecUint8(v) => {
-                    let mut vs = Vec::with_capacity(v.len());
-                    vs.extend(v.iter().map(|&x| typedef::TimeMode(x)));
-                    vs
-                }
-                _ => Vec::new(),
-            },
-            time_zone_offset: vals[5].to_vec_i8(),
-            backlight_mode: typedef::BacklightMode(vals[12].as_u8()),
-            activity_tracker_enabled: typedef::Bool(vals[36].as_u8()),
-            clock_time: typedef::DateTime(vals[39].as_u32()),
-            pages_enabled: vals[40].to_vec_u16(),
-            move_alert_enabled: typedef::Bool(vals[46].as_u8()),
-            date_mode: typedef::DateMode(vals[47].as_u8()),
-            display_orientation: typedef::DisplayOrientation(vals[55].as_u8()),
-            mounting_side: typedef::Side(vals[56].as_u8()),
-            default_page: vals[57].to_vec_u16(),
-            autosync_min_steps: vals[58].as_u16(),
-            autosync_min_time: vals[59].as_u16(),
-            lactate_threshold_autodetect_enabled: typedef::Bool(vals[80].as_u8()),
-            ble_auto_upload_enabled: typedef::Bool(vals[86].as_u8()),
-            auto_sync_frequency: typedef::AutoSyncFrequency(vals[89].as_u8()),
-            auto_activity_detect: typedef::AutoActivityDetect(vals[90].as_u32()),
-            number_of_screens: vals[94].as_u8(),
-            smart_notification_display_orientation: typedef::DisplayOrientation(vals[95].as_u8()),
-            tap_interface: typedef::Switch(vals[134].as_u8()),
-            tap_sensitivity: typedef::TapSensitivity(vals[174].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<DeviceSettings> for Message {
     fn from(m: DeviceSettings) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 24];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.active_time_zone != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.active_time_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.utc_offset != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.utc_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_offset.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_mode.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::TIME_MODE,
                 value: Value::VecUint8({
@@ -289,199 +308,175 @@ impl From<DeviceSettings> for Message {
                     unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_zone_offset.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SINT8,
                 value: Value::VecInt8(m.time_zone_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.backlight_mode != typedef::BacklightMode(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::BACKLIGHT_MODE,
                 value: Value::Uint8(m.backlight_mode.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.activity_tracker_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 36,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.activity_tracker_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.clock_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 39,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.clock_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.pages_enabled.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 40,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.pages_enabled),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.move_alert_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 46,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.move_alert_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.date_mode != typedef::DateMode(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 47,
                 profile_type: ProfileType::DATE_MODE,
                 value: Value::Uint8(m.date_mode.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.display_orientation != typedef::DisplayOrientation(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 55,
                 profile_type: ProfileType::DISPLAY_ORIENTATION,
                 value: Value::Uint8(m.display_orientation.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mounting_side != typedef::Side(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 56,
                 profile_type: ProfileType::SIDE,
                 value: Value::Uint8(m.mounting_side.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.default_page.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 57,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.default_page),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.autosync_min_steps != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 58,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.autosync_min_steps),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.autosync_min_time != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 59,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.autosync_min_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.lactate_threshold_autodetect_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 80,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.lactate_threshold_autodetect_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ble_auto_upload_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 86,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.ble_auto_upload_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.auto_sync_frequency != typedef::AutoSyncFrequency(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 89,
                 profile_type: ProfileType::AUTO_SYNC_FREQUENCY,
                 value: Value::Uint8(m.auto_sync_frequency.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.auto_activity_detect != typedef::AutoActivityDetect(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 90,
                 profile_type: ProfileType::AUTO_ACTIVITY_DETECT,
                 value: Value::Uint32(m.auto_activity_detect.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.number_of_screens != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 94,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.number_of_screens),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.smart_notification_display_orientation != typedef::DisplayOrientation(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 95,
                 profile_type: ProfileType::DISPLAY_ORIENTATION,
                 value: Value::Uint8(m.smart_notification_display_orientation.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.tap_interface != typedef::Switch(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 134,
                 profile_type: ProfileType::SWITCH,
                 value: Value::Uint8(m.tap_interface.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.tap_sensitivity != typedef::TapSensitivity(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 174,
                 profile_type: ProfileType::TAP_SENSITIVITY,
                 value: Value::Uint8(m.tap_sensitivity.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::DEVICE_SETTINGS,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/dive_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_alarm.rs
@@ -131,6 +131,22 @@ impl DiveAlarm {
         self.speed = unscaled as i32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.depth != u32::MAX) as usize
+            + (self.time != i32::MAX) as usize
+            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.alarm_type != typedef::DiveAlarmType(u8::MAX)) as usize
+            + (self.sound != typedef::Tone(u8::MAX)) as usize
+            + (!self.dive_types.is_empty()) as usize
+            + (self.id != u32::MAX) as usize
+            + (self.popup_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.trigger_on_descent != typedef::Bool(u8::MAX)) as usize
+            + (self.trigger_on_ascent != typedef::Bool(u8::MAX)) as usize
+            + (self.repeating != typedef::Bool(u8::MAX)) as usize
+            + (self.speed != i32::MAX) as usize
+    }
 }
 
 impl Default for DiveAlarm {
@@ -142,118 +158,103 @@ impl Default for DiveAlarm {
 impl From<&Message> for DiveAlarm {
     /// from creates new DiveAlarm struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [4095, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.depth = field.value.as_u32(),
+                1 => v.time = field.value.as_i32(),
+                2 => v.enabled = typedef::Bool(field.value.as_u8()),
+                3 => v.alarm_type = typedef::DiveAlarmType(field.value.as_u8()),
+                4 => v.sound = typedef::Tone(field.value.as_u8()),
+                5 => {
+                    v.dive_types = match &field.value {
+                        Value::VecUint8(v) => {
+                            let mut vs = Vec::with_capacity(v.len());
+                            vs.extend(v.iter().map(|&x| typedef::SubSport(x)));
+                            vs
+                        }
+                        _ => Vec::new(),
+                    }
+                }
+                6 => v.id = field.value.as_u32(),
+                7 => v.popup_enabled = typedef::Bool(field.value.as_u8()),
+                8 => v.trigger_on_descent = typedef::Bool(field.value.as_u8()),
+                9 => v.trigger_on_ascent = typedef::Bool(field.value.as_u8()),
+                10 => v.repeating = typedef::Bool(field.value.as_u8()),
+                11 => v.speed = field.value.as_i32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            depth: vals[0].as_u32(),
-            time: vals[1].as_i32(),
-            enabled: typedef::Bool(vals[2].as_u8()),
-            alarm_type: typedef::DiveAlarmType(vals[3].as_u8()),
-            sound: typedef::Tone(vals[4].as_u8()),
-            dive_types: match &vals[5] {
-                Value::VecUint8(v) => {
-                    let mut vs = Vec::with_capacity(v.len());
-                    vs.extend(v.iter().map(|&x| typedef::SubSport(x)));
-                    vs
-                }
-                _ => Vec::new(),
-            },
-            id: vals[6].as_u32(),
-            popup_enabled: typedef::Bool(vals[7].as_u8()),
-            trigger_on_descent: typedef::Bool(vals[8].as_u8()),
-            trigger_on_ascent: typedef::Bool(vals[9].as_u8()),
-            repeating: typedef::Bool(vals[10].as_u8()),
-            speed: vals[11].as_i32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<DiveAlarm> for Message {
     fn from(m: DiveAlarm) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 13];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.alarm_type != typedef::DiveAlarmType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DIVE_ALARM_TYPE,
                 value: Value::Uint8(m.alarm_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sound != typedef::Tone(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::TONE,
                 value: Value::Uint8(m.sound.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.dive_types.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::VecUint8({
@@ -261,73 +262,63 @@ impl From<DiveAlarm> for Message {
                     unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.id != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.popup_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.popup_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.trigger_on_descent != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.trigger_on_descent.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.trigger_on_ascent != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.trigger_on_ascent.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.repeating != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.repeating.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.speed != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::DIVE_ALARM,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
@@ -131,6 +131,22 @@ impl DiveApneaAlarm {
         self.speed = unscaled as i32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.depth != u32::MAX) as usize
+            + (self.time != i32::MAX) as usize
+            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.alarm_type != typedef::DiveAlarmType(u8::MAX)) as usize
+            + (self.sound != typedef::Tone(u8::MAX)) as usize
+            + (!self.dive_types.is_empty()) as usize
+            + (self.id != u32::MAX) as usize
+            + (self.popup_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.trigger_on_descent != typedef::Bool(u8::MAX)) as usize
+            + (self.trigger_on_ascent != typedef::Bool(u8::MAX)) as usize
+            + (self.repeating != typedef::Bool(u8::MAX)) as usize
+            + (self.speed != i32::MAX) as usize
+    }
 }
 
 impl Default for DiveApneaAlarm {
@@ -142,118 +158,103 @@ impl Default for DiveApneaAlarm {
 impl From<&Message> for DiveApneaAlarm {
     /// from creates new DiveApneaAlarm struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [4095, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.depth = field.value.as_u32(),
+                1 => v.time = field.value.as_i32(),
+                2 => v.enabled = typedef::Bool(field.value.as_u8()),
+                3 => v.alarm_type = typedef::DiveAlarmType(field.value.as_u8()),
+                4 => v.sound = typedef::Tone(field.value.as_u8()),
+                5 => {
+                    v.dive_types = match &field.value {
+                        Value::VecUint8(v) => {
+                            let mut vs = Vec::with_capacity(v.len());
+                            vs.extend(v.iter().map(|&x| typedef::SubSport(x)));
+                            vs
+                        }
+                        _ => Vec::new(),
+                    }
+                }
+                6 => v.id = field.value.as_u32(),
+                7 => v.popup_enabled = typedef::Bool(field.value.as_u8()),
+                8 => v.trigger_on_descent = typedef::Bool(field.value.as_u8()),
+                9 => v.trigger_on_ascent = typedef::Bool(field.value.as_u8()),
+                10 => v.repeating = typedef::Bool(field.value.as_u8()),
+                11 => v.speed = field.value.as_i32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            depth: vals[0].as_u32(),
-            time: vals[1].as_i32(),
-            enabled: typedef::Bool(vals[2].as_u8()),
-            alarm_type: typedef::DiveAlarmType(vals[3].as_u8()),
-            sound: typedef::Tone(vals[4].as_u8()),
-            dive_types: match &vals[5] {
-                Value::VecUint8(v) => {
-                    let mut vs = Vec::with_capacity(v.len());
-                    vs.extend(v.iter().map(|&x| typedef::SubSport(x)));
-                    vs
-                }
-                _ => Vec::new(),
-            },
-            id: vals[6].as_u32(),
-            popup_enabled: typedef::Bool(vals[7].as_u8()),
-            trigger_on_descent: typedef::Bool(vals[8].as_u8()),
-            trigger_on_ascent: typedef::Bool(vals[9].as_u8()),
-            repeating: typedef::Bool(vals[10].as_u8()),
-            speed: vals[11].as_i32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<DiveApneaAlarm> for Message {
     fn from(m: DiveApneaAlarm) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 13];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.alarm_type != typedef::DiveAlarmType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DIVE_ALARM_TYPE,
                 value: Value::Uint8(m.alarm_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sound != typedef::Tone(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::TONE,
                 value: Value::Uint8(m.sound.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.dive_types.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::VecUint8({
@@ -261,73 +262,63 @@ impl From<DiveApneaAlarm> for Message {
                     unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.id != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.popup_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.popup_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.trigger_on_descent != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.trigger_on_descent.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.trigger_on_ascent != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.trigger_on_ascent.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.repeating != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.repeating.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.speed != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::DIVE_APNEA_ALARM,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/dive_gas.rs
+++ b/rustyfit/src/profile/mesgdef/dive_gas.rs
@@ -50,6 +50,14 @@ impl DiveGas {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.helium_content != u8::MAX) as usize
+            + (self.oxygen_content != u8::MAX) as usize
+            + (self.status != typedef::DiveGasStatus(u8::MAX)) as usize
+            + (self.mode != typedef::DiveGasMode(u8::MAX)) as usize
+    }
 }
 
 impl Default for DiveGas {
@@ -61,102 +69,83 @@ impl Default for DiveGas {
 impl From<&Message> for DiveGas {
     /// from creates new DiveGas struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.helium_content = field.value.as_u8(),
+                1 => v.oxygen_content = field.value.as_u8(),
+                2 => v.status = typedef::DiveGasStatus(field.value.as_u8()),
+                3 => v.mode = typedef::DiveGasMode(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            helium_content: vals[0].as_u8(),
-            oxygen_content: vals[1].as_u8(),
-            status: typedef::DiveGasStatus(vals[2].as_u8()),
-            mode: typedef::DiveGasMode(vals[3].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<DiveGas> for Message {
     fn from(m: DiveGas) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.helium_content != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.helium_content),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.oxygen_content != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.oxygen_content),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.status != typedef::DiveGasStatus(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DIVE_GAS_STATUS,
                 value: Value::Uint8(m.status.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mode != typedef::DiveGasMode(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DIVE_GAS_MODE,
                 value: Value::Uint8(m.mode.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::DIVE_GAS,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/dive_settings.rs
+++ b/rustyfit/src/profile/mesgdef/dive_settings.rs
@@ -342,6 +342,46 @@ impl DiveSettings {
         self.last_stop_multiple = unscaled as u8;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (!self.name.is_empty()) as usize
+            + (self.model != typedef::TissueModelType(u8::MAX)) as usize
+            + (self.gf_low != u8::MAX) as usize
+            + (self.gf_high != u8::MAX) as usize
+            + (self.water_type != typedef::WaterType(u8::MAX)) as usize
+            + (self.water_density != f32::MAX) as usize
+            + (self.po2_warn != u8::MAX) as usize
+            + (self.po2_critical != u8::MAX) as usize
+            + (self.po2_deco != u8::MAX) as usize
+            + (self.safety_stop_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.bottom_depth != f32::MAX) as usize
+            + (self.bottom_time != u32::MAX) as usize
+            + (self.apnea_countdown_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.apnea_countdown_time != u32::MAX) as usize
+            + (self.backlight_mode != typedef::DiveBacklightMode(u8::MAX)) as usize
+            + (self.backlight_brightness != u8::MAX) as usize
+            + (self.backlight_timeout != typedef::BacklightTimeout(u8::MAX)) as usize
+            + (self.repeat_dive_interval != u16::MAX) as usize
+            + (self.safety_stop_time != u16::MAX) as usize
+            + (self.heart_rate_source_type != typedef::SourceType(u8::MAX)) as usize
+            + (self.heart_rate_source != u8::MAX) as usize
+            + (self.travel_gas != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.ccr_low_setpoint_switch_mode != typedef::CcrSetpointSwitchMode(u8::MAX))
+                as usize
+            + (self.ccr_low_setpoint != u8::MAX) as usize
+            + (self.ccr_low_setpoint_depth != u32::MAX) as usize
+            + (self.ccr_high_setpoint_switch_mode != typedef::CcrSetpointSwitchMode(u8::MAX))
+                as usize
+            + (self.ccr_high_setpoint != u8::MAX) as usize
+            + (self.ccr_high_setpoint_depth != u32::MAX) as usize
+            + (self.gas_consumption_display != typedef::GasConsumptionRateType(u8::MAX)) as usize
+            + (self.up_key_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.dive_sounds != typedef::Tone(u8::MAX)) as usize
+            + (self.last_stop_multiple != u8::MAX) as usize
+            + (self.no_fly_time_mode != typedef::NoFlyTimeMode(u8::MAX)) as usize
+    }
 }
 
 impl Default for DiveSettings {
@@ -353,402 +393,361 @@ impl Default for DiveSettings {
 impl From<&Message> for DiveSettings {
     /// from creates new DiveSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [242397216767, 0, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.name = field.value.as_str().to_owned(),
+                1 => v.model = typedef::TissueModelType(field.value.as_u8()),
+                2 => v.gf_low = field.value.as_u8(),
+                3 => v.gf_high = field.value.as_u8(),
+                4 => v.water_type = typedef::WaterType(field.value.as_u8()),
+                5 => v.water_density = field.value.as_f32(),
+                6 => v.po2_warn = field.value.as_u8(),
+                7 => v.po2_critical = field.value.as_u8(),
+                8 => v.po2_deco = field.value.as_u8(),
+                9 => v.safety_stop_enabled = typedef::Bool(field.value.as_u8()),
+                10 => v.bottom_depth = field.value.as_f32(),
+                11 => v.bottom_time = field.value.as_u32(),
+                12 => v.apnea_countdown_enabled = typedef::Bool(field.value.as_u8()),
+                13 => v.apnea_countdown_time = field.value.as_u32(),
+                14 => v.backlight_mode = typedef::DiveBacklightMode(field.value.as_u8()),
+                15 => v.backlight_brightness = field.value.as_u8(),
+                16 => v.backlight_timeout = typedef::BacklightTimeout(field.value.as_u8()),
+                17 => v.repeat_dive_interval = field.value.as_u16(),
+                18 => v.safety_stop_time = field.value.as_u16(),
+                19 => v.heart_rate_source_type = typedef::SourceType(field.value.as_u8()),
+                20 => v.heart_rate_source = field.value.as_u8(),
+                21 => v.travel_gas = typedef::MessageIndex(field.value.as_u16()),
+                22 => {
+                    v.ccr_low_setpoint_switch_mode =
+                        typedef::CcrSetpointSwitchMode(field.value.as_u8())
+                }
+                23 => v.ccr_low_setpoint = field.value.as_u8(),
+                24 => v.ccr_low_setpoint_depth = field.value.as_u32(),
+                25 => {
+                    v.ccr_high_setpoint_switch_mode =
+                        typedef::CcrSetpointSwitchMode(field.value.as_u8())
+                }
+                26 => v.ccr_high_setpoint = field.value.as_u8(),
+                27 => v.ccr_high_setpoint_depth = field.value.as_u32(),
+                29 => {
+                    v.gas_consumption_display = typedef::GasConsumptionRateType(field.value.as_u8())
+                }
+                30 => v.up_key_enabled = typedef::Bool(field.value.as_u8()),
+                35 => v.dive_sounds = typedef::Tone(field.value.as_u8()),
+                36 => v.last_stop_multiple = field.value.as_u8(),
+                37 => v.no_fly_time_mode = typedef::NoFlyTimeMode(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            name: vals[0].as_str().to_owned(),
-            model: typedef::TissueModelType(vals[1].as_u8()),
-            gf_low: vals[2].as_u8(),
-            gf_high: vals[3].as_u8(),
-            water_type: typedef::WaterType(vals[4].as_u8()),
-            water_density: vals[5].as_f32(),
-            po2_warn: vals[6].as_u8(),
-            po2_critical: vals[7].as_u8(),
-            po2_deco: vals[8].as_u8(),
-            safety_stop_enabled: typedef::Bool(vals[9].as_u8()),
-            bottom_depth: vals[10].as_f32(),
-            bottom_time: vals[11].as_u32(),
-            apnea_countdown_enabled: typedef::Bool(vals[12].as_u8()),
-            apnea_countdown_time: vals[13].as_u32(),
-            backlight_mode: typedef::DiveBacklightMode(vals[14].as_u8()),
-            backlight_brightness: vals[15].as_u8(),
-            backlight_timeout: typedef::BacklightTimeout(vals[16].as_u8()),
-            repeat_dive_interval: vals[17].as_u16(),
-            safety_stop_time: vals[18].as_u16(),
-            heart_rate_source_type: typedef::SourceType(vals[19].as_u8()),
-            heart_rate_source: vals[20].as_u8(),
-            travel_gas: typedef::MessageIndex(vals[21].as_u16()),
-            ccr_low_setpoint_switch_mode: typedef::CcrSetpointSwitchMode(vals[22].as_u8()),
-            ccr_low_setpoint: vals[23].as_u8(),
-            ccr_low_setpoint_depth: vals[24].as_u32(),
-            ccr_high_setpoint_switch_mode: typedef::CcrSetpointSwitchMode(vals[25].as_u8()),
-            ccr_high_setpoint: vals[26].as_u8(),
-            ccr_high_setpoint_depth: vals[27].as_u32(),
-            gas_consumption_display: typedef::GasConsumptionRateType(vals[29].as_u8()),
-            up_key_enabled: typedef::Bool(vals[30].as_u8()),
-            dive_sounds: typedef::Tone(vals[35].as_u8()),
-            last_stop_multiple: vals[36].as_u8(),
-            no_fly_time_mode: typedef::NoFlyTimeMode(vals[37].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<DiveSettings> for Message {
     fn from(m: DiveSettings) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 35];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.model != typedef::TissueModelType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::TISSUE_MODEL_TYPE,
                 value: Value::Uint8(m.model.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.gf_low != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.gf_low),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.gf_high != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.gf_high),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.water_type != typedef::WaterType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::WATER_TYPE,
                 value: Value::Uint8(m.water_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.water_density != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.water_density),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.po2_warn != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.po2_warn),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.po2_critical != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.po2_critical),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.po2_deco != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.po2_deco),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.safety_stop_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.safety_stop_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bottom_depth != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.bottom_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bottom_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.bottom_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.apnea_countdown_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.apnea_countdown_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.apnea_countdown_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.apnea_countdown_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.backlight_mode != typedef::DiveBacklightMode(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::DIVE_BACKLIGHT_MODE,
                 value: Value::Uint8(m.backlight_mode.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.backlight_brightness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.backlight_brightness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.backlight_timeout != typedef::BacklightTimeout(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::BACKLIGHT_TIMEOUT,
                 value: Value::Uint8(m.backlight_timeout.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.repeat_dive_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.repeat_dive_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.safety_stop_time != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.safety_stop_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.heart_rate_source_type != typedef::SourceType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::SOURCE_TYPE,
                 value: Value::Uint8(m.heart_rate_source_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.heart_rate_source != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 20,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.heart_rate_source),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.travel_gas != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.travel_gas.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ccr_low_setpoint_switch_mode != typedef::CcrSetpointSwitchMode(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::CCR_SETPOINT_SWITCH_MODE,
                 value: Value::Uint8(m.ccr_low_setpoint_switch_mode.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ccr_low_setpoint != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.ccr_low_setpoint),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ccr_low_setpoint_depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.ccr_low_setpoint_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ccr_high_setpoint_switch_mode != typedef::CcrSetpointSwitchMode(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::CCR_SETPOINT_SWITCH_MODE,
                 value: Value::Uint8(m.ccr_high_setpoint_switch_mode.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ccr_high_setpoint != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 26,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.ccr_high_setpoint),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ccr_high_setpoint_depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 27,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.ccr_high_setpoint_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.gas_consumption_display != typedef::GasConsumptionRateType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 29,
                 profile_type: ProfileType::GAS_CONSUMPTION_RATE_TYPE,
                 value: Value::Uint8(m.gas_consumption_display.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.up_key_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 30,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.up_key_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.dive_sounds != typedef::Tone(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 35,
                 profile_type: ProfileType::TONE,
                 value: Value::Uint8(m.dive_sounds.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.last_stop_multiple != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 36,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.last_stop_multiple),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.no_fly_time_mode != typedef::NoFlyTimeMode(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 37,
                 profile_type: ProfileType::NO_FLY_TIME_MODE,
                 value: Value::Uint8(m.no_fly_time_mode.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::DIVE_SETTINGS,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/dive_summary.rs
+++ b/rustyfit/src/profile/mesgdef/dive_summary.rs
@@ -387,6 +387,32 @@ impl DiveSummary {
         self.hang_time = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.reference_mesg != typedef::MesgNum(u16::MAX)) as usize
+            + (self.reference_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.avg_depth != u32::MAX) as usize
+            + (self.max_depth != u32::MAX) as usize
+            + (self.surface_interval != u32::MAX) as usize
+            + (self.start_cns != u8::MAX) as usize
+            + (self.end_cns != u8::MAX) as usize
+            + (self.start_n2 != u16::MAX) as usize
+            + (self.end_n2 != u16::MAX) as usize
+            + (self.o2_toxicity != u16::MAX) as usize
+            + (self.dive_number != u32::MAX) as usize
+            + (self.bottom_time != u32::MAX) as usize
+            + (self.avg_pressure_sac != u16::MAX) as usize
+            + (self.avg_volume_sac != u16::MAX) as usize
+            + (self.avg_rmv != u16::MAX) as usize
+            + (self.descent_time != u32::MAX) as usize
+            + (self.ascent_time != u32::MAX) as usize
+            + (self.avg_ascent_rate != i32::MAX) as usize
+            + (self.avg_descent_rate != u32::MAX) as usize
+            + (self.max_ascent_rate != u32::MAX) as usize
+            + (self.max_descent_rate != u32::MAX) as usize
+            + (self.hang_time != u32::MAX) as usize
+    }
 }
 
 impl Default for DiveSummary {
@@ -398,282 +424,245 @@ impl Default for DiveSummary {
 impl From<&Message> for DiveSummary {
     /// from creates new DiveSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [63176703, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.reference_mesg = typedef::MesgNum(field.value.as_u16()),
+                1 => v.reference_index = typedef::MessageIndex(field.value.as_u16()),
+                2 => v.avg_depth = field.value.as_u32(),
+                3 => v.max_depth = field.value.as_u32(),
+                4 => v.surface_interval = field.value.as_u32(),
+                5 => v.start_cns = field.value.as_u8(),
+                6 => v.end_cns = field.value.as_u8(),
+                7 => v.start_n2 = field.value.as_u16(),
+                8 => v.end_n2 = field.value.as_u16(),
+                9 => v.o2_toxicity = field.value.as_u16(),
+                10 => v.dive_number = field.value.as_u32(),
+                11 => v.bottom_time = field.value.as_u32(),
+                12 => v.avg_pressure_sac = field.value.as_u16(),
+                13 => v.avg_volume_sac = field.value.as_u16(),
+                14 => v.avg_rmv = field.value.as_u16(),
+                15 => v.descent_time = field.value.as_u32(),
+                16 => v.ascent_time = field.value.as_u32(),
+                17 => v.avg_ascent_rate = field.value.as_i32(),
+                22 => v.avg_descent_rate = field.value.as_u32(),
+                23 => v.max_ascent_rate = field.value.as_u32(),
+                24 => v.max_descent_rate = field.value.as_u32(),
+                25 => v.hang_time = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            reference_mesg: typedef::MesgNum(vals[0].as_u16()),
-            reference_index: typedef::MessageIndex(vals[1].as_u16()),
-            avg_depth: vals[2].as_u32(),
-            max_depth: vals[3].as_u32(),
-            surface_interval: vals[4].as_u32(),
-            start_cns: vals[5].as_u8(),
-            end_cns: vals[6].as_u8(),
-            start_n2: vals[7].as_u16(),
-            end_n2: vals[8].as_u16(),
-            o2_toxicity: vals[9].as_u16(),
-            dive_number: vals[10].as_u32(),
-            bottom_time: vals[11].as_u32(),
-            avg_pressure_sac: vals[12].as_u16(),
-            avg_volume_sac: vals[13].as_u16(),
-            avg_rmv: vals[14].as_u16(),
-            descent_time: vals[15].as_u32(),
-            ascent_time: vals[16].as_u32(),
-            avg_ascent_rate: vals[17].as_i32(),
-            avg_descent_rate: vals[22].as_u32(),
-            max_ascent_rate: vals[23].as_u32(),
-            max_descent_rate: vals[24].as_u32(),
-            hang_time: vals[25].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<DiveSummary> for Message {
     fn from(m: DiveSummary) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 23];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.reference_mesg != typedef::MesgNum(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::MESG_NUM,
                 value: Value::Uint16(m.reference_mesg.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.reference_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.reference_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.avg_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.max_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.surface_interval != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.surface_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_cns != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.start_cns),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_cns != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.end_cns),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_n2 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.start_n2),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_n2 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.end_n2),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.o2_toxicity != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.o2_toxicity),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.dive_number != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.dive_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bottom_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.bottom_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_pressure_sac != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_pressure_sac),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_volume_sac != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_volume_sac),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_rmv != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_rmv),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.descent_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.descent_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ascent_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.ascent_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_ascent_rate != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.avg_ascent_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_descent_rate != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.avg_descent_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_ascent_rate != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.max_ascent_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_descent_rate != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.max_descent_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hang_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.hang_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::DIVE_SUMMARY,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/event.rs
+++ b/rustyfit/src/profile/mesgdef/event.rs
@@ -186,6 +186,28 @@ impl Event {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.event != typedef::Event(u8::MAX)) as usize
+            + (self.event_type != typedef::EventType(u8::MAX)) as usize
+            + (self.data16 != u16::MAX) as usize
+            + (self.data != u32::MAX) as usize
+            + (self.event_group != u8::MAX) as usize
+            + (self.score != u16::MAX) as usize
+            + (self.opponent_score != u16::MAX) as usize
+            + (self.front_gear_num != u8::MIN) as usize
+            + (self.front_gear != u8::MIN) as usize
+            + (self.rear_gear_num != u8::MIN) as usize
+            + (self.rear_gear != u8::MIN) as usize
+            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+            + (self.activity_type != typedef::ActivityType(u8::MAX)) as usize
+            + (self.start_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.radar_threat_level_max != typedef::RadarThreatLevelType(u8::MAX)) as usize
+            + (self.radar_threat_count != u8::MAX) as usize
+            + (self.radar_threat_avg_approach_speed != u8::MAX) as usize
+            + (self.radar_threat_max_approach_speed != u8::MAX) as usize
+    }
 }
 
 impl Default for Event {
@@ -197,248 +219,215 @@ impl Default for Event {
 impl From<&Message> for Event {
     /// from creates new Event struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-        let mut state = [0u8; 4];
-
         const KNOWN_NUMS: [u64; 4] = [31522719, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.event = typedef::Event(field.value.as_u8()),
+                1 => v.event_type = typedef::EventType(field.value.as_u8()),
+                2 => v.data16 = field.value.as_u16(),
+                3 => v.data = field.value.as_u32(),
+                4 => v.event_group = field.value.as_u8(),
+                7 => v.score = field.value.as_u16(),
+                8 => v.opponent_score = field.value.as_u16(),
+                9 => v.front_gear_num = field.value.as_u8z(),
+                10 => v.front_gear = field.value.as_u8z(),
+                11 => v.rear_gear_num = field.value.as_u8z(),
+                12 => v.rear_gear = field.value.as_u8z(),
+                13 => v.device_index = typedef::DeviceIndex(field.value.as_u8()),
+                14 => v.activity_type = typedef::ActivityType(field.value.as_u8()),
+                15 => v.start_timestamp = typedef::DateTime(field.value.as_u32()),
+                21 => v.radar_threat_level_max = typedef::RadarThreatLevelType(field.value.as_u8()),
+                22 => v.radar_threat_count = field.value.as_u8(),
+                23 => v.radar_threat_avg_approach_speed = field.value.as_u8(),
+                24 => v.radar_threat_max_approach_speed = field.value.as_u8(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 25 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            event: typedef::Event(vals[0].as_u8()),
-            event_type: typedef::EventType(vals[1].as_u8()),
-            data16: vals[2].as_u16(),
-            data: vals[3].as_u32(),
-            event_group: vals[4].as_u8(),
-            score: vals[7].as_u16(),
-            opponent_score: vals[8].as_u16(),
-            front_gear_num: vals[9].as_u8z(),
-            front_gear: vals[10].as_u8z(),
-            rear_gear_num: vals[11].as_u8z(),
-            rear_gear: vals[12].as_u8z(),
-            device_index: typedef::DeviceIndex(vals[13].as_u8()),
-            activity_type: typedef::ActivityType(vals[14].as_u8()),
-            start_timestamp: typedef::DateTime(vals[15].as_u32()),
-            radar_threat_level_max: typedef::RadarThreatLevelType(vals[21].as_u8()),
-            radar_threat_count: vals[22].as_u8(),
-            radar_threat_avg_approach_speed: vals[23].as_u8(),
-            radar_threat_max_approach_speed: vals[24].as_u8(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Event> for Message {
     fn from(m: Event) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 19];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event != typedef::Event(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
                 value: Value::Uint8(m.event.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_type != typedef::EventType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
                 value: Value::Uint8(m.event_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.data16 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.data16),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.data != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.data),
-                is_expanded: is_expanded(&state, 3),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 3),
+            });
+        };
         if m.event_group != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.event_group),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.score != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.score),
-                is_expanded: is_expanded(&state, 7),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 7),
+            });
+        };
         if m.opponent_score != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.opponent_score),
-                is_expanded: is_expanded(&state, 8),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 8),
+            });
+        };
         if m.front_gear_num != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.front_gear_num),
-                is_expanded: is_expanded(&state, 9),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 9),
+            });
+        };
         if m.front_gear != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.front_gear),
-                is_expanded: is_expanded(&state, 10),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 10),
+            });
+        };
         if m.rear_gear_num != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.rear_gear_num),
-                is_expanded: is_expanded(&state, 11),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 11),
+            });
+        };
         if m.rear_gear != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.rear_gear),
-                is_expanded: is_expanded(&state, 12),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 12),
+            });
+        };
         if m.device_index != typedef::DeviceIndex(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::DEVICE_INDEX,
                 value: Value::Uint8(m.device_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.activity_type != typedef::ActivityType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::ACTIVITY_TYPE,
                 value: Value::Uint8(m.activity_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.radar_threat_level_max != typedef::RadarThreatLevelType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::RADAR_THREAT_LEVEL_TYPE,
                 value: Value::Uint8(m.radar_threat_level_max.0),
-                is_expanded: is_expanded(&state, 21),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 21),
+            });
+        };
         if m.radar_threat_count != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.radar_threat_count),
-                is_expanded: is_expanded(&state, 22),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 22),
+            });
+        };
         if m.radar_threat_avg_approach_speed != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.radar_threat_avg_approach_speed),
-                is_expanded: is_expanded(&state, 23),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 23),
+            });
+        };
         if m.radar_threat_max_approach_speed != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.radar_threat_max_approach_speed),
-                is_expanded: is_expanded(&state, 24),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 24),
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::EVENT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
@@ -101,6 +101,20 @@ impl ExdDataConceptConfiguration {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.screen_index != u8::MAX) as usize
+            + (self.concept_field != u8::MAX) as usize
+            + (self.field_id != u8::MAX) as usize
+            + (self.concept_index != u8::MAX) as usize
+            + (self.data_page != u8::MAX) as usize
+            + (self.concept_key != u8::MAX) as usize
+            + (self.scaling != u8::MAX) as usize
+            + (self.data_units != typedef::ExdDataUnits(u8::MAX)) as usize
+            + (self.qualifier != typedef::ExdQualifiers(u8::MAX)) as usize
+            + (self.descriptor != typedef::ExdDescriptors(u8::MAX)) as usize
+            + (self.is_signed != typedef::Bool(u8::MAX)) as usize
+    }
 }
 
 impl Default for ExdDataConceptConfiguration {
@@ -112,168 +126,143 @@ impl Default for ExdDataConceptConfiguration {
 impl From<&Message> for ExdDataConceptConfiguration {
     /// from creates new ExdDataConceptConfiguration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 12];
-        let mut state = [0u8; 1];
-
         const KNOWN_NUMS: [u64; 4] = [3967, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                0 => v.screen_index = field.value.as_u8(),
+                1 => v.concept_field = field.value.as_u8(),
+                2 => v.field_id = field.value.as_u8(),
+                3 => v.concept_index = field.value.as_u8(),
+                4 => v.data_page = field.value.as_u8(),
+                5 => v.concept_key = field.value.as_u8(),
+                6 => v.scaling = field.value.as_u8(),
+                8 => v.data_units = typedef::ExdDataUnits(field.value.as_u8()),
+                9 => v.qualifier = typedef::ExdQualifiers(field.value.as_u8()),
+                10 => v.descriptor = typedef::ExdDescriptors(field.value.as_u8()),
+                11 => v.is_signed = typedef::Bool(field.value.as_u8()),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 4 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            screen_index: vals[0].as_u8(),
-            concept_field: vals[1].as_u8(),
-            field_id: vals[2].as_u8(),
-            concept_index: vals[3].as_u8(),
-            data_page: vals[4].as_u8(),
-            concept_key: vals[5].as_u8(),
-            scaling: vals[6].as_u8(),
-            data_units: typedef::ExdDataUnits(vals[8].as_u8()),
-            qualifier: typedef::ExdQualifiers(vals[9].as_u8()),
-            descriptor: typedef::ExdDescriptors(vals[10].as_u8()),
-            is_signed: typedef::Bool(vals[11].as_u8()),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ExdDataConceptConfiguration> for Message {
     fn from(m: ExdDataConceptConfiguration) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 11];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.screen_index != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.screen_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.concept_field != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::BYTE,
                 value: Value::Uint8(m.concept_field),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.field_id != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.field_id),
-                is_expanded: is_expanded(&state, 2),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 2),
+            });
+        };
         if m.concept_index != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.concept_index),
-                is_expanded: is_expanded(&state, 3),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 3),
+            });
+        };
         if m.data_page != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.data_page),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.concept_key != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.concept_key),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.scaling != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.scaling),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.data_units != typedef::ExdDataUnits(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::EXD_DATA_UNITS,
                 value: Value::Uint8(m.data_units.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.qualifier != typedef::ExdQualifiers(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::EXD_QUALIFIERS,
                 value: Value::Uint8(m.qualifier.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.descriptor != typedef::ExdDescriptors(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::EXD_DESCRIPTORS,
                 value: Value::Uint8(m.descriptor.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.is_signed != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.is_signed.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::EXD_DATA_CONCEPT_CONFIGURATION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
@@ -84,6 +84,15 @@ impl ExdDataFieldConfiguration {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.screen_index != u8::MAX) as usize
+            + (self.concept_field != u8::MAX) as usize
+            + (self.field_id != u8::MAX) as usize
+            + (self.concept_count != u8::MAX) as usize
+            + (self.display_type != typedef::ExdDisplayType(u8::MAX)) as usize
+            + (self.title != [const { String::new() }; 32]) as usize
+    }
 }
 
 impl Default for ExdDataFieldConfiguration {
@@ -95,127 +104,109 @@ impl Default for ExdDataFieldConfiguration {
 impl From<&Message> for ExdDataFieldConfiguration {
     /// from creates new ExdDataFieldConfiguration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 6];
-        let mut state = [0u8; 1];
-
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                0 => v.screen_index = field.value.as_u8(),
+                1 => v.concept_field = field.value.as_u8(),
+                2 => v.field_id = field.value.as_u8(),
+                3 => v.concept_count = field.value.as_u8(),
+                4 => v.display_type = typedef::ExdDisplayType(field.value.as_u8()),
+                5 => {
+                    v.title = match &field.value {
+                        Value::VecString(v) => {
+                            let mut arr = [const { String::new() }; 32];
+                            for (i, x) in v.iter().take(32).enumerate() {
+                                arr[i] = x.to_owned();
+                            }
+                            arr
+                        }
+                        _ => [const { String::new() }; 32],
+                    }
+                }
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 4 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            screen_index: vals[0].as_u8(),
-            concept_field: vals[1].as_u8(),
-            field_id: vals[2].as_u8(),
-            concept_count: vals[3].as_u8(),
-            display_type: typedef::ExdDisplayType(vals[4].as_u8()),
-            title: match &vals[5] {
-                Value::VecString(v) => {
-                    let mut arr = [const { String::new() }; 32];
-                    for (i, x) in v.iter().take(32).enumerate() {
-                        arr[i] = x.to_owned();
-                    }
-                    arr
-                }
-                _ => [const { String::new() }; 32],
-            },
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ExdDataFieldConfiguration> for Message {
     fn from(m: ExdDataFieldConfiguration) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.screen_index != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.screen_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.concept_field != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::BYTE,
                 value: Value::Uint8(m.concept_field),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.field_id != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.field_id),
-                is_expanded: is_expanded(&state, 2),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 2),
+            });
+        };
         if m.concept_count != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.concept_count),
-                is_expanded: is_expanded(&state, 3),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 3),
+            });
+        };
         if m.display_type != typedef::ExdDisplayType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::EXD_DISPLAY_TYPE,
                 value: Value::Uint8(m.display_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.title != [const { String::new() }; 32] {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::STRING,
                 value: Value::VecString(Vec::from(&m.title)),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::EXD_DATA_FIELD_CONFIGURATION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
@@ -45,6 +45,13 @@ impl ExdScreenConfiguration {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.screen_index != u8::MAX) as usize
+            + (self.field_count != u8::MAX) as usize
+            + (self.layout != typedef::ExdLayout(u8::MAX)) as usize
+            + (self.screen_enabled != typedef::Bool(u8::MAX)) as usize
+    }
 }
 
 impl Default for ExdScreenConfiguration {
@@ -56,92 +63,74 @@ impl Default for ExdScreenConfiguration {
 impl From<&Message> for ExdScreenConfiguration {
     /// from creates new ExdScreenConfiguration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 4];
-
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.screen_index = field.value.as_u8(),
+                1 => v.field_count = field.value.as_u8(),
+                2 => v.layout = typedef::ExdLayout(field.value.as_u8()),
+                3 => v.screen_enabled = typedef::Bool(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            screen_index: vals[0].as_u8(),
-            field_count: vals[1].as_u8(),
-            layout: typedef::ExdLayout(vals[2].as_u8()),
-            screen_enabled: typedef::Bool(vals[3].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ExdScreenConfiguration> for Message {
     fn from(m: ExdScreenConfiguration) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.screen_index != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.screen_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.field_count != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.field_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.layout != typedef::ExdLayout(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::EXD_LAYOUT,
                 value: Value::Uint8(m.layout.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.screen_enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.screen_enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::EXD_SCREEN_CONFIGURATION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/exercise_title.rs
+++ b/rustyfit/src/profile/mesgdef/exercise_title.rs
@@ -46,6 +46,13 @@ impl ExerciseTitle {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.exercise_category != typedef::ExerciseCategory(u16::MAX)) as usize
+            + (self.exercise_name != u16::MAX) as usize
+            + (!self.wkt_step_name.is_empty()) as usize
+    }
 }
 
 impl Default for ExerciseTitle {
@@ -57,92 +64,74 @@ impl Default for ExerciseTitle {
 impl From<&Message> for ExerciseTitle {
     /// from creates new ExerciseTitle struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.exercise_category = typedef::ExerciseCategory(field.value.as_u16()),
+                1 => v.exercise_name = field.value.as_u16(),
+                2 => v.wkt_step_name = field.value.to_vec_string(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            exercise_category: typedef::ExerciseCategory(vals[0].as_u16()),
-            exercise_name: vals[1].as_u16(),
-            wkt_step_name: vals[2].to_vec_string(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ExerciseTitle> for Message {
     fn from(m: ExerciseTitle) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.exercise_category != typedef::ExerciseCategory(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EXERCISE_CATEGORY,
                 value: Value::Uint16(m.exercise_category.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.exercise_name != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.exercise_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.wkt_step_name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::STRING,
                 value: Value::VecString(m.wkt_step_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::EXERCISE_TITLE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/field_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/field_capabilities.rs
@@ -48,6 +48,14 @@ impl FieldCapabilities {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.file != typedef::File(u8::MAX)) as usize
+            + (self.mesg_num != typedef::MesgNum(u16::MAX)) as usize
+            + (self.field_num != u8::MAX) as usize
+            + (self.count != u16::MAX) as usize
+    }
 }
 
 impl Default for FieldCapabilities {
@@ -59,102 +67,83 @@ impl Default for FieldCapabilities {
 impl From<&Message> for FieldCapabilities {
     /// from creates new FieldCapabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.file = typedef::File(field.value.as_u8()),
+                1 => v.mesg_num = typedef::MesgNum(field.value.as_u16()),
+                2 => v.field_num = field.value.as_u8(),
+                3 => v.count = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            file: typedef::File(vals[0].as_u8()),
-            mesg_num: typedef::MesgNum(vals[1].as_u16()),
-            field_num: vals[2].as_u8(),
-            count: vals[3].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<FieldCapabilities> for Message {
     fn from(m: FieldCapabilities) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.file != typedef::File(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
                 value: Value::Uint8(m.file.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mesg_num != typedef::MesgNum(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESG_NUM,
                 value: Value::Uint16(m.mesg_num.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.field_num != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.field_num),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::FIELD_CAPABILITIES,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/field_description.rs
+++ b/rustyfit/src/profile/mesgdef/field_description.rs
@@ -83,6 +83,23 @@ impl FieldDescription {
             unknown_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.developer_data_index != u8::MAX) as usize
+            + (self.field_definition_number != u8::MAX) as usize
+            + (self.fit_base_type_id != typedef::FitBaseType(u8::MAX)) as usize
+            + (!self.field_name.is_empty()) as usize
+            + (self.array != u8::MAX) as usize
+            + (!self.components.is_empty()) as usize
+            + (self.scale != u8::MAX) as usize
+            + (self.offset != i8::MAX) as usize
+            + (!self.units.is_empty()) as usize
+            + (!self.bits.is_empty()) as usize
+            + (!self.accumulate.is_empty()) as usize
+            + (self.fit_base_unit_id != typedef::FitBaseUnit(u16::MAX)) as usize
+            + (self.native_mesg_num != typedef::MesgNum(u16::MAX)) as usize
+            + (self.native_field_num != u8::MAX) as usize
+    }
 }
 
 impl Default for FieldDescription {
@@ -94,191 +111,163 @@ impl Default for FieldDescription {
 impl From<&Message> for FieldDescription {
     /// from creates new FieldDescription struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 16];
-
         const KNOWN_NUMS: [u64; 4] = [59391, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.developer_data_index = field.value.as_u8(),
+                1 => v.field_definition_number = field.value.as_u8(),
+                2 => v.fit_base_type_id = typedef::FitBaseType(field.value.as_u8()),
+                3 => v.field_name = field.value.to_vec_string(),
+                4 => v.array = field.value.as_u8(),
+                5 => v.components = field.value.as_str().to_owned(),
+                6 => v.scale = field.value.as_u8(),
+                7 => v.offset = field.value.as_i8(),
+                8 => v.units = field.value.to_vec_string(),
+                9 => v.bits = field.value.as_str().to_owned(),
+                10 => v.accumulate = field.value.as_str().to_owned(),
+                13 => v.fit_base_unit_id = typedef::FitBaseUnit(field.value.as_u16()),
+                14 => v.native_mesg_num = typedef::MesgNum(field.value.as_u16()),
+                15 => v.native_field_num = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            developer_data_index: vals[0].as_u8(),
-            field_definition_number: vals[1].as_u8(),
-            fit_base_type_id: typedef::FitBaseType(vals[2].as_u8()),
-            field_name: vals[3].to_vec_string(),
-            array: vals[4].as_u8(),
-            components: vals[5].as_str().to_owned(),
-            scale: vals[6].as_u8(),
-            offset: vals[7].as_i8(),
-            units: vals[8].to_vec_string(),
-            bits: vals[9].as_str().to_owned(),
-            accumulate: vals[10].as_str().to_owned(),
-            fit_base_unit_id: typedef::FitBaseUnit(vals[13].as_u16()),
-            native_mesg_num: typedef::MesgNum(vals[14].as_u16()),
-            native_field_num: vals[15].as_u8(),
-            unknown_fields,
-        }
+        v
     }
 }
 
 impl From<FieldDescription> for Message {
     fn from(m: FieldDescription) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 14];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.developer_data_index != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.developer_data_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.field_definition_number != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.field_definition_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.fit_base_type_id != typedef::FitBaseType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::FIT_BASE_TYPE,
                 value: Value::Uint8(m.fit_base_type_id.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.field_name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::STRING,
                 value: Value::VecString(m.field_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.array != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.array),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.components.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.components),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.scale != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.scale),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.offset != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.units.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::STRING,
                 value: Value::VecString(m.units),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.bits.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.bits),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.accumulate.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.accumulate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.fit_base_unit_id != typedef::FitBaseUnit(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::FIT_BASE_UNIT,
                 value: Value::Uint16(m.fit_base_unit_id.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.native_mesg_num != typedef::MesgNum(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::MESG_NUM,
                 value: Value::Uint16(m.native_mesg_num.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.native_field_num != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.native_field_num),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::FIELD_DESCRIPTION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: Vec::new(),
         }
     }

--- a/rustyfit/src/profile/mesgdef/file_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/file_capabilities.rs
@@ -56,6 +56,15 @@ impl FileCapabilities {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.r#type != typedef::File(u8::MAX)) as usize
+            + (self.flags != typedef::FileFlags(u8::MIN)) as usize
+            + (!self.directory.is_empty()) as usize
+            + (self.max_count != u16::MAX) as usize
+            + (self.max_size != u32::MAX) as usize
+    }
 }
 
 impl Default for FileCapabilities {
@@ -67,112 +76,92 @@ impl Default for FileCapabilities {
 impl From<&Message> for FileCapabilities {
     /// from creates new FileCapabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.r#type = typedef::File(field.value.as_u8()),
+                1 => v.flags = typedef::FileFlags(field.value.as_u8z()),
+                2 => v.directory = field.value.as_str().to_owned(),
+                3 => v.max_count = field.value.as_u16(),
+                4 => v.max_size = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            r#type: typedef::File(vals[0].as_u8()),
-            flags: typedef::FileFlags(vals[1].as_u8z()),
-            directory: vals[2].as_str().to_owned(),
-            max_count: vals[3].as_u16(),
-            max_size: vals[4].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<FileCapabilities> for Message {
     fn from(m: FileCapabilities) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.r#type != typedef::File(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
                 value: Value::Uint8(m.r#type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.flags != typedef::FileFlags(u8::MIN) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::FILE_FLAGS,
                 value: Value::Uint8(m.flags.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.directory.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.directory),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_size != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.max_size),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::FILE_CAPABILITIES,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/file_creator.rs
+++ b/rustyfit/src/profile/mesgdef/file_creator.rs
@@ -36,6 +36,10 @@ impl FileCreator {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.software_version != u16::MAX) as usize + (self.hardware_version != u8::MAX) as usize
+    }
 }
 
 impl Default for FileCreator {
@@ -47,72 +51,56 @@ impl Default for FileCreator {
 impl From<&Message> for FileCreator {
     /// from creates new FileCreator struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 2];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.software_version = field.value.as_u16(),
+                1 => v.hardware_version = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            software_version: vals[0].as_u16(),
-            hardware_version: vals[1].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<FileCreator> for Message {
     fn from(m: FileCreator) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 2];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.software_version != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.software_version),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hardware_version != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.hardware_version),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::FILE_CREATOR,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/file_id.rs
+++ b/rustyfit/src/profile/mesgdef/file_id.rs
@@ -59,6 +59,16 @@ impl FileId {
             unknown_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.r#type != typedef::File(u8::MAX)) as usize
+            + (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.product != u16::MAX) as usize
+            + (self.serial_number != u32::MIN) as usize
+            + (self.time_created != typedef::DateTime(u32::MAX)) as usize
+            + (self.number != u16::MAX) as usize
+            + (!self.product_name.is_empty()) as usize
+    }
 }
 
 impl Default for FileId {
@@ -70,121 +80,100 @@ impl Default for FileId {
 impl From<&Message> for FileId {
     /// from creates new FileId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 9];
-
         const KNOWN_NUMS: [u64; 4] = [319, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.r#type = typedef::File(field.value.as_u8()),
+                1 => v.manufacturer = typedef::Manufacturer(field.value.as_u16()),
+                2 => v.product = field.value.as_u16(),
+                3 => v.serial_number = field.value.as_u32z(),
+                4 => v.time_created = typedef::DateTime(field.value.as_u32()),
+                5 => v.number = field.value.as_u16(),
+                8 => v.product_name = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            r#type: typedef::File(vals[0].as_u8()),
-            manufacturer: typedef::Manufacturer(vals[1].as_u16()),
-            product: vals[2].as_u16(),
-            serial_number: vals[3].as_u32z(),
-            time_created: typedef::DateTime(vals[4].as_u32()),
-            number: vals[5].as_u16(),
-            product_name: vals[8].as_str().to_owned(),
-            unknown_fields,
-        }
+        v
     }
 }
 
 impl From<FileId> for Message {
     fn from(m: FileId) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.r#type != typedef::File(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
                 value: Value::Uint8(m.r#type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.manufacturer != typedef::Manufacturer(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MANUFACTURER,
                 value: Value::Uint16(m.manufacturer.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.product != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.product),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.serial_number != u32::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32Z,
                 value: Value::Uint32(m.serial_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time_created != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.time_created.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.number != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.product_name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.product_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::FILE_ID,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: Vec::new(),
         }
     }

--- a/rustyfit/src/profile/mesgdef/goal.rs
+++ b/rustyfit/src/profile/mesgdef/goal.rs
@@ -80,6 +80,22 @@ impl Goal {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.start_date != typedef::DateTime(u32::MAX)) as usize
+            + (self.end_date != typedef::DateTime(u32::MAX)) as usize
+            + (self.r#type != typedef::Goal(u8::MAX)) as usize
+            + (self.value != u32::MAX) as usize
+            + (self.repeat != typedef::Bool(u8::MAX)) as usize
+            + (self.target_value != u32::MAX) as usize
+            + (self.recurrence != typedef::GoalRecurrence(u8::MAX)) as usize
+            + (self.recurrence_value != u16::MAX) as usize
+            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.source != typedef::GoalSource(u8::MAX)) as usize
+    }
 }
 
 impl Default for Goal {
@@ -91,182 +107,155 @@ impl Default for Goal {
 impl From<&Message> for Goal {
     /// from creates new Goal struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [4095, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.sport = typedef::Sport(field.value.as_u8()),
+                1 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                2 => v.start_date = typedef::DateTime(field.value.as_u32()),
+                3 => v.end_date = typedef::DateTime(field.value.as_u32()),
+                4 => v.r#type = typedef::Goal(field.value.as_u8()),
+                5 => v.value = field.value.as_u32(),
+                6 => v.repeat = typedef::Bool(field.value.as_u8()),
+                7 => v.target_value = field.value.as_u32(),
+                8 => v.recurrence = typedef::GoalRecurrence(field.value.as_u8()),
+                9 => v.recurrence_value = field.value.as_u16(),
+                10 => v.enabled = typedef::Bool(field.value.as_u8()),
+                11 => v.source = typedef::GoalSource(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            sport: typedef::Sport(vals[0].as_u8()),
-            sub_sport: typedef::SubSport(vals[1].as_u8()),
-            start_date: typedef::DateTime(vals[2].as_u32()),
-            end_date: typedef::DateTime(vals[3].as_u32()),
-            r#type: typedef::Goal(vals[4].as_u8()),
-            value: vals[5].as_u32(),
-            repeat: typedef::Bool(vals[6].as_u8()),
-            target_value: vals[7].as_u32(),
-            recurrence: typedef::GoalRecurrence(vals[8].as_u8()),
-            recurrence_value: vals[9].as_u16(),
-            enabled: typedef::Bool(vals[10].as_u8()),
-            source: typedef::GoalSource(vals[11].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Goal> for Message {
     fn from(m: Goal) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 13];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_date != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_date.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_date != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.end_date.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.r#type != typedef::Goal(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::GOAL,
                 value: Value::Uint8(m.r#type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.value != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.repeat != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.repeat.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.target_value != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.target_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.recurrence != typedef::GoalRecurrence(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::GOAL_RECURRENCE,
                 value: Value::Uint8(m.recurrence.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.recurrence_value != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.recurrence_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.source != typedef::GoalSource(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::GOAL_SOURCE,
                 value: Value::Uint8(m.source.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::GOAL,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -166,6 +166,18 @@ impl GpsMetadata {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (self.position_lat != i32::MAX) as usize
+            + (self.position_long != i32::MAX) as usize
+            + (self.enhanced_altitude != u32::MAX) as usize
+            + (self.enhanced_speed != u32::MAX) as usize
+            + (self.heading != u16::MAX) as usize
+            + (self.utc_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.velocity != [i16::MAX; 3]) as usize
+    }
 }
 
 impl Default for GpsMetadata {
@@ -177,151 +189,130 @@ impl Default for GpsMetadata {
 impl From<&Message> for GpsMetadata {
     /// from creates new GpsMetadata struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.position_lat = field.value.as_i32(),
+                2 => v.position_long = field.value.as_i32(),
+                3 => v.enhanced_altitude = field.value.as_u32(),
+                4 => v.enhanced_speed = field.value.as_u32(),
+                5 => v.heading = field.value.as_u16(),
+                6 => v.utc_timestamp = typedef::DateTime(field.value.as_u32()),
+                7 => {
+                    v.velocity = match &field.value {
+                        Value::VecInt16(v) => {
+                            let mut arr = [i16::MAX; 3];
+                            for (i, x) in v.iter().take(3).enumerate() {
+                                arr[i] = *x;
+                            }
+                            arr
+                        }
+                        _ => [i16::MAX; 3],
+                    }
+                }
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            position_lat: vals[1].as_i32(),
-            position_long: vals[2].as_i32(),
-            enhanced_altitude: vals[3].as_u32(),
-            enhanced_speed: vals[4].as_u32(),
-            heading: vals[5].as_u16(),
-            utc_timestamp: typedef::DateTime(vals[6].as_u32()),
-            velocity: match &vals[7] {
-                Value::VecInt16(v) => {
-                    let mut arr = [i16::MAX; 3];
-                    for (i, x) in v.iter().take(3).enumerate() {
-                        arr[i] = *x;
-                    }
-                    arr
-                }
-                _ => [i16::MAX; 3],
-            },
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<GpsMetadata> for Message {
     fn from(m: GpsMetadata) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 9];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.heading != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.heading),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.utc_timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.utc_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.velocity != [i16::MAX; 3] {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(Vec::from(&m.velocity)),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::GPS_METADATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/gyroscope_data.rs
@@ -73,6 +73,18 @@ impl GyroscopeData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (!self.sample_time_offset.is_empty()) as usize
+            + (!self.gyro_x.is_empty()) as usize
+            + (!self.gyro_y.is_empty()) as usize
+            + (!self.gyro_z.is_empty()) as usize
+            + (!self.calibrated_gyro_x.is_empty()) as usize
+            + (!self.calibrated_gyro_y.is_empty()) as usize
+            + (!self.calibrated_gyro_z.is_empty()) as usize
+    }
 }
 
 impl Default for GyroscopeData {
@@ -84,142 +96,119 @@ impl Default for GyroscopeData {
 impl From<&Message> for GyroscopeData {
     /// from creates new GyroscopeData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.sample_time_offset = field.value.to_vec_u16(),
+                2 => v.gyro_x = field.value.to_vec_u16(),
+                3 => v.gyro_y = field.value.to_vec_u16(),
+                4 => v.gyro_z = field.value.to_vec_u16(),
+                5 => v.calibrated_gyro_x = field.value.to_vec_f32(),
+                6 => v.calibrated_gyro_y = field.value.to_vec_f32(),
+                7 => v.calibrated_gyro_z = field.value.to_vec_f32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            sample_time_offset: vals[1].to_vec_u16(),
-            gyro_x: vals[2].to_vec_u16(),
-            gyro_y: vals[3].to_vec_u16(),
-            gyro_z: vals[4].to_vec_u16(),
-            calibrated_gyro_x: vals[5].to_vec_f32(),
-            calibrated_gyro_y: vals[6].to_vec_f32(),
-            calibrated_gyro_z: vals[7].to_vec_f32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<GyroscopeData> for Message {
     fn from(m: GyroscopeData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 9];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.sample_time_offset.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.sample_time_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.gyro_x.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.gyro_x),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.gyro_y.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.gyro_y),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.gyro_z.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.gyro_z),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.calibrated_gyro_x.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::VecFloat32(m.calibrated_gyro_x),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.calibrated_gyro_y.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::VecFloat32(m.calibrated_gyro_y),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.calibrated_gyro_z.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::VecFloat32(m.calibrated_gyro_z),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::GYROSCOPE_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hr.rs
+++ b/rustyfit/src/profile/mesgdef/hr.rs
@@ -154,6 +154,15 @@ impl Hr {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.fractional_timestamp != u16::MAX) as usize
+            + (self.time256 != u8::MAX) as usize
+            + (!self.filtered_bpm.is_empty()) as usize
+            + (!self.event_timestamp.is_empty()) as usize
+            + (!self.event_timestamp_12.is_empty()) as usize
+    }
 }
 
 impl Default for Hr {
@@ -165,118 +174,98 @@ impl Default for Hr {
 impl From<&Message> for Hr {
     /// from creates new Hr struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-        let mut state = [0u8; 2];
-
         const KNOWN_NUMS: [u64; 4] = [1603, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.fractional_timestamp = field.value.as_u16(),
+                1 => v.time256 = field.value.as_u8(),
+                6 => v.filtered_bpm = field.value.to_vec_u8(),
+                9 => v.event_timestamp = field.value.to_vec_u32(),
+                10 => v.event_timestamp_12 = field.value.to_vec_u8(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 10 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            fractional_timestamp: vals[0].as_u16(),
-            time256: vals[1].as_u8(),
-            filtered_bpm: vals[6].to_vec_u8(),
-            event_timestamp: vals[9].to_vec_u32(),
-            event_timestamp_12: vals[10].to_vec_u8(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Hr> for Message {
     fn from(m: Hr) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.fractional_timestamp != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.fractional_timestamp),
-                is_expanded: is_expanded(&state, 0),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 0),
+            });
+        };
         if m.time256 != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.time256),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.filtered_bpm.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.filtered_bpm),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.event_timestamp.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.event_timestamp),
-                is_expanded: is_expanded(&state, 9),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 9),
+            });
+        };
         if !m.event_timestamp_12.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.event_timestamp_12),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HR,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hr_zone.rs
+++ b/rustyfit/src/profile/mesgdef/hr_zone.rs
@@ -43,6 +43,12 @@ impl HrZone {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.high_bpm != u8::MAX) as usize
+            + (!self.name.is_empty()) as usize
+    }
 }
 
 impl Default for HrZone {
@@ -54,82 +60,65 @@ impl Default for HrZone {
 impl From<&Message> for HrZone {
     /// from creates new HrZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [6, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                1 => v.high_bpm = field.value.as_u8(),
+                2 => v.name = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            high_bpm: vals[1].as_u8(),
-            name: vals[2].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HrZone> for Message {
     fn from(m: HrZone) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.high_bpm != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.high_bpm),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HR_ZONE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hrm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/hrm_profile.rs
@@ -50,6 +50,14 @@ impl HrmProfile {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.hrm_ant_id != u16::MIN) as usize
+            + (self.log_hrv != typedef::Bool(u8::MAX)) as usize
+            + (self.hrm_ant_id_trans_type != u8::MIN) as usize
+    }
 }
 
 impl Default for HrmProfile {
@@ -61,102 +69,83 @@ impl Default for HrmProfile {
 impl From<&Message> for HrmProfile {
     /// from creates new HrmProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.enabled = typedef::Bool(field.value.as_u8()),
+                1 => v.hrm_ant_id = field.value.as_u16z(),
+                2 => v.log_hrv = typedef::Bool(field.value.as_u8()),
+                3 => v.hrm_ant_id_trans_type = field.value.as_u8z(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            enabled: typedef::Bool(vals[0].as_u8()),
-            hrm_ant_id: vals[1].as_u16z(),
-            log_hrv: typedef::Bool(vals[2].as_u8()),
-            hrm_ant_id_trans_type: vals[3].as_u8z(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HrmProfile> for Message {
     fn from(m: HrmProfile) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hrm_ant_id != u16::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16Z,
                 value: Value::Uint16(m.hrm_ant_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.log_hrv != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.log_hrv.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hrm_ant_id_trans_type != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.hrm_ant_id_trans_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HRM_PROFILE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hrv.rs
+++ b/rustyfit/src/profile/mesgdef/hrv.rs
@@ -63,6 +63,10 @@ impl Hrv {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (!self.time.is_empty()) as usize
+    }
 }
 
 impl Default for Hrv {
@@ -74,62 +78,47 @@ impl Default for Hrv {
 impl From<&Message> for Hrv {
     /// from creates new Hrv struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 1];
-
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.time = field.value.to_vec_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            time: vals[0].to_vec_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Hrv> for Message {
     fn from(m: Hrv) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 1];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if !m.time.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HRV,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
@@ -180,6 +180,17 @@ impl HrvStatusSummary {
         self.baseline_balanced_upper = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.weekly_average != u16::MAX) as usize
+            + (self.last_night_average != u16::MAX) as usize
+            + (self.last_night_5_min_high != u16::MAX) as usize
+            + (self.baseline_low_upper != u16::MAX) as usize
+            + (self.baseline_balanced_lower != u16::MAX) as usize
+            + (self.baseline_balanced_upper != u16::MAX) as usize
+            + (self.status != typedef::HrvStatus(u8::MAX)) as usize
+    }
 }
 
 impl Default for HrvStatusSummary {
@@ -191,132 +202,110 @@ impl Default for HrvStatusSummary {
 impl From<&Message> for HrvStatusSummary {
     /// from creates new HrvStatusSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.weekly_average = field.value.as_u16(),
+                1 => v.last_night_average = field.value.as_u16(),
+                2 => v.last_night_5_min_high = field.value.as_u16(),
+                3 => v.baseline_low_upper = field.value.as_u16(),
+                4 => v.baseline_balanced_lower = field.value.as_u16(),
+                5 => v.baseline_balanced_upper = field.value.as_u16(),
+                6 => v.status = typedef::HrvStatus(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            weekly_average: vals[0].as_u16(),
-            last_night_average: vals[1].as_u16(),
-            last_night_5_min_high: vals[2].as_u16(),
-            baseline_low_upper: vals[3].as_u16(),
-            baseline_balanced_lower: vals[4].as_u16(),
-            baseline_balanced_upper: vals[5].as_u16(),
-            status: typedef::HrvStatus(vals[6].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HrvStatusSummary> for Message {
     fn from(m: HrvStatusSummary) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 8];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weekly_average != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.weekly_average),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.last_night_average != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.last_night_average),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.last_night_5_min_high != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.last_night_5_min_high),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.baseline_low_upper != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.baseline_low_upper),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.baseline_balanced_lower != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.baseline_balanced_lower),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.baseline_balanced_upper != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.baseline_balanced_upper),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.status != typedef::HrvStatus(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::HRV_STATUS,
                 value: Value::Uint8(m.status.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HRV_STATUS_SUMMARY,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hrv_value.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_value.rs
@@ -56,6 +56,10 @@ impl HrvValue {
         self.value = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize + (self.value != u16::MAX) as usize
+    }
 }
 
 impl Default for HrvValue {
@@ -67,72 +71,56 @@ impl Default for HrvValue {
 impl From<&Message> for HrvValue {
     /// from creates new HrvValue struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.value = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            value: vals[0].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HrvValue> for Message {
     fn from(m: HrvValue) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 2];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.value != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HRV_VALUE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
@@ -153,6 +153,16 @@ impl HsaAccelerometerData {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (self.sampling_interval != u16::MAX) as usize
+            + (!self.accel_x.is_empty()) as usize
+            + (!self.accel_y.is_empty()) as usize
+            + (!self.accel_z.is_empty()) as usize
+            + (self.timestamp_32k != u32::MAX) as usize
+    }
 }
 
 impl Default for HsaAccelerometerData {
@@ -164,122 +174,101 @@ impl Default for HsaAccelerometerData {
 impl From<&Message> for HsaAccelerometerData {
     /// from creates new HsaAccelerometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.sampling_interval = field.value.as_u16(),
+                2 => v.accel_x = field.value.to_vec_i16(),
+                3 => v.accel_y = field.value.to_vec_i16(),
+                4 => v.accel_z = field.value.to_vec_i16(),
+                5 => v.timestamp_32k = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            sampling_interval: vals[1].as_u16(),
-            accel_x: vals[2].to_vec_i16(),
-            accel_y: vals[3].to_vec_i16(),
-            accel_z: vals[4].to_vec_i16(),
-            timestamp_32k: vals[5].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaAccelerometerData> for Message {
     fn from(m: HsaAccelerometerData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sampling_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.sampling_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.accel_x.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.accel_x),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.accel_y.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.accel_y),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.accel_z.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.accel_z),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_32k != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.timestamp_32k),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_ACCELEROMETER_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
@@ -53,6 +53,14 @@ impl HsaBodyBatteryData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.processing_interval != u16::MAX) as usize
+            + (!self.level.is_empty()) as usize
+            + (!self.charged.is_empty()) as usize
+            + (!self.uncharged.is_empty()) as usize
+    }
 }
 
 impl Default for HsaBodyBatteryData {
@@ -64,102 +72,83 @@ impl Default for HsaBodyBatteryData {
 impl From<&Message> for HsaBodyBatteryData {
     /// from creates new HsaBodyBatteryData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.processing_interval = field.value.as_u16(),
+                1 => v.level = field.value.to_vec_i8(),
+                2 => v.charged = field.value.to_vec_i16(),
+                3 => v.uncharged = field.value.to_vec_i16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            processing_interval: vals[0].as_u16(),
-            level: vals[1].to_vec_i8(),
-            charged: vals[2].to_vec_i16(),
-            uncharged: vals[3].to_vec_i16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaBodyBatteryData> for Message {
     fn from(m: HsaBodyBatteryData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.processing_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.processing_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.level.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT8,
                 value: Value::VecInt8(m.level),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.charged.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.charged),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.uncharged.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.uncharged),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_BODY_BATTERY_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
@@ -43,6 +43,12 @@ impl HsaConfigurationData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (!self.data.is_empty()) as usize
+            + (self.data_size != u8::MAX) as usize
+    }
 }
 
 impl Default for HsaConfigurationData {
@@ -54,82 +60,65 @@ impl Default for HsaConfigurationData {
 impl From<&Message> for HsaConfigurationData {
     /// from creates new HsaConfigurationData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.data = field.value.to_vec_u8(),
+                1 => v.data_size = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            data: vals[0].to_vec_u8(),
-            data_size: vals[1].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaConfigurationData> for Message {
     fn from(m: HsaConfigurationData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.data.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.data),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.data_size != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.data_size),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_CONFIGURATION_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_event.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_event.rs
@@ -38,6 +38,11 @@ impl HsaEvent {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.event_id != u8::MAX) as usize
+    }
 }
 
 impl Default for HsaEvent {
@@ -49,72 +54,56 @@ impl Default for HsaEvent {
 impl From<&Message> for HsaEvent {
     /// from creates new HsaEvent struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.event_id = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            event_id: vals[0].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaEvent> for Message {
     fn from(m: HsaEvent) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 2];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_id != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.event_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_EVENT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
@@ -153,6 +153,16 @@ impl HsaGyroscopeData {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (self.sampling_interval != u16::MAX) as usize
+            + (!self.gyro_x.is_empty()) as usize
+            + (!self.gyro_y.is_empty()) as usize
+            + (!self.gyro_z.is_empty()) as usize
+            + (self.timestamp_32k != u32::MAX) as usize
+    }
 }
 
 impl Default for HsaGyroscopeData {
@@ -164,122 +174,101 @@ impl Default for HsaGyroscopeData {
 impl From<&Message> for HsaGyroscopeData {
     /// from creates new HsaGyroscopeData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.sampling_interval = field.value.as_u16(),
+                2 => v.gyro_x = field.value.to_vec_i16(),
+                3 => v.gyro_y = field.value.to_vec_i16(),
+                4 => v.gyro_z = field.value.to_vec_i16(),
+                5 => v.timestamp_32k = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            sampling_interval: vals[1].as_u16(),
-            gyro_x: vals[2].to_vec_i16(),
-            gyro_y: vals[3].to_vec_i16(),
-            gyro_z: vals[4].to_vec_i16(),
-            timestamp_32k: vals[5].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaGyroscopeData> for Message {
     fn from(m: HsaGyroscopeData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sampling_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.sampling_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.gyro_x.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.gyro_x),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.gyro_y.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.gyro_y),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.gyro_z.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.gyro_z),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_32k != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.timestamp_32k),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_GYROSCOPE_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
@@ -48,6 +48,13 @@ impl HsaHeartRateData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.processing_interval != u16::MAX) as usize
+            + (self.status != u8::MAX) as usize
+            + (!self.heart_rate.is_empty()) as usize
+    }
 }
 
 impl Default for HsaHeartRateData {
@@ -59,92 +66,74 @@ impl Default for HsaHeartRateData {
 impl From<&Message> for HsaHeartRateData {
     /// from creates new HsaHeartRateData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.processing_interval = field.value.as_u16(),
+                1 => v.status = field.value.as_u8(),
+                2 => v.heart_rate = field.value.to_vec_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            processing_interval: vals[0].as_u16(),
-            status: vals[1].as_u8(),
-            heart_rate: vals[2].to_vec_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaHeartRateData> for Message {
     fn from(m: HsaHeartRateData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.processing_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.processing_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.status != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.status),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.heart_rate.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_HEART_RATE_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
@@ -73,6 +73,12 @@ impl HsaRespirationData {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.processing_interval != u16::MAX) as usize
+            + (!self.respiration_rate.is_empty()) as usize
+    }
 }
 
 impl Default for HsaRespirationData {
@@ -84,82 +90,65 @@ impl Default for HsaRespirationData {
 impl From<&Message> for HsaRespirationData {
     /// from creates new HsaRespirationData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.processing_interval = field.value.as_u16(),
+                1 => v.respiration_rate = field.value.to_vec_i16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            processing_interval: vals[0].as_u16(),
-            respiration_rate: vals[1].to_vec_i16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaRespirationData> for Message {
     fn from(m: HsaRespirationData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.processing_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.processing_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.respiration_rate.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT16,
                 value: Value::VecInt16(m.respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_RESPIRATION_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
@@ -48,6 +48,13 @@ impl HsaSpo2Data {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.processing_interval != u16::MAX) as usize
+            + (!self.reading_spo2.is_empty()) as usize
+            + (!self.confidence.is_empty()) as usize
+    }
 }
 
 impl Default for HsaSpo2Data {
@@ -59,92 +66,74 @@ impl Default for HsaSpo2Data {
 impl From<&Message> for HsaSpo2Data {
     /// from creates new HsaSpo2Data struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.processing_interval = field.value.as_u16(),
+                1 => v.reading_spo2 = field.value.to_vec_u8(),
+                2 => v.confidence = field.value.to_vec_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            processing_interval: vals[0].as_u16(),
-            reading_spo2: vals[1].to_vec_u8(),
-            confidence: vals[2].to_vec_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaSpo2Data> for Message {
     fn from(m: HsaSpo2Data) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.processing_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.processing_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.reading_spo2.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.reading_spo2),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.confidence.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.confidence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_SPO2_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_step_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_step_data.rs
@@ -43,6 +43,12 @@ impl HsaStepData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.processing_interval != u16::MAX) as usize
+            + (!self.steps.is_empty()) as usize
+    }
 }
 
 impl Default for HsaStepData {
@@ -54,82 +60,65 @@ impl Default for HsaStepData {
 impl From<&Message> for HsaStepData {
     /// from creates new HsaStepData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.processing_interval = field.value.as_u16(),
+                1 => v.steps = field.value.to_vec_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            processing_interval: vals[0].as_u16(),
-            steps: vals[1].to_vec_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaStepData> for Message {
     fn from(m: HsaStepData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.processing_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.processing_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.steps.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.steps),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_STEP_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
@@ -42,6 +42,12 @@ impl HsaStressData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.processing_interval != u16::MAX) as usize
+            + (!self.stress_level.is_empty()) as usize
+    }
 }
 
 impl Default for HsaStressData {
@@ -53,82 +59,65 @@ impl Default for HsaStressData {
 impl From<&Message> for HsaStressData {
     /// from creates new HsaStressData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.processing_interval = field.value.as_u16(),
+                1 => v.stress_level = field.value.to_vec_i8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            processing_interval: vals[0].as_u16(),
-            stress_level: vals[1].to_vec_i8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaStressData> for Message {
     fn from(m: HsaStressData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.processing_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.processing_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.stress_level.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT8,
                 value: Value::VecInt8(m.stress_level),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_STRESS_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
@@ -73,6 +73,12 @@ impl HsaWristTemperatureData {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.processing_interval != u16::MAX) as usize
+            + (!self.value.is_empty()) as usize
+    }
 }
 
 impl Default for HsaWristTemperatureData {
@@ -84,82 +90,65 @@ impl Default for HsaWristTemperatureData {
 impl From<&Message> for HsaWristTemperatureData {
     /// from creates new HsaWristTemperatureData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.processing_interval = field.value.as_u16(),
+                1 => v.value = field.value.to_vec_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            processing_interval: vals[0].as_u16(),
-            value: vals[1].to_vec_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<HsaWristTemperatureData> for Message {
     fn from(m: HsaWristTemperatureData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.processing_interval != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.processing_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.value.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::HSA_WRIST_TEMPERATURE_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -155,6 +155,19 @@ impl Jump {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.distance != f32::MAX) as usize
+            + (self.height != f32::MAX) as usize
+            + (self.rotations != u8::MAX) as usize
+            + (self.hang_time != f32::MAX) as usize
+            + (self.score != f32::MAX) as usize
+            + (self.position_lat != i32::MAX) as usize
+            + (self.position_long != i32::MAX) as usize
+            + (self.speed != u16::MAX) as usize
+            + (self.enhanced_speed != u32::MAX) as usize
+    }
 }
 
 impl Default for Jump {
@@ -166,158 +179,134 @@ impl Default for Jump {
 impl From<&Message> for Jump {
     /// from creates new Jump struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-        let mut state = [0u8; 2];
-
         const KNOWN_NUMS: [u64; 4] = [511, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.distance = field.value.as_f32(),
+                1 => v.height = field.value.as_f32(),
+                2 => v.rotations = field.value.as_u8(),
+                3 => v.hang_time = field.value.as_f32(),
+                4 => v.score = field.value.as_f32(),
+                5 => v.position_lat = field.value.as_i32(),
+                6 => v.position_long = field.value.as_i32(),
+                7 => v.speed = field.value.as_u16(),
+                8 => v.enhanced_speed = field.value.as_u32(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 9 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            distance: vals[0].as_f32(),
-            height: vals[1].as_f32(),
-            rotations: vals[2].as_u8(),
-            hang_time: vals[3].as_f32(),
-            score: vals[4].as_f32(),
-            position_lat: vals[5].as_i32(),
-            position_long: vals[6].as_i32(),
-            speed: vals[7].as_u16(),
-            enhanced_speed: vals[8].as_u32(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Jump> for Message {
     fn from(m: Jump) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 10];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.distance != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.height != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.height),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.rotations != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.rotations),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hang_time != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.hang_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.score != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_speed),
-                is_expanded: is_expanded(&state, 8),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 8),
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::JUMP,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -2068,6 +2068,133 @@ impl Lap {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.event != typedef::Event(u8::MAX)) as usize
+            + (self.event_type != typedef::EventType(u8::MAX)) as usize
+            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_position_lat != i32::MAX) as usize
+            + (self.start_position_long != i32::MAX) as usize
+            + (self.end_position_lat != i32::MAX) as usize
+            + (self.end_position_long != i32::MAX) as usize
+            + (self.total_elapsed_time != u32::MAX) as usize
+            + (self.total_timer_time != u32::MAX) as usize
+            + (self.total_distance != u32::MAX) as usize
+            + (self.total_cycles != u32::MAX) as usize
+            + (self.total_calories != u16::MAX) as usize
+            + (self.total_fat_calories != u16::MAX) as usize
+            + (self.avg_speed != u16::MAX) as usize
+            + (self.max_speed != u16::MAX) as usize
+            + (self.avg_heart_rate != u8::MAX) as usize
+            + (self.max_heart_rate != u8::MAX) as usize
+            + (self.avg_cadence != u8::MAX) as usize
+            + (self.max_cadence != u8::MAX) as usize
+            + (self.avg_power != u16::MAX) as usize
+            + (self.max_power != u16::MAX) as usize
+            + (self.total_ascent != u16::MAX) as usize
+            + (self.total_descent != u16::MAX) as usize
+            + (self.intensity != typedef::Intensity(u8::MAX)) as usize
+            + (self.lap_trigger != typedef::LapTrigger(u8::MAX)) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.event_group != u8::MAX) as usize
+            + (self.num_lengths != u16::MAX) as usize
+            + (self.normalized_power != u16::MAX) as usize
+            + (self.left_right_balance != typedef::LeftRightBalance100(u16::MAX)) as usize
+            + (self.first_length_index != u16::MAX) as usize
+            + (self.avg_stroke_distance != u16::MAX) as usize
+            + (self.swim_stroke != typedef::SwimStroke(u8::MAX)) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.num_active_lengths != u16::MAX) as usize
+            + (self.total_work != u32::MAX) as usize
+            + (self.avg_altitude != u16::MAX) as usize
+            + (self.max_altitude != u16::MAX) as usize
+            + (self.gps_accuracy != u8::MAX) as usize
+            + (self.avg_grade != i16::MAX) as usize
+            + (self.avg_pos_grade != i16::MAX) as usize
+            + (self.avg_neg_grade != i16::MAX) as usize
+            + (self.max_pos_grade != i16::MAX) as usize
+            + (self.max_neg_grade != i16::MAX) as usize
+            + (self.avg_temperature != i8::MAX) as usize
+            + (self.max_temperature != i8::MAX) as usize
+            + (self.total_moving_time != u32::MAX) as usize
+            + (self.avg_pos_vertical_speed != i16::MAX) as usize
+            + (self.avg_neg_vertical_speed != i16::MAX) as usize
+            + (self.max_pos_vertical_speed != i16::MAX) as usize
+            + (self.max_neg_vertical_speed != i16::MAX) as usize
+            + (!self.time_in_hr_zone.is_empty()) as usize
+            + (!self.time_in_speed_zone.is_empty()) as usize
+            + (!self.time_in_cadence_zone.is_empty()) as usize
+            + (!self.time_in_power_zone.is_empty()) as usize
+            + (self.repetition_num != u16::MAX) as usize
+            + (self.min_altitude != u16::MAX) as usize
+            + (self.min_heart_rate != u8::MAX) as usize
+            + (self.active_time != u32::MAX) as usize
+            + (self.wkt_step_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.opponent_score != u16::MAX) as usize
+            + (!self.stroke_count.is_empty()) as usize
+            + (!self.zone_count.is_empty()) as usize
+            + (self.avg_vertical_oscillation != u16::MAX) as usize
+            + (self.avg_stance_time_percent != u16::MAX) as usize
+            + (self.avg_stance_time != u16::MAX) as usize
+            + (self.avg_fractional_cadence != u8::MAX) as usize
+            + (self.max_fractional_cadence != u8::MAX) as usize
+            + (self.total_fractional_cycles != u8::MAX) as usize
+            + (self.player_score != u16::MAX) as usize
+            + (!self.avg_total_hemoglobin_conc.is_empty()) as usize
+            + (!self.min_total_hemoglobin_conc.is_empty()) as usize
+            + (!self.max_total_hemoglobin_conc.is_empty()) as usize
+            + (!self.avg_saturated_hemoglobin_percent.is_empty()) as usize
+            + (!self.min_saturated_hemoglobin_percent.is_empty()) as usize
+            + (!self.max_saturated_hemoglobin_percent.is_empty()) as usize
+            + (self.avg_left_torque_effectiveness != u8::MAX) as usize
+            + (self.avg_right_torque_effectiveness != u8::MAX) as usize
+            + (self.avg_left_pedal_smoothness != u8::MAX) as usize
+            + (self.avg_right_pedal_smoothness != u8::MAX) as usize
+            + (self.avg_combined_pedal_smoothness != u8::MAX) as usize
+            + (self.time_standing != u32::MAX) as usize
+            + (self.stand_count != u16::MAX) as usize
+            + (self.avg_left_pco != i8::MAX) as usize
+            + (self.avg_right_pco != i8::MAX) as usize
+            + (!self.avg_left_power_phase.is_empty()) as usize
+            + (!self.avg_left_power_phase_peak.is_empty()) as usize
+            + (!self.avg_right_power_phase.is_empty()) as usize
+            + (!self.avg_right_power_phase_peak.is_empty()) as usize
+            + (!self.avg_power_position.is_empty()) as usize
+            + (!self.max_power_position.is_empty()) as usize
+            + (!self.avg_cadence_position.is_empty()) as usize
+            + (!self.max_cadence_position.is_empty()) as usize
+            + (self.enhanced_avg_speed != u32::MAX) as usize
+            + (self.enhanced_max_speed != u32::MAX) as usize
+            + (self.enhanced_avg_altitude != u32::MAX) as usize
+            + (self.enhanced_min_altitude != u32::MAX) as usize
+            + (self.enhanced_max_altitude != u32::MAX) as usize
+            + (self.avg_lev_motor_power != u16::MAX) as usize
+            + (self.max_lev_motor_power != u16::MAX) as usize
+            + (self.lev_battery_consumption != u8::MAX) as usize
+            + (self.avg_vertical_ratio != u16::MAX) as usize
+            + (self.avg_stance_time_balance != u16::MAX) as usize
+            + (self.avg_step_length != u16::MAX) as usize
+            + (self.avg_vam != u16::MAX) as usize
+            + (self.avg_depth != u32::MAX) as usize
+            + (self.max_depth != u32::MAX) as usize
+            + (self.min_temperature != i8::MAX) as usize
+            + (self.enhanced_avg_respiration_rate != u16::MAX) as usize
+            + (self.enhanced_max_respiration_rate != u16::MAX) as usize
+            + (self.avg_respiration_rate != u8::MAX) as usize
+            + (self.max_respiration_rate != u8::MAX) as usize
+            + (self.total_grit != f32::MAX) as usize
+            + (self.total_flow != f32::MAX) as usize
+            + (self.jump_count != u16::MAX) as usize
+            + (self.avg_grit != f32::MAX) as usize
+            + (self.avg_flow != f32::MAX) as usize
+            + (self.total_fractional_ascent != u8::MAX) as usize
+            + (self.total_fractional_descent != u8::MAX) as usize
+            + (self.avg_core_temperature != u16::MAX) as usize
+            + (self.min_core_temperature != u16::MAX) as usize
+            + (self.max_core_temperature != u16::MAX) as usize
+    }
 }
 
 impl Default for Lap {
@@ -2079,9 +2206,6 @@ impl Default for Lap {
 impl From<&Message> for Lap {
     /// from creates new Lap struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-        let mut state = [0u8; 18];
-
         const KNOWN_NUMS: [u64; 4] = [
             18446744000829325311,
             2305842996261682368,
@@ -2092,1290 +2216,1155 @@ impl From<&Message> for Lap {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.event = typedef::Event(field.value.as_u8()),
+                1 => v.event_type = typedef::EventType(field.value.as_u8()),
+                2 => v.start_time = typedef::DateTime(field.value.as_u32()),
+                3 => v.start_position_lat = field.value.as_i32(),
+                4 => v.start_position_long = field.value.as_i32(),
+                5 => v.end_position_lat = field.value.as_i32(),
+                6 => v.end_position_long = field.value.as_i32(),
+                7 => v.total_elapsed_time = field.value.as_u32(),
+                8 => v.total_timer_time = field.value.as_u32(),
+                9 => v.total_distance = field.value.as_u32(),
+                10 => v.total_cycles = field.value.as_u32(),
+                11 => v.total_calories = field.value.as_u16(),
+                12 => v.total_fat_calories = field.value.as_u16(),
+                13 => v.avg_speed = field.value.as_u16(),
+                14 => v.max_speed = field.value.as_u16(),
+                15 => v.avg_heart_rate = field.value.as_u8(),
+                16 => v.max_heart_rate = field.value.as_u8(),
+                17 => v.avg_cadence = field.value.as_u8(),
+                18 => v.max_cadence = field.value.as_u8(),
+                19 => v.avg_power = field.value.as_u16(),
+                20 => v.max_power = field.value.as_u16(),
+                21 => v.total_ascent = field.value.as_u16(),
+                22 => v.total_descent = field.value.as_u16(),
+                23 => v.intensity = typedef::Intensity(field.value.as_u8()),
+                24 => v.lap_trigger = typedef::LapTrigger(field.value.as_u8()),
+                25 => v.sport = typedef::Sport(field.value.as_u8()),
+                26 => v.event_group = field.value.as_u8(),
+                32 => v.num_lengths = field.value.as_u16(),
+                33 => v.normalized_power = field.value.as_u16(),
+                34 => v.left_right_balance = typedef::LeftRightBalance100(field.value.as_u16()),
+                35 => v.first_length_index = field.value.as_u16(),
+                37 => v.avg_stroke_distance = field.value.as_u16(),
+                38 => v.swim_stroke = typedef::SwimStroke(field.value.as_u8()),
+                39 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                40 => v.num_active_lengths = field.value.as_u16(),
+                41 => v.total_work = field.value.as_u32(),
+                42 => v.avg_altitude = field.value.as_u16(),
+                43 => v.max_altitude = field.value.as_u16(),
+                44 => v.gps_accuracy = field.value.as_u8(),
+                45 => v.avg_grade = field.value.as_i16(),
+                46 => v.avg_pos_grade = field.value.as_i16(),
+                47 => v.avg_neg_grade = field.value.as_i16(),
+                48 => v.max_pos_grade = field.value.as_i16(),
+                49 => v.max_neg_grade = field.value.as_i16(),
+                50 => v.avg_temperature = field.value.as_i8(),
+                51 => v.max_temperature = field.value.as_i8(),
+                52 => v.total_moving_time = field.value.as_u32(),
+                53 => v.avg_pos_vertical_speed = field.value.as_i16(),
+                54 => v.avg_neg_vertical_speed = field.value.as_i16(),
+                55 => v.max_pos_vertical_speed = field.value.as_i16(),
+                56 => v.max_neg_vertical_speed = field.value.as_i16(),
+                57 => v.time_in_hr_zone = field.value.to_vec_u32(),
+                58 => v.time_in_speed_zone = field.value.to_vec_u32(),
+                59 => v.time_in_cadence_zone = field.value.to_vec_u32(),
+                60 => v.time_in_power_zone = field.value.to_vec_u32(),
+                61 => v.repetition_num = field.value.as_u16(),
+                62 => v.min_altitude = field.value.as_u16(),
+                63 => v.min_heart_rate = field.value.as_u8(),
+                70 => v.active_time = field.value.as_u32(),
+                71 => v.wkt_step_index = typedef::MessageIndex(field.value.as_u16()),
+                74 => v.opponent_score = field.value.as_u16(),
+                75 => v.stroke_count = field.value.to_vec_u16(),
+                76 => v.zone_count = field.value.to_vec_u16(),
+                77 => v.avg_vertical_oscillation = field.value.as_u16(),
+                78 => v.avg_stance_time_percent = field.value.as_u16(),
+                79 => v.avg_stance_time = field.value.as_u16(),
+                80 => v.avg_fractional_cadence = field.value.as_u8(),
+                81 => v.max_fractional_cadence = field.value.as_u8(),
+                82 => v.total_fractional_cycles = field.value.as_u8(),
+                83 => v.player_score = field.value.as_u16(),
+                84 => v.avg_total_hemoglobin_conc = field.value.to_vec_u16(),
+                85 => v.min_total_hemoglobin_conc = field.value.to_vec_u16(),
+                86 => v.max_total_hemoglobin_conc = field.value.to_vec_u16(),
+                87 => v.avg_saturated_hemoglobin_percent = field.value.to_vec_u16(),
+                88 => v.min_saturated_hemoglobin_percent = field.value.to_vec_u16(),
+                89 => v.max_saturated_hemoglobin_percent = field.value.to_vec_u16(),
+                91 => v.avg_left_torque_effectiveness = field.value.as_u8(),
+                92 => v.avg_right_torque_effectiveness = field.value.as_u8(),
+                93 => v.avg_left_pedal_smoothness = field.value.as_u8(),
+                94 => v.avg_right_pedal_smoothness = field.value.as_u8(),
+                95 => v.avg_combined_pedal_smoothness = field.value.as_u8(),
+                98 => v.time_standing = field.value.as_u32(),
+                99 => v.stand_count = field.value.as_u16(),
+                100 => v.avg_left_pco = field.value.as_i8(),
+                101 => v.avg_right_pco = field.value.as_i8(),
+                102 => v.avg_left_power_phase = field.value.to_vec_u8(),
+                103 => v.avg_left_power_phase_peak = field.value.to_vec_u8(),
+                104 => v.avg_right_power_phase = field.value.to_vec_u8(),
+                105 => v.avg_right_power_phase_peak = field.value.to_vec_u8(),
+                106 => v.avg_power_position = field.value.to_vec_u16(),
+                107 => v.max_power_position = field.value.to_vec_u16(),
+                108 => v.avg_cadence_position = field.value.to_vec_u8(),
+                109 => v.max_cadence_position = field.value.to_vec_u8(),
+                110 => v.enhanced_avg_speed = field.value.as_u32(),
+                111 => v.enhanced_max_speed = field.value.as_u32(),
+                112 => v.enhanced_avg_altitude = field.value.as_u32(),
+                113 => v.enhanced_min_altitude = field.value.as_u32(),
+                114 => v.enhanced_max_altitude = field.value.as_u32(),
+                115 => v.avg_lev_motor_power = field.value.as_u16(),
+                116 => v.max_lev_motor_power = field.value.as_u16(),
+                117 => v.lev_battery_consumption = field.value.as_u8(),
+                118 => v.avg_vertical_ratio = field.value.as_u16(),
+                119 => v.avg_stance_time_balance = field.value.as_u16(),
+                120 => v.avg_step_length = field.value.as_u16(),
+                121 => v.avg_vam = field.value.as_u16(),
+                122 => v.avg_depth = field.value.as_u32(),
+                123 => v.max_depth = field.value.as_u32(),
+                124 => v.min_temperature = field.value.as_i8(),
+                136 => v.enhanced_avg_respiration_rate = field.value.as_u16(),
+                137 => v.enhanced_max_respiration_rate = field.value.as_u16(),
+                147 => v.avg_respiration_rate = field.value.as_u8(),
+                148 => v.max_respiration_rate = field.value.as_u8(),
+                149 => v.total_grit = field.value.as_f32(),
+                150 => v.total_flow = field.value.as_f32(),
+                151 => v.jump_count = field.value.as_u16(),
+                153 => v.avg_grit = field.value.as_f32(),
+                154 => v.avg_flow = field.value.as_f32(),
+                156 => v.total_fractional_ascent = field.value.as_u8(),
+                157 => v.total_fractional_descent = field.value.as_u8(),
+                158 => v.avg_core_temperature = field.value.as_u16(),
+                159 => v.min_core_temperature = field.value.as_u16(),
+                160 => v.max_core_temperature = field.value.as_u16(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 138 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            event: typedef::Event(vals[0].as_u8()),
-            event_type: typedef::EventType(vals[1].as_u8()),
-            start_time: typedef::DateTime(vals[2].as_u32()),
-            start_position_lat: vals[3].as_i32(),
-            start_position_long: vals[4].as_i32(),
-            end_position_lat: vals[5].as_i32(),
-            end_position_long: vals[6].as_i32(),
-            total_elapsed_time: vals[7].as_u32(),
-            total_timer_time: vals[8].as_u32(),
-            total_distance: vals[9].as_u32(),
-            total_cycles: vals[10].as_u32(),
-            total_calories: vals[11].as_u16(),
-            total_fat_calories: vals[12].as_u16(),
-            avg_speed: vals[13].as_u16(),
-            max_speed: vals[14].as_u16(),
-            avg_heart_rate: vals[15].as_u8(),
-            max_heart_rate: vals[16].as_u8(),
-            avg_cadence: vals[17].as_u8(),
-            max_cadence: vals[18].as_u8(),
-            avg_power: vals[19].as_u16(),
-            max_power: vals[20].as_u16(),
-            total_ascent: vals[21].as_u16(),
-            total_descent: vals[22].as_u16(),
-            intensity: typedef::Intensity(vals[23].as_u8()),
-            lap_trigger: typedef::LapTrigger(vals[24].as_u8()),
-            sport: typedef::Sport(vals[25].as_u8()),
-            event_group: vals[26].as_u8(),
-            num_lengths: vals[32].as_u16(),
-            normalized_power: vals[33].as_u16(),
-            left_right_balance: typedef::LeftRightBalance100(vals[34].as_u16()),
-            first_length_index: vals[35].as_u16(),
-            avg_stroke_distance: vals[37].as_u16(),
-            swim_stroke: typedef::SwimStroke(vals[38].as_u8()),
-            sub_sport: typedef::SubSport(vals[39].as_u8()),
-            num_active_lengths: vals[40].as_u16(),
-            total_work: vals[41].as_u32(),
-            avg_altitude: vals[42].as_u16(),
-            max_altitude: vals[43].as_u16(),
-            gps_accuracy: vals[44].as_u8(),
-            avg_grade: vals[45].as_i16(),
-            avg_pos_grade: vals[46].as_i16(),
-            avg_neg_grade: vals[47].as_i16(),
-            max_pos_grade: vals[48].as_i16(),
-            max_neg_grade: vals[49].as_i16(),
-            avg_temperature: vals[50].as_i8(),
-            max_temperature: vals[51].as_i8(),
-            total_moving_time: vals[52].as_u32(),
-            avg_pos_vertical_speed: vals[53].as_i16(),
-            avg_neg_vertical_speed: vals[54].as_i16(),
-            max_pos_vertical_speed: vals[55].as_i16(),
-            max_neg_vertical_speed: vals[56].as_i16(),
-            time_in_hr_zone: vals[57].to_vec_u32(),
-            time_in_speed_zone: vals[58].to_vec_u32(),
-            time_in_cadence_zone: vals[59].to_vec_u32(),
-            time_in_power_zone: vals[60].to_vec_u32(),
-            repetition_num: vals[61].as_u16(),
-            min_altitude: vals[62].as_u16(),
-            min_heart_rate: vals[63].as_u8(),
-            active_time: vals[70].as_u32(),
-            wkt_step_index: typedef::MessageIndex(vals[71].as_u16()),
-            opponent_score: vals[74].as_u16(),
-            stroke_count: vals[75].to_vec_u16(),
-            zone_count: vals[76].to_vec_u16(),
-            avg_vertical_oscillation: vals[77].as_u16(),
-            avg_stance_time_percent: vals[78].as_u16(),
-            avg_stance_time: vals[79].as_u16(),
-            avg_fractional_cadence: vals[80].as_u8(),
-            max_fractional_cadence: vals[81].as_u8(),
-            total_fractional_cycles: vals[82].as_u8(),
-            player_score: vals[83].as_u16(),
-            avg_total_hemoglobin_conc: vals[84].to_vec_u16(),
-            min_total_hemoglobin_conc: vals[85].to_vec_u16(),
-            max_total_hemoglobin_conc: vals[86].to_vec_u16(),
-            avg_saturated_hemoglobin_percent: vals[87].to_vec_u16(),
-            min_saturated_hemoglobin_percent: vals[88].to_vec_u16(),
-            max_saturated_hemoglobin_percent: vals[89].to_vec_u16(),
-            avg_left_torque_effectiveness: vals[91].as_u8(),
-            avg_right_torque_effectiveness: vals[92].as_u8(),
-            avg_left_pedal_smoothness: vals[93].as_u8(),
-            avg_right_pedal_smoothness: vals[94].as_u8(),
-            avg_combined_pedal_smoothness: vals[95].as_u8(),
-            time_standing: vals[98].as_u32(),
-            stand_count: vals[99].as_u16(),
-            avg_left_pco: vals[100].as_i8(),
-            avg_right_pco: vals[101].as_i8(),
-            avg_left_power_phase: vals[102].to_vec_u8(),
-            avg_left_power_phase_peak: vals[103].to_vec_u8(),
-            avg_right_power_phase: vals[104].to_vec_u8(),
-            avg_right_power_phase_peak: vals[105].to_vec_u8(),
-            avg_power_position: vals[106].to_vec_u16(),
-            max_power_position: vals[107].to_vec_u16(),
-            avg_cadence_position: vals[108].to_vec_u8(),
-            max_cadence_position: vals[109].to_vec_u8(),
-            enhanced_avg_speed: vals[110].as_u32(),
-            enhanced_max_speed: vals[111].as_u32(),
-            enhanced_avg_altitude: vals[112].as_u32(),
-            enhanced_min_altitude: vals[113].as_u32(),
-            enhanced_max_altitude: vals[114].as_u32(),
-            avg_lev_motor_power: vals[115].as_u16(),
-            max_lev_motor_power: vals[116].as_u16(),
-            lev_battery_consumption: vals[117].as_u8(),
-            avg_vertical_ratio: vals[118].as_u16(),
-            avg_stance_time_balance: vals[119].as_u16(),
-            avg_step_length: vals[120].as_u16(),
-            avg_vam: vals[121].as_u16(),
-            avg_depth: vals[122].as_u32(),
-            max_depth: vals[123].as_u32(),
-            min_temperature: vals[124].as_i8(),
-            enhanced_avg_respiration_rate: vals[136].as_u16(),
-            enhanced_max_respiration_rate: vals[137].as_u16(),
-            avg_respiration_rate: vals[147].as_u8(),
-            max_respiration_rate: vals[148].as_u8(),
-            total_grit: vals[149].as_f32(),
-            total_flow: vals[150].as_f32(),
-            jump_count: vals[151].as_u16(),
-            avg_grit: vals[153].as_f32(),
-            avg_flow: vals[154].as_f32(),
-            total_fractional_ascent: vals[156].as_u8(),
-            total_fractional_descent: vals[157].as_u8(),
-            avg_core_temperature: vals[158].as_u16(),
-            min_core_temperature: vals[159].as_u16(),
-            max_core_temperature: vals[160].as_u16(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Lap> for Message {
     fn from(m: Lap) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 124];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event != typedef::Event(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
                 value: Value::Uint8(m.event.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_type != typedef::EventType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
                 value: Value::Uint8(m.event_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.start_position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.start_position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.end_position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.end_position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_elapsed_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_elapsed_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_timer_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_timer_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_cycles != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_cycles),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fat_calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_fat_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 20,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_ascent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_ascent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_descent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_descent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.intensity != typedef::Intensity(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::INTENSITY,
                 value: Value::Uint8(m.intensity.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.lap_trigger != typedef::LapTrigger(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::LAP_TRIGGER,
                 value: Value::Uint8(m.lap_trigger.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_group != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 26,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.event_group),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.num_lengths != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 32,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.num_lengths),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.normalized_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 33,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.normalized_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.left_right_balance != typedef::LeftRightBalance100(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 34,
                 profile_type: ProfileType::LEFT_RIGHT_BALANCE_100,
                 value: Value::Uint16(m.left_right_balance.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.first_length_index != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 35,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.first_length_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stroke_distance != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 37,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_stroke_distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.swim_stroke != typedef::SwimStroke(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 38,
                 profile_type: ProfileType::SWIM_STROKE,
                 value: Value::Uint8(m.swim_stroke.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 39,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.num_active_lengths != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 40,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.num_active_lengths),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_work != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 41,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_work),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 42,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 43,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.gps_accuracy != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 44,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.gps_accuracy),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 45,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_pos_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 46,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_pos_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_neg_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 47,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_neg_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_pos_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 48,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_pos_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_neg_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 49,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_neg_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 50,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.avg_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 51,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.max_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_moving_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 52,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_moving_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_pos_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 53,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_pos_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_neg_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 54,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_neg_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_pos_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 55,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_pos_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_neg_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 56,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_neg_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_hr_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 57,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_hr_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_speed_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 58,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_speed_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_cadence_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 59,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_cadence_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_power_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 60,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_power_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.repetition_num != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 61,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.repetition_num),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 62,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.min_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 63,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.min_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 70,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.active_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.wkt_step_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 71,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.wkt_step_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.opponent_score != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 74,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.opponent_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.stroke_count.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 75,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.stroke_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.zone_count.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 76,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.zone_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_vertical_oscillation != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 77,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_vertical_oscillation),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stance_time_percent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 78,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_stance_time_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stance_time != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 79,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_stance_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_fractional_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 80,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_fractional_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_fractional_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 81,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_fractional_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fractional_cycles != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 82,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_fractional_cycles),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.player_score != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 83,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.player_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_total_hemoglobin_conc.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 84,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.avg_total_hemoglobin_conc),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.min_total_hemoglobin_conc.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 85,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.min_total_hemoglobin_conc),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_total_hemoglobin_conc.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 86,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.max_total_hemoglobin_conc),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_saturated_hemoglobin_percent.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 87,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.avg_saturated_hemoglobin_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.min_saturated_hemoglobin_percent.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 88,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.min_saturated_hemoglobin_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_saturated_hemoglobin_percent.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 89,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.max_saturated_hemoglobin_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_left_torque_effectiveness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 91,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_left_torque_effectiveness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_right_torque_effectiveness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 92,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_right_torque_effectiveness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_left_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 93,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_left_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_right_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 94,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_right_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_combined_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 95,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_combined_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time_standing != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 98,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.time_standing),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.stand_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 99,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.stand_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_left_pco != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 100,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.avg_left_pco),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_right_pco != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 101,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.avg_right_pco),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_left_power_phase.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 102,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_left_power_phase),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_left_power_phase_peak.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 103,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_left_power_phase_peak),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_right_power_phase.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 104,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_right_power_phase),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_right_power_phase_peak.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 105,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_right_power_phase_peak),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_power_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 106,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.avg_power_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_power_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 107,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.max_power_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_cadence_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 108,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_cadence_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_cadence_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 109,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.max_cadence_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_avg_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 110,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_avg_speed),
-                is_expanded: is_expanded(&state, 110),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 110),
+            });
+        };
         if m.enhanced_max_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 111,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_max_speed),
-                is_expanded: is_expanded(&state, 111),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 111),
+            });
+        };
         if m.enhanced_avg_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 112,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_avg_altitude),
-                is_expanded: is_expanded(&state, 112),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 112),
+            });
+        };
         if m.enhanced_min_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 113,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_min_altitude),
-                is_expanded: is_expanded(&state, 113),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 113),
+            });
+        };
         if m.enhanced_max_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 114,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_max_altitude),
-                is_expanded: is_expanded(&state, 114),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 114),
+            });
+        };
         if m.avg_lev_motor_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 115,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_lev_motor_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_lev_motor_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 116,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_lev_motor_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.lev_battery_consumption != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 117,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.lev_battery_consumption),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_vertical_ratio != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 118,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_vertical_ratio),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stance_time_balance != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 119,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_stance_time_balance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_step_length != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 120,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_step_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_vam != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 121,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_vam),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 122,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.avg_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 123,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.max_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 124,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.min_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_avg_respiration_rate != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 136,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.enhanced_avg_respiration_rate),
-                is_expanded: is_expanded(&state, 136),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 136),
+            });
+        };
         if m.enhanced_max_respiration_rate != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 137,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.enhanced_max_respiration_rate),
-                is_expanded: is_expanded(&state, 137),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 137),
+            });
+        };
         if m.avg_respiration_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 147,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_respiration_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 148,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_grit != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 149,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.total_grit),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_flow != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 150,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.total_flow),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.jump_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 151,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.jump_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_grit != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 153,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.avg_grit),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_flow != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 154,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.avg_flow),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fractional_ascent != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 156,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_fractional_ascent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fractional_descent != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 157,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_fractional_descent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_core_temperature != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 158,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_core_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_core_temperature != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 159,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.min_core_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_core_temperature != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 160,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_core_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::LAP,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/length.rs
+++ b/rustyfit/src/profile/mesgdef/length.rs
@@ -251,6 +251,31 @@ impl Length {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.event != typedef::Event(u8::MAX)) as usize
+            + (self.event_type != typedef::EventType(u8::MAX)) as usize
+            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.total_elapsed_time != u32::MAX) as usize
+            + (self.total_timer_time != u32::MAX) as usize
+            + (self.total_strokes != u16::MAX) as usize
+            + (self.avg_speed != u16::MAX) as usize
+            + (self.swim_stroke != typedef::SwimStroke(u8::MAX)) as usize
+            + (self.avg_swimming_cadence != u8::MAX) as usize
+            + (self.event_group != u8::MAX) as usize
+            + (self.total_calories != u16::MAX) as usize
+            + (self.length_type != typedef::LengthType(u8::MAX)) as usize
+            + (self.player_score != u16::MAX) as usize
+            + (self.opponent_score != u16::MAX) as usize
+            + (!self.stroke_count.is_empty()) as usize
+            + (!self.zone_count.is_empty()) as usize
+            + (self.enhanced_avg_respiration_rate != u16::MAX) as usize
+            + (self.enhanced_max_respiration_rate != u16::MAX) as usize
+            + (self.avg_respiration_rate != u8::MAX) as usize
+            + (self.max_respiration_rate != u8::MAX) as usize
+    }
 }
 
 impl Default for Length {
@@ -262,278 +287,242 @@ impl Default for Length {
 impl From<&Message> for Length {
     /// from creates new Length struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-        let mut state = [0u8; 3];
-
         const KNOWN_NUMS: [u64; 4] = [66854655, 0, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.event = typedef::Event(field.value.as_u8()),
+                1 => v.event_type = typedef::EventType(field.value.as_u8()),
+                2 => v.start_time = typedef::DateTime(field.value.as_u32()),
+                3 => v.total_elapsed_time = field.value.as_u32(),
+                4 => v.total_timer_time = field.value.as_u32(),
+                5 => v.total_strokes = field.value.as_u16(),
+                6 => v.avg_speed = field.value.as_u16(),
+                7 => v.swim_stroke = typedef::SwimStroke(field.value.as_u8()),
+                9 => v.avg_swimming_cadence = field.value.as_u8(),
+                10 => v.event_group = field.value.as_u8(),
+                11 => v.total_calories = field.value.as_u16(),
+                12 => v.length_type = typedef::LengthType(field.value.as_u8()),
+                18 => v.player_score = field.value.as_u16(),
+                19 => v.opponent_score = field.value.as_u16(),
+                20 => v.stroke_count = field.value.to_vec_u16(),
+                21 => v.zone_count = field.value.to_vec_u16(),
+                22 => v.enhanced_avg_respiration_rate = field.value.as_u16(),
+                23 => v.enhanced_max_respiration_rate = field.value.as_u16(),
+                24 => v.avg_respiration_rate = field.value.as_u8(),
+                25 => v.max_respiration_rate = field.value.as_u8(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 24 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            event: typedef::Event(vals[0].as_u8()),
-            event_type: typedef::EventType(vals[1].as_u8()),
-            start_time: typedef::DateTime(vals[2].as_u32()),
-            total_elapsed_time: vals[3].as_u32(),
-            total_timer_time: vals[4].as_u32(),
-            total_strokes: vals[5].as_u16(),
-            avg_speed: vals[6].as_u16(),
-            swim_stroke: typedef::SwimStroke(vals[7].as_u8()),
-            avg_swimming_cadence: vals[9].as_u8(),
-            event_group: vals[10].as_u8(),
-            total_calories: vals[11].as_u16(),
-            length_type: typedef::LengthType(vals[12].as_u8()),
-            player_score: vals[18].as_u16(),
-            opponent_score: vals[19].as_u16(),
-            stroke_count: vals[20].to_vec_u16(),
-            zone_count: vals[21].to_vec_u16(),
-            enhanced_avg_respiration_rate: vals[22].as_u16(),
-            enhanced_max_respiration_rate: vals[23].as_u16(),
-            avg_respiration_rate: vals[24].as_u8(),
-            max_respiration_rate: vals[25].as_u8(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Length> for Message {
     fn from(m: Length) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 22];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event != typedef::Event(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
                 value: Value::Uint8(m.event.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_type != typedef::EventType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
                 value: Value::Uint8(m.event_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_elapsed_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_elapsed_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_timer_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_timer_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_strokes != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_strokes),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.swim_stroke != typedef::SwimStroke(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::SWIM_STROKE,
                 value: Value::Uint8(m.swim_stroke.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_swimming_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_swimming_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_group != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.event_group),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.length_type != typedef::LengthType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::LENGTH_TYPE,
                 value: Value::Uint8(m.length_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.player_score != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.player_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.opponent_score != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.opponent_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.stroke_count.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 20,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.stroke_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.zone_count.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.zone_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_avg_respiration_rate != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.enhanced_avg_respiration_rate),
-                is_expanded: is_expanded(&state, 22),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 22),
+            });
+        };
         if m.enhanced_max_respiration_rate != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.enhanced_max_respiration_rate),
-                is_expanded: is_expanded(&state, 23),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 23),
+            });
+        };
         if m.avg_respiration_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_respiration_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::LENGTH,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/magnetometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/magnetometer_data.rs
@@ -73,6 +73,18 @@ impl MagnetometerData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (!self.sample_time_offset.is_empty()) as usize
+            + (!self.mag_x.is_empty()) as usize
+            + (!self.mag_y.is_empty()) as usize
+            + (!self.mag_z.is_empty()) as usize
+            + (!self.calibrated_mag_x.is_empty()) as usize
+            + (!self.calibrated_mag_y.is_empty()) as usize
+            + (!self.calibrated_mag_z.is_empty()) as usize
+    }
 }
 
 impl Default for MagnetometerData {
@@ -84,142 +96,119 @@ impl Default for MagnetometerData {
 impl From<&Message> for MagnetometerData {
     /// from creates new MagnetometerData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.sample_time_offset = field.value.to_vec_u16(),
+                2 => v.mag_x = field.value.to_vec_u16(),
+                3 => v.mag_y = field.value.to_vec_u16(),
+                4 => v.mag_z = field.value.to_vec_u16(),
+                5 => v.calibrated_mag_x = field.value.to_vec_f32(),
+                6 => v.calibrated_mag_y = field.value.to_vec_f32(),
+                7 => v.calibrated_mag_z = field.value.to_vec_f32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            sample_time_offset: vals[1].to_vec_u16(),
-            mag_x: vals[2].to_vec_u16(),
-            mag_y: vals[3].to_vec_u16(),
-            mag_z: vals[4].to_vec_u16(),
-            calibrated_mag_x: vals[5].to_vec_f32(),
-            calibrated_mag_y: vals[6].to_vec_f32(),
-            calibrated_mag_z: vals[7].to_vec_f32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<MagnetometerData> for Message {
     fn from(m: MagnetometerData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 9];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.sample_time_offset.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.sample_time_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.mag_x.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.mag_x),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.mag_y.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.mag_y),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.mag_z.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.mag_z),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.calibrated_mag_x.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::VecFloat32(m.calibrated_mag_x),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.calibrated_mag_y.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::VecFloat32(m.calibrated_mag_y),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.calibrated_mag_z.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::VecFloat32(m.calibrated_mag_z),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::MAGNETOMETER_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/max_met_data.rs
+++ b/rustyfit/src/profile/mesgdef/max_met_data.rs
@@ -84,6 +84,17 @@ impl MaxMetData {
         self.vo2_max = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.update_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.vo2_max != u16::MAX) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.max_met_category != typedef::MaxMetCategory(u8::MAX)) as usize
+            + (self.calibrated_data != typedef::Bool(u8::MAX)) as usize
+            + (self.hr_source != typedef::MaxMetHeartRateSource(u8::MAX)) as usize
+            + (self.speed_source != typedef::MaxMetSpeedSource(u8::MAX)) as usize
+    }
 }
 
 impl Default for MaxMetData {
@@ -95,132 +106,110 @@ impl Default for MaxMetData {
 impl From<&Message> for MaxMetData {
     /// from creates new MaxMetData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 14];
-
         const KNOWN_NUMS: [u64; 4] = [13157, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.update_time = typedef::DateTime(field.value.as_u32()),
+                2 => v.vo2_max = field.value.as_u16(),
+                5 => v.sport = typedef::Sport(field.value.as_u8()),
+                6 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                8 => v.max_met_category = typedef::MaxMetCategory(field.value.as_u8()),
+                9 => v.calibrated_data = typedef::Bool(field.value.as_u8()),
+                12 => v.hr_source = typedef::MaxMetHeartRateSource(field.value.as_u8()),
+                13 => v.speed_source = typedef::MaxMetSpeedSource(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            update_time: typedef::DateTime(vals[0].as_u32()),
-            vo2_max: vals[2].as_u16(),
-            sport: typedef::Sport(vals[5].as_u8()),
-            sub_sport: typedef::SubSport(vals[6].as_u8()),
-            max_met_category: typedef::MaxMetCategory(vals[8].as_u8()),
-            calibrated_data: typedef::Bool(vals[9].as_u8()),
-            hr_source: typedef::MaxMetHeartRateSource(vals[12].as_u8()),
-            speed_source: typedef::MaxMetSpeedSource(vals[13].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<MaxMetData> for Message {
     fn from(m: MaxMetData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 8];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.update_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.update_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.vo2_max != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.vo2_max),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_met_category != typedef::MaxMetCategory(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::MAX_MET_CATEGORY,
                 value: Value::Uint8(m.max_met_category.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.calibrated_data != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.calibrated_data.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hr_source != typedef::MaxMetHeartRateSource(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::MAX_MET_HEART_RATE_SOURCE,
                 value: Value::Uint8(m.hr_source.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.speed_source != typedef::MaxMetSpeedSource(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::MAX_MET_SPEED_SOURCE,
                 value: Value::Uint8(m.speed_source.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::MAX_MET_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/memo_glob.rs
+++ b/rustyfit/src/profile/mesgdef/memo_glob.rs
@@ -58,6 +58,15 @@ impl MemoGlob {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.part_index != u32::MAX) as usize
+            + (!self.memo.is_empty()) as usize
+            + (self.mesg_num != typedef::MesgNum(u16::MAX)) as usize
+            + (self.parent_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.field_num != u8::MAX) as usize
+            + (!self.data.is_empty()) as usize
+    }
 }
 
 impl Default for MemoGlob {
@@ -69,112 +78,92 @@ impl Default for MemoGlob {
 impl From<&Message> for MemoGlob {
     /// from creates new MemoGlob struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 251];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 288230376151711744];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                250 => v.part_index = field.value.as_u32(),
+                0 => v.memo = field.value.to_vec_u8(),
+                1 => v.mesg_num = typedef::MesgNum(field.value.as_u16()),
+                2 => v.parent_index = typedef::MessageIndex(field.value.as_u16()),
+                3 => v.field_num = field.value.as_u8(),
+                4 => v.data = field.value.to_vec_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            part_index: vals[250].as_u32(),
-            memo: vals[0].to_vec_u8(),
-            mesg_num: typedef::MesgNum(vals[1].as_u16()),
-            parent_index: typedef::MessageIndex(vals[2].as_u16()),
-            field_num: vals[3].as_u8(),
-            data: vals[4].to_vec_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<MemoGlob> for Message {
     fn from(m: MemoGlob) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.part_index != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 250,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.part_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.memo.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.memo),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mesg_num != typedef::MesgNum(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESG_NUM,
                 value: Value::Uint16(m.mesg_num.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.parent_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.parent_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.field_num != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.field_num),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.data.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::VecUint8(m.data),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::MEMO_GLOB,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
@@ -48,6 +48,14 @@ impl MesgCapabilities {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.file != typedef::File(u8::MAX)) as usize
+            + (self.mesg_num != typedef::MesgNum(u16::MAX)) as usize
+            + (self.count_type != typedef::MesgCount(u8::MAX)) as usize
+            + (self.count != u16::MAX) as usize
+    }
 }
 
 impl Default for MesgCapabilities {
@@ -59,102 +67,83 @@ impl Default for MesgCapabilities {
 impl From<&Message> for MesgCapabilities {
     /// from creates new MesgCapabilities struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.file = typedef::File(field.value.as_u8()),
+                1 => v.mesg_num = typedef::MesgNum(field.value.as_u16()),
+                2 => v.count_type = typedef::MesgCount(field.value.as_u8()),
+                3 => v.count = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            file: typedef::File(vals[0].as_u8()),
-            mesg_num: typedef::MesgNum(vals[1].as_u16()),
-            count_type: typedef::MesgCount(vals[2].as_u8()),
-            count: vals[3].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<MesgCapabilities> for Message {
     fn from(m: MesgCapabilities) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.file != typedef::File(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
                 value: Value::Uint8(m.file.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mesg_num != typedef::MesgNum(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESG_NUM,
                 value: Value::Uint16(m.mesg_num.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.count_type != typedef::MesgCount(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::MESG_COUNT,
                 value: Value::Uint8(m.count_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::MESG_CAPABILITIES,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/met_zone.rs
+++ b/rustyfit/src/profile/mesgdef/met_zone.rs
@@ -84,6 +84,13 @@ impl MetZone {
         self.fat_calories = unscaled as u8;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.high_bpm != u8::MAX) as usize
+            + (self.calories != u16::MAX) as usize
+            + (self.fat_calories != u8::MAX) as usize
+    }
 }
 
 impl Default for MetZone {
@@ -95,92 +102,74 @@ impl Default for MetZone {
 impl From<&Message> for MetZone {
     /// from creates new MetZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [14, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                1 => v.high_bpm = field.value.as_u8(),
+                2 => v.calories = field.value.as_u16(),
+                3 => v.fat_calories = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            high_bpm: vals[1].as_u8(),
-            calories: vals[2].as_u16(),
-            fat_calories: vals[3].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<MetZone> for Message {
     fn from(m: MetZone) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.high_bpm != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.high_bpm),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.fat_calories != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.fat_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::MET_ZONE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/monitoring.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring.rs
@@ -370,6 +370,38 @@ impl Monitoring {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+            + (self.calories != u16::MAX) as usize
+            + (self.distance != u32::MAX) as usize
+            + (self.cycles != u32::MAX) as usize
+            + (self.active_time != u32::MAX) as usize
+            + (self.activity_type != typedef::ActivityType(u8::MAX)) as usize
+            + (self.activity_subtype != typedef::ActivitySubtype(u8::MAX)) as usize
+            + (self.activity_level != typedef::ActivityLevel(u8::MAX)) as usize
+            + (self.distance_16 != u16::MAX) as usize
+            + (self.cycles_16 != u16::MAX) as usize
+            + (self.active_time_16 != u16::MAX) as usize
+            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+            + (self.temperature != i16::MAX) as usize
+            + (self.temperature_min != i16::MAX) as usize
+            + (self.temperature_max != i16::MAX) as usize
+            + (self.activity_time != [u16::MAX; 8]) as usize
+            + (self.active_calories != u16::MAX) as usize
+            + (self.current_activity_type_intensity != u8::MAX) as usize
+            + (self.timestamp_min_8 != u8::MAX) as usize
+            + (self.timestamp_16 != u16::MAX) as usize
+            + (self.heart_rate != u8::MAX) as usize
+            + (self.intensity != u8::MAX) as usize
+            + (self.duration_min != u16::MAX) as usize
+            + (self.duration != u32::MAX) as usize
+            + (self.ascent != u32::MAX) as usize
+            + (self.descent != u32::MAX) as usize
+            + (self.moderate_activity_minutes != u16::MAX) as usize
+            + (self.vigorous_activity_minutes != u16::MAX) as usize
+    }
 }
 
 impl Default for Monitoring {
@@ -381,357 +413,316 @@ impl Default for Monitoring {
 impl From<&Message> for Monitoring {
     /// from creates new Monitoring struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-        let mut state = [0u8; 4];
-
         const KNOWN_NUMS: [u64; 4] = [34343608319, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.device_index = typedef::DeviceIndex(field.value.as_u8()),
+                1 => v.calories = field.value.as_u16(),
+                2 => v.distance = field.value.as_u32(),
+                3 => v.cycles = field.value.as_u32(),
+                4 => v.active_time = field.value.as_u32(),
+                5 => v.activity_type = typedef::ActivityType(field.value.as_u8()),
+                6 => v.activity_subtype = typedef::ActivitySubtype(field.value.as_u8()),
+                7 => v.activity_level = typedef::ActivityLevel(field.value.as_u8()),
+                8 => v.distance_16 = field.value.as_u16(),
+                9 => v.cycles_16 = field.value.as_u16(),
+                10 => v.active_time_16 = field.value.as_u16(),
+                11 => v.local_timestamp = typedef::LocalDateTime(field.value.as_u32()),
+                12 => v.temperature = field.value.as_i16(),
+                14 => v.temperature_min = field.value.as_i16(),
+                15 => v.temperature_max = field.value.as_i16(),
+                16 => {
+                    v.activity_time = match &field.value {
+                        Value::VecUint16(v) => {
+                            let mut arr = [u16::MAX; 8];
+                            for (i, x) in v.iter().take(8).enumerate() {
+                                arr[i] = *x;
+                            }
+                            arr
+                        }
+                        _ => [u16::MAX; 8],
+                    }
+                }
+                19 => v.active_calories = field.value.as_u16(),
+                24 => v.current_activity_type_intensity = field.value.as_u8(),
+                25 => v.timestamp_min_8 = field.value.as_u8(),
+                26 => v.timestamp_16 = field.value.as_u16(),
+                27 => v.heart_rate = field.value.as_u8(),
+                28 => v.intensity = field.value.as_u8(),
+                29 => v.duration_min = field.value.as_u16(),
+                30 => v.duration = field.value.as_u32(),
+                31 => v.ascent = field.value.as_u32(),
+                32 => v.descent = field.value.as_u32(),
+                33 => v.moderate_activity_minutes = field.value.as_u16(),
+                34 => v.vigorous_activity_minutes = field.value.as_u16(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 29 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            device_index: typedef::DeviceIndex(vals[0].as_u8()),
-            calories: vals[1].as_u16(),
-            distance: vals[2].as_u32(),
-            cycles: vals[3].as_u32(),
-            active_time: vals[4].as_u32(),
-            activity_type: typedef::ActivityType(vals[5].as_u8()),
-            activity_subtype: typedef::ActivitySubtype(vals[6].as_u8()),
-            activity_level: typedef::ActivityLevel(vals[7].as_u8()),
-            distance_16: vals[8].as_u16(),
-            cycles_16: vals[9].as_u16(),
-            active_time_16: vals[10].as_u16(),
-            local_timestamp: typedef::LocalDateTime(vals[11].as_u32()),
-            temperature: vals[12].as_i16(),
-            temperature_min: vals[14].as_i16(),
-            temperature_max: vals[15].as_i16(),
-            activity_time: match &vals[16] {
-                Value::VecUint16(v) => {
-                    let mut arr = [u16::MAX; 8];
-                    for (i, x) in v.iter().take(8).enumerate() {
-                        arr[i] = *x;
-                    }
-                    arr
-                }
-                _ => [u16::MAX; 8],
-            },
-            active_calories: vals[19].as_u16(),
-            current_activity_type_intensity: vals[24].as_u8(),
-            timestamp_min_8: vals[25].as_u8(),
-            timestamp_16: vals[26].as_u16(),
-            heart_rate: vals[27].as_u8(),
-            intensity: vals[28].as_u8(),
-            duration_min: vals[29].as_u16(),
-            duration: vals[30].as_u32(),
-            ascent: vals[31].as_u32(),
-            descent: vals[32].as_u32(),
-            moderate_activity_minutes: vals[33].as_u16(),
-            vigorous_activity_minutes: vals[34].as_u16(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Monitoring> for Message {
     fn from(m: Monitoring) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 29];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.device_index != typedef::DeviceIndex(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DEVICE_INDEX,
                 value: Value::Uint8(m.device_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cycles != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.cycles),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.active_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.activity_type != typedef::ActivityType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::ACTIVITY_TYPE,
                 value: Value::Uint8(m.activity_type.0),
-                is_expanded: is_expanded(&state, 5),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 5),
+            });
+        };
         if m.activity_subtype != typedef::ActivitySubtype(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::ACTIVITY_SUBTYPE,
                 value: Value::Uint8(m.activity_subtype.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.activity_level != typedef::ActivityLevel(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::ACTIVITY_LEVEL,
                 value: Value::Uint8(m.activity_level.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.distance_16 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.distance_16),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cycles_16 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.cycles_16),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_time_16 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.active_time_16),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::LOCAL_DATE_TIME,
                 value: Value::Uint32(m.local_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.temperature != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.temperature_min != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.temperature_min),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.temperature_max != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.temperature_max),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.activity_time != [u16::MAX; 8] {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(Vec::from(&m.activity_time)),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.active_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.current_activity_type_intensity != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::BYTE,
                 value: Value::Uint8(m.current_activity_type_intensity),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_min_8 != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.timestamp_min_8),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_16 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 26,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_16),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 27,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.intensity != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 28,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.intensity),
-                is_expanded: is_expanded(&state, 28),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 28),
+            });
+        };
         if m.duration_min != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 29,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.duration_min),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.duration != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 30,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.duration),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ascent != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 31,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.ascent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.descent != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 32,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.descent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.moderate_activity_minutes != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 33,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.moderate_activity_minutes),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.vigorous_activity_minutes != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 34,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.vigorous_activity_minutes),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::MONITORING,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
@@ -43,6 +43,12 @@ impl MonitoringHrData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.resting_heart_rate != u8::MAX) as usize
+            + (self.current_day_resting_heart_rate != u8::MAX) as usize
+    }
 }
 
 impl Default for MonitoringHrData {
@@ -54,82 +60,65 @@ impl Default for MonitoringHrData {
 impl From<&Message> for MonitoringHrData {
     /// from creates new MonitoringHrData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.resting_heart_rate = field.value.as_u8(),
+                1 => v.current_day_resting_heart_rate = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            resting_heart_rate: vals[0].as_u8(),
-            current_day_resting_heart_rate: vals[1].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<MonitoringHrData> for Message {
     fn from(m: MonitoringHrData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.resting_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.resting_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.current_day_resting_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.current_day_resting_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::MONITORING_HR_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/monitoring_info.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_info.rs
@@ -117,6 +117,15 @@ impl MonitoringInfo {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+            + (!self.activity_type.is_empty()) as usize
+            + (!self.cycles_to_distance.is_empty()) as usize
+            + (!self.cycles_to_calories.is_empty()) as usize
+            + (self.resting_metabolic_rate != u16::MAX) as usize
+    }
 }
 
 impl Default for MonitoringInfo {
@@ -128,75 +137,64 @@ impl Default for MonitoringInfo {
 impl From<&Message> for MonitoringInfo {
     /// from creates new MonitoringInfo struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [59, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.local_timestamp = typedef::LocalDateTime(field.value.as_u32()),
+                1 => {
+                    v.activity_type = match &field.value {
+                        Value::VecUint8(v) => {
+                            let mut vs = Vec::with_capacity(v.len());
+                            vs.extend(v.iter().map(|&x| typedef::ActivityType(x)));
+                            vs
+                        }
+                        _ => Vec::new(),
+                    }
+                }
+                3 => v.cycles_to_distance = field.value.to_vec_u16(),
+                4 => v.cycles_to_calories = field.value.to_vec_u16(),
+                5 => v.resting_metabolic_rate = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            local_timestamp: typedef::LocalDateTime(vals[0].as_u32()),
-            activity_type: match &vals[1] {
-                Value::VecUint8(v) => {
-                    let mut vs = Vec::with_capacity(v.len());
-                    vs.extend(v.iter().map(|&x| typedef::ActivityType(x)));
-                    vs
-                }
-                _ => Vec::new(),
-            },
-            cycles_to_distance: vals[3].to_vec_u16(),
-            cycles_to_calories: vals[4].to_vec_u16(),
-            resting_metabolic_rate: vals[5].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<MonitoringInfo> for Message {
     fn from(m: MonitoringInfo) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::LOCAL_DATE_TIME,
                 value: Value::Uint32(m.local_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.activity_type.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::ACTIVITY_TYPE,
                 value: Value::VecUint8({
@@ -204,46 +202,39 @@ impl From<MonitoringInfo> for Message {
                     unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.cycles_to_distance.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.cycles_to_distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.cycles_to_calories.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.cycles_to_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.resting_metabolic_rate != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.resting_metabolic_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::MONITORING_INFO,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/nap_event.rs
+++ b/rustyfit/src/profile/mesgdef/nap_event.rs
@@ -73,6 +73,19 @@ impl NapEvent {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_timezone_offset != i16::MAX) as usize
+            + (self.end_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.end_timezone_offset != i16::MAX) as usize
+            + (self.feedback != typedef::NapPeriodFeedback(u8::MAX)) as usize
+            + (self.is_deleted != typedef::Bool(u8::MAX)) as usize
+            + (self.source != typedef::NapSource(u8::MAX)) as usize
+            + (self.update_timestamp != typedef::DateTime(u32::MAX)) as usize
+    }
 }
 
 impl Default for NapEvent {
@@ -84,152 +97,128 @@ impl Default for NapEvent {
 impl From<&Message> for NapEvent {
     /// from creates new NapEvent struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.start_time = typedef::DateTime(field.value.as_u32()),
+                1 => v.start_timezone_offset = field.value.as_i16(),
+                2 => v.end_time = typedef::DateTime(field.value.as_u32()),
+                3 => v.end_timezone_offset = field.value.as_i16(),
+                4 => v.feedback = typedef::NapPeriodFeedback(field.value.as_u8()),
+                5 => v.is_deleted = typedef::Bool(field.value.as_u8()),
+                6 => v.source = typedef::NapSource(field.value.as_u8()),
+                7 => v.update_timestamp = typedef::DateTime(field.value.as_u32()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            start_time: typedef::DateTime(vals[0].as_u32()),
-            start_timezone_offset: vals[1].as_i16(),
-            end_time: typedef::DateTime(vals[2].as_u32()),
-            end_timezone_offset: vals[3].as_i16(),
-            feedback: typedef::NapPeriodFeedback(vals[4].as_u8()),
-            is_deleted: typedef::Bool(vals[5].as_u8()),
-            source: typedef::NapSource(vals[6].as_u8()),
-            update_timestamp: typedef::DateTime(vals[7].as_u32()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<NapEvent> for Message {
     fn from(m: NapEvent) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 10];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_timezone_offset != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.start_timezone_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.end_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_timezone_offset != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.end_timezone_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.feedback != typedef::NapPeriodFeedback(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::NAP_PERIOD_FEEDBACK,
                 value: Value::Uint8(m.feedback.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.is_deleted != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.is_deleted.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.source != typedef::NapSource(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::NAP_SOURCE,
                 value: Value::Uint8(m.source.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.update_timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.update_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::NAP_EVENT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/nmea_sentence.rs
+++ b/rustyfit/src/profile/mesgdef/nmea_sentence.rs
@@ -45,6 +45,12 @@ impl NmeaSentence {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (!self.sentence.is_empty()) as usize
+    }
 }
 
 impl Default for NmeaSentence {
@@ -56,82 +62,65 @@ impl Default for NmeaSentence {
 impl From<&Message> for NmeaSentence {
     /// from creates new NmeaSentence struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.sentence = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            sentence: vals[1].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<NmeaSentence> for Message {
     fn from(m: NmeaSentence) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.sentence.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.sentence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::NMEA_SENTENCE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/obdii_data.rs
+++ b/rustyfit/src/profile/mesgdef/obdii_data.rs
@@ -73,6 +73,18 @@ impl ObdiiData {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (!self.time_offset.is_empty()) as usize
+            + (self.pid != u8::MAX) as usize
+            + (!self.raw_data.is_empty()) as usize
+            + (!self.pid_data_size.is_empty()) as usize
+            + (!self.system_time.is_empty()) as usize
+            + (self.start_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_timestamp_ms != u16::MAX) as usize
+    }
 }
 
 impl Default for ObdiiData {
@@ -84,142 +96,119 @@ impl Default for ObdiiData {
 impl From<&Message> for ObdiiData {
     /// from creates new ObdiiData struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [255, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.time_offset = field.value.to_vec_u16(),
+                2 => v.pid = field.value.as_u8(),
+                3 => v.raw_data = field.value.to_vec_u8(),
+                4 => v.pid_data_size = field.value.to_vec_u8(),
+                5 => v.system_time = field.value.to_vec_u32(),
+                6 => v.start_timestamp = typedef::DateTime(field.value.as_u32()),
+                7 => v.start_timestamp_ms = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            time_offset: vals[1].to_vec_u16(),
-            pid: vals[2].as_u8(),
-            raw_data: vals[3].to_vec_u8(),
-            pid_data_size: vals[4].to_vec_u8(),
-            system_time: vals[5].to_vec_u32(),
-            start_timestamp: typedef::DateTime(vals[6].as_u32()),
-            start_timestamp_ms: vals[7].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ObdiiData> for Message {
     fn from(m: ObdiiData) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 9];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_offset.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.time_offset),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pid != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BYTE,
                 value: Value::Uint8(m.pid),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.raw_data.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(m.raw_data),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.pid_data_size.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.pid_data_size),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.system_time.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.system_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.start_timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::OBDII_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/ohr_settings.rs
+++ b/rustyfit/src/profile/mesgdef/ohr_settings.rs
@@ -37,6 +37,11 @@ impl OhrSettings {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.enabled != typedef::Switch(u8::MAX)) as usize
+    }
 }
 
 impl Default for OhrSettings {
@@ -48,72 +53,56 @@ impl Default for OhrSettings {
 impl From<&Message> for OhrSettings {
     /// from creates new OhrSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.enabled = typedef::Switch(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            enabled: typedef::Switch(vals[0].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<OhrSettings> for Message {
     fn from(m: OhrSettings) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 2];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enabled != typedef::Switch(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SWITCH,
                 value: Value::Uint8(m.enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::OHR_SETTINGS,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
@@ -58,6 +58,15 @@ impl OneDSensorCalibration {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.sensor_type != typedef::SensorType(u8::MAX)) as usize
+            + (self.calibration_factor != u32::MAX) as usize
+            + (self.calibration_divisor != u32::MAX) as usize
+            + (self.level_shift != u32::MAX) as usize
+            + (self.offset_cal != i32::MAX) as usize
+    }
 }
 
 impl Default for OneDSensorCalibration {
@@ -69,112 +78,92 @@ impl Default for OneDSensorCalibration {
 impl From<&Message> for OneDSensorCalibration {
     /// from creates new OneDSensorCalibration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.sensor_type = typedef::SensorType(field.value.as_u8()),
+                1 => v.calibration_factor = field.value.as_u32(),
+                2 => v.calibration_divisor = field.value.as_u32(),
+                3 => v.level_shift = field.value.as_u32(),
+                4 => v.offset_cal = field.value.as_i32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            sensor_type: typedef::SensorType(vals[0].as_u8()),
-            calibration_factor: vals[1].as_u32(),
-            calibration_divisor: vals[2].as_u32(),
-            level_shift: vals[3].as_u32(),
-            offset_cal: vals[4].as_i32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<OneDSensorCalibration> for Message {
     fn from(m: OneDSensorCalibration) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sensor_type != typedef::SensorType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SENSOR_TYPE,
                 value: Value::Uint8(m.sensor_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.calibration_factor != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.calibration_factor),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.calibration_divisor != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.calibration_divisor),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.level_shift != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.level_shift),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.offset_cal != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.offset_cal),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::ONE_D_SENSOR_CALIBRATION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/power_zone.rs
+++ b/rustyfit/src/profile/mesgdef/power_zone.rs
@@ -43,6 +43,12 @@ impl PowerZone {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.high_value != u16::MAX) as usize
+            + (!self.name.is_empty()) as usize
+    }
 }
 
 impl Default for PowerZone {
@@ -54,82 +60,65 @@ impl Default for PowerZone {
 impl From<&Message> for PowerZone {
     /// from creates new PowerZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [6, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                1 => v.high_value = field.value.as_u16(),
+                2 => v.name = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            high_value: vals[1].as_u16(),
-            name: vals[2].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<PowerZone> for Message {
     fn from(m: PowerZone) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.high_value != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.high_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::POWER_ZONE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/raw_bbi.rs
+++ b/rustyfit/src/profile/mesgdef/raw_bbi.rs
@@ -86,6 +86,15 @@ impl RawBbi {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (!self.data.is_empty()) as usize
+            + (!self.time.is_empty()) as usize
+            + (!self.quality.is_empty()) as usize
+            + (!self.gap.is_empty()) as usize
+    }
 }
 
 impl Default for RawBbi {
@@ -97,118 +106,98 @@ impl Default for RawBbi {
 impl From<&Message> for RawBbi {
     /// from creates new RawBbi struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-        let mut state = [0u8; 1];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.data = field.value.to_vec_u16(),
+                2 => v.time = field.value.to_vec_u16(),
+                3 => v.quality = field.value.to_vec_u8(),
+                4 => v.gap = field.value.to_vec_u8(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 5 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            data: vals[1].to_vec_u16(),
-            time: vals[2].to_vec_u16(),
-            quality: vals[3].to_vec_u8(),
-            gap: vals[4].to_vec_u8(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<RawBbi> for Message {
     fn from(m: RawBbi) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.data.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.data),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.time),
-                is_expanded: is_expanded(&state, 2),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 2),
+            });
+        };
         if !m.quality.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.quality),
-                is_expanded: is_expanded(&state, 3),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 3),
+            });
+        };
         if !m.gap.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.gap),
-                is_expanded: is_expanded(&state, 4),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 4),
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::RAW_BBI,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -1431,6 +1431,93 @@ impl Record {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.position_lat != i32::MAX) as usize
+            + (self.position_long != i32::MAX) as usize
+            + (self.altitude != u16::MAX) as usize
+            + (self.heart_rate != u8::MAX) as usize
+            + (self.cadence != u8::MAX) as usize
+            + (self.distance != u32::MAX) as usize
+            + (self.speed != u16::MAX) as usize
+            + (self.power != u16::MAX) as usize
+            + (self.compressed_speed_distance != [u8::MAX; 3]) as usize
+            + (self.grade != i16::MAX) as usize
+            + (self.resistance != u8::MAX) as usize
+            + (self.time_from_course != i32::MAX) as usize
+            + (self.cycle_length != u8::MAX) as usize
+            + (self.temperature != i8::MAX) as usize
+            + (!self.speed_1s.is_empty()) as usize
+            + (self.cycles != u8::MAX) as usize
+            + (self.total_cycles != u32::MAX) as usize
+            + (self.compressed_accumulated_power != u16::MAX) as usize
+            + (self.accumulated_power != u32::MAX) as usize
+            + (self.left_right_balance != typedef::LeftRightBalance(u8::MAX)) as usize
+            + (self.gps_accuracy != u8::MAX) as usize
+            + (self.vertical_speed != i16::MAX) as usize
+            + (self.calories != u16::MAX) as usize
+            + (self.vertical_oscillation != u16::MAX) as usize
+            + (self.stance_time_percent != u16::MAX) as usize
+            + (self.stance_time != u16::MAX) as usize
+            + (self.activity_type != typedef::ActivityType(u8::MAX)) as usize
+            + (self.left_torque_effectiveness != u8::MAX) as usize
+            + (self.right_torque_effectiveness != u8::MAX) as usize
+            + (self.left_pedal_smoothness != u8::MAX) as usize
+            + (self.right_pedal_smoothness != u8::MAX) as usize
+            + (self.combined_pedal_smoothness != u8::MAX) as usize
+            + (self.time128 != u8::MAX) as usize
+            + (self.stroke_type != typedef::StrokeType(u8::MAX)) as usize
+            + (self.zone != u8::MAX) as usize
+            + (self.ball_speed != u16::MAX) as usize
+            + (self.cadence256 != u16::MAX) as usize
+            + (self.fractional_cadence != u8::MAX) as usize
+            + (self.total_hemoglobin_conc != u16::MAX) as usize
+            + (self.total_hemoglobin_conc_min != u16::MAX) as usize
+            + (self.total_hemoglobin_conc_max != u16::MAX) as usize
+            + (self.saturated_hemoglobin_percent != u16::MAX) as usize
+            + (self.saturated_hemoglobin_percent_min != u16::MAX) as usize
+            + (self.saturated_hemoglobin_percent_max != u16::MAX) as usize
+            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+            + (self.left_pco != i8::MAX) as usize
+            + (self.right_pco != i8::MAX) as usize
+            + (!self.left_power_phase.is_empty()) as usize
+            + (!self.left_power_phase_peak.is_empty()) as usize
+            + (!self.right_power_phase.is_empty()) as usize
+            + (!self.right_power_phase_peak.is_empty()) as usize
+            + (self.enhanced_speed != u32::MAX) as usize
+            + (self.enhanced_altitude != u32::MAX) as usize
+            + (self.battery_soc != u8::MAX) as usize
+            + (self.motor_power != u16::MAX) as usize
+            + (self.vertical_ratio != u16::MAX) as usize
+            + (self.stance_time_balance != u16::MAX) as usize
+            + (self.step_length != u16::MAX) as usize
+            + (self.cycle_length16 != u16::MAX) as usize
+            + (self.absolute_pressure != u32::MAX) as usize
+            + (self.depth != u32::MAX) as usize
+            + (self.next_stop_depth != u32::MAX) as usize
+            + (self.next_stop_time != u32::MAX) as usize
+            + (self.time_to_surface != u32::MAX) as usize
+            + (self.ndl_time != u32::MAX) as usize
+            + (self.cns_load != u8::MAX) as usize
+            + (self.n2_load != u16::MAX) as usize
+            + (self.respiration_rate != u8::MAX) as usize
+            + (self.enhanced_respiration_rate != u16::MAX) as usize
+            + (self.grit != f32::MAX) as usize
+            + (self.flow != f32::MAX) as usize
+            + (self.current_stress != u16::MAX) as usize
+            + (self.ebike_travel_range != u16::MAX) as usize
+            + (self.ebike_battery_level != u8::MAX) as usize
+            + (self.ebike_assist_mode != u8::MAX) as usize
+            + (self.ebike_assist_level_percent != u8::MAX) as usize
+            + (self.air_time_remaining != u32::MAX) as usize
+            + (self.pressure_sac != u16::MAX) as usize
+            + (self.volume_sac != u16::MAX) as usize
+            + (self.rmv != u16::MAX) as usize
+            + (self.ascent_rate != i32::MAX) as usize
+            + (self.po2 != u8::MAX) as usize
+            + (self.core_temperature != u16::MAX) as usize
+    }
 }
 
 impl Default for Record {
@@ -1442,9 +1529,6 @@ impl Default for Record {
 impl From<&Message> for Record {
     /// from creates new Record struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-        let mut state = [0u8; 14];
-
         const KNOWN_NUMS: [u64; 4] = [
             5764606990190788607,
             18013290270358914040,
@@ -1455,899 +1539,806 @@ impl From<&Message> for Record {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.position_lat = field.value.as_i32(),
+                1 => v.position_long = field.value.as_i32(),
+                2 => v.altitude = field.value.as_u16(),
+                3 => v.heart_rate = field.value.as_u8(),
+                4 => v.cadence = field.value.as_u8(),
+                5 => v.distance = field.value.as_u32(),
+                6 => v.speed = field.value.as_u16(),
+                7 => v.power = field.value.as_u16(),
+                8 => {
+                    v.compressed_speed_distance = match &field.value {
+                        Value::VecUint8(v) => {
+                            let mut arr = [u8::MAX; 3];
+                            for (i, x) in v.iter().take(3).enumerate() {
+                                arr[i] = *x;
+                            }
+                            arr
+                        }
+                        _ => [u8::MAX; 3],
+                    }
+                }
+                9 => v.grade = field.value.as_i16(),
+                10 => v.resistance = field.value.as_u8(),
+                11 => v.time_from_course = field.value.as_i32(),
+                12 => v.cycle_length = field.value.as_u8(),
+                13 => v.temperature = field.value.as_i8(),
+                17 => v.speed_1s = field.value.to_vec_u8(),
+                18 => v.cycles = field.value.as_u8(),
+                19 => v.total_cycles = field.value.as_u32(),
+                28 => v.compressed_accumulated_power = field.value.as_u16(),
+                29 => v.accumulated_power = field.value.as_u32(),
+                30 => v.left_right_balance = typedef::LeftRightBalance(field.value.as_u8()),
+                31 => v.gps_accuracy = field.value.as_u8(),
+                32 => v.vertical_speed = field.value.as_i16(),
+                33 => v.calories = field.value.as_u16(),
+                39 => v.vertical_oscillation = field.value.as_u16(),
+                40 => v.stance_time_percent = field.value.as_u16(),
+                41 => v.stance_time = field.value.as_u16(),
+                42 => v.activity_type = typedef::ActivityType(field.value.as_u8()),
+                43 => v.left_torque_effectiveness = field.value.as_u8(),
+                44 => v.right_torque_effectiveness = field.value.as_u8(),
+                45 => v.left_pedal_smoothness = field.value.as_u8(),
+                46 => v.right_pedal_smoothness = field.value.as_u8(),
+                47 => v.combined_pedal_smoothness = field.value.as_u8(),
+                48 => v.time128 = field.value.as_u8(),
+                49 => v.stroke_type = typedef::StrokeType(field.value.as_u8()),
+                50 => v.zone = field.value.as_u8(),
+                51 => v.ball_speed = field.value.as_u16(),
+                52 => v.cadence256 = field.value.as_u16(),
+                53 => v.fractional_cadence = field.value.as_u8(),
+                54 => v.total_hemoglobin_conc = field.value.as_u16(),
+                55 => v.total_hemoglobin_conc_min = field.value.as_u16(),
+                56 => v.total_hemoglobin_conc_max = field.value.as_u16(),
+                57 => v.saturated_hemoglobin_percent = field.value.as_u16(),
+                58 => v.saturated_hemoglobin_percent_min = field.value.as_u16(),
+                59 => v.saturated_hemoglobin_percent_max = field.value.as_u16(),
+                62 => v.device_index = typedef::DeviceIndex(field.value.as_u8()),
+                67 => v.left_pco = field.value.as_i8(),
+                68 => v.right_pco = field.value.as_i8(),
+                69 => v.left_power_phase = field.value.to_vec_u8(),
+                70 => v.left_power_phase_peak = field.value.to_vec_u8(),
+                71 => v.right_power_phase = field.value.to_vec_u8(),
+                72 => v.right_power_phase_peak = field.value.to_vec_u8(),
+                73 => v.enhanced_speed = field.value.as_u32(),
+                78 => v.enhanced_altitude = field.value.as_u32(),
+                81 => v.battery_soc = field.value.as_u8(),
+                82 => v.motor_power = field.value.as_u16(),
+                83 => v.vertical_ratio = field.value.as_u16(),
+                84 => v.stance_time_balance = field.value.as_u16(),
+                85 => v.step_length = field.value.as_u16(),
+                87 => v.cycle_length16 = field.value.as_u16(),
+                91 => v.absolute_pressure = field.value.as_u32(),
+                92 => v.depth = field.value.as_u32(),
+                93 => v.next_stop_depth = field.value.as_u32(),
+                94 => v.next_stop_time = field.value.as_u32(),
+                95 => v.time_to_surface = field.value.as_u32(),
+                96 => v.ndl_time = field.value.as_u32(),
+                97 => v.cns_load = field.value.as_u8(),
+                98 => v.n2_load = field.value.as_u16(),
+                99 => v.respiration_rate = field.value.as_u8(),
+                108 => v.enhanced_respiration_rate = field.value.as_u16(),
+                114 => v.grit = field.value.as_f32(),
+                115 => v.flow = field.value.as_f32(),
+                116 => v.current_stress = field.value.as_u16(),
+                117 => v.ebike_travel_range = field.value.as_u16(),
+                118 => v.ebike_battery_level = field.value.as_u8(),
+                119 => v.ebike_assist_mode = field.value.as_u8(),
+                120 => v.ebike_assist_level_percent = field.value.as_u8(),
+                123 => v.air_time_remaining = field.value.as_u32(),
+                124 => v.pressure_sac = field.value.as_u16(),
+                125 => v.volume_sac = field.value.as_u16(),
+                126 => v.rmv = field.value.as_u16(),
+                127 => v.ascent_rate = field.value.as_i32(),
+                129 => v.po2 = field.value.as_u8(),
+                139 => v.core_temperature = field.value.as_u16(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 109 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            position_lat: vals[0].as_i32(),
-            position_long: vals[1].as_i32(),
-            altitude: vals[2].as_u16(),
-            heart_rate: vals[3].as_u8(),
-            cadence: vals[4].as_u8(),
-            distance: vals[5].as_u32(),
-            speed: vals[6].as_u16(),
-            power: vals[7].as_u16(),
-            compressed_speed_distance: match &vals[8] {
-                Value::VecUint8(v) => {
-                    let mut arr = [u8::MAX; 3];
-                    for (i, x) in v.iter().take(3).enumerate() {
-                        arr[i] = *x;
-                    }
-                    arr
-                }
-                _ => [u8::MAX; 3],
-            },
-            grade: vals[9].as_i16(),
-            resistance: vals[10].as_u8(),
-            time_from_course: vals[11].as_i32(),
-            cycle_length: vals[12].as_u8(),
-            temperature: vals[13].as_i8(),
-            speed_1s: vals[17].to_vec_u8(),
-            cycles: vals[18].as_u8(),
-            total_cycles: vals[19].as_u32(),
-            compressed_accumulated_power: vals[28].as_u16(),
-            accumulated_power: vals[29].as_u32(),
-            left_right_balance: typedef::LeftRightBalance(vals[30].as_u8()),
-            gps_accuracy: vals[31].as_u8(),
-            vertical_speed: vals[32].as_i16(),
-            calories: vals[33].as_u16(),
-            vertical_oscillation: vals[39].as_u16(),
-            stance_time_percent: vals[40].as_u16(),
-            stance_time: vals[41].as_u16(),
-            activity_type: typedef::ActivityType(vals[42].as_u8()),
-            left_torque_effectiveness: vals[43].as_u8(),
-            right_torque_effectiveness: vals[44].as_u8(),
-            left_pedal_smoothness: vals[45].as_u8(),
-            right_pedal_smoothness: vals[46].as_u8(),
-            combined_pedal_smoothness: vals[47].as_u8(),
-            time128: vals[48].as_u8(),
-            stroke_type: typedef::StrokeType(vals[49].as_u8()),
-            zone: vals[50].as_u8(),
-            ball_speed: vals[51].as_u16(),
-            cadence256: vals[52].as_u16(),
-            fractional_cadence: vals[53].as_u8(),
-            total_hemoglobin_conc: vals[54].as_u16(),
-            total_hemoglobin_conc_min: vals[55].as_u16(),
-            total_hemoglobin_conc_max: vals[56].as_u16(),
-            saturated_hemoglobin_percent: vals[57].as_u16(),
-            saturated_hemoglobin_percent_min: vals[58].as_u16(),
-            saturated_hemoglobin_percent_max: vals[59].as_u16(),
-            device_index: typedef::DeviceIndex(vals[62].as_u8()),
-            left_pco: vals[67].as_i8(),
-            right_pco: vals[68].as_i8(),
-            left_power_phase: vals[69].to_vec_u8(),
-            left_power_phase_peak: vals[70].to_vec_u8(),
-            right_power_phase: vals[71].to_vec_u8(),
-            right_power_phase_peak: vals[72].to_vec_u8(),
-            enhanced_speed: vals[73].as_u32(),
-            enhanced_altitude: vals[78].as_u32(),
-            battery_soc: vals[81].as_u8(),
-            motor_power: vals[82].as_u16(),
-            vertical_ratio: vals[83].as_u16(),
-            stance_time_balance: vals[84].as_u16(),
-            step_length: vals[85].as_u16(),
-            cycle_length16: vals[87].as_u16(),
-            absolute_pressure: vals[91].as_u32(),
-            depth: vals[92].as_u32(),
-            next_stop_depth: vals[93].as_u32(),
-            next_stop_time: vals[94].as_u32(),
-            time_to_surface: vals[95].as_u32(),
-            ndl_time: vals[96].as_u32(),
-            cns_load: vals[97].as_u8(),
-            n2_load: vals[98].as_u16(),
-            respiration_rate: vals[99].as_u8(),
-            enhanced_respiration_rate: vals[108].as_u16(),
-            grit: vals[114].as_f32(),
-            flow: vals[115].as_f32(),
-            current_stress: vals[116].as_u16(),
-            ebike_travel_range: vals[117].as_u16(),
-            ebike_battery_level: vals[118].as_u8(),
-            ebike_assist_mode: vals[119].as_u8(),
-            ebike_assist_level_percent: vals[120].as_u8(),
-            air_time_remaining: vals[123].as_u32(),
-            pressure_sac: vals[124].as_u16(),
-            volume_sac: vals[125].as_u16(),
-            rmv: vals[126].as_u16(),
-            ascent_rate: vals[127].as_i32(),
-            po2: vals[129].as_u8(),
-            core_temperature: vals[139].as_u16(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Record> for Message {
     fn from(m: Record) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 84];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.distance),
-                is_expanded: is_expanded(&state, 5),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 5),
+            });
+        };
         if m.speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.speed),
-                is_expanded: is_expanded(&state, 6),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 6),
+            });
+        };
         if m.power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.compressed_speed_distance != [u8::MAX; 3] {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(Vec::from(&m.compressed_speed_distance)),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.resistance != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.resistance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time_from_course != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.time_from_course),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cycle_length != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.cycle_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.speed_1s.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.speed_1s),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cycles != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.cycles),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_cycles != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_cycles),
-                is_expanded: is_expanded(&state, 19),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 19),
+            });
+        };
         if m.compressed_accumulated_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 28,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.compressed_accumulated_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.accumulated_power != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 29,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.accumulated_power),
-                is_expanded: is_expanded(&state, 29),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 29),
+            });
+        };
         if m.left_right_balance != typedef::LeftRightBalance(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 30,
                 profile_type: ProfileType::LEFT_RIGHT_BALANCE,
                 value: Value::Uint8(m.left_right_balance.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.gps_accuracy != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 31,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.gps_accuracy),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 32,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 33,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.vertical_oscillation != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 39,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.vertical_oscillation),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.stance_time_percent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 40,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.stance_time_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.stance_time != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 41,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.stance_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.activity_type != typedef::ActivityType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 42,
                 profile_type: ProfileType::ACTIVITY_TYPE,
                 value: Value::Uint8(m.activity_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.left_torque_effectiveness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 43,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.left_torque_effectiveness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.right_torque_effectiveness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 44,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.right_torque_effectiveness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.left_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 45,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.left_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.right_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 46,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.right_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.combined_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 47,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.combined_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time128 != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 48,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.time128),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.stroke_type != typedef::StrokeType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 49,
                 profile_type: ProfileType::STROKE_TYPE,
                 value: Value::Uint8(m.stroke_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.zone != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 50,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ball_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 51,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.ball_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cadence256 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 52,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.cadence256),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.fractional_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 53,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.fractional_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_hemoglobin_conc != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 54,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_hemoglobin_conc),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_hemoglobin_conc_min != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 55,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_hemoglobin_conc_min),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_hemoglobin_conc_max != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 56,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_hemoglobin_conc_max),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.saturated_hemoglobin_percent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 57,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.saturated_hemoglobin_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.saturated_hemoglobin_percent_min != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 58,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.saturated_hemoglobin_percent_min),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.saturated_hemoglobin_percent_max != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 59,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.saturated_hemoglobin_percent_max),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.device_index != typedef::DeviceIndex(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 62,
                 profile_type: ProfileType::DEVICE_INDEX,
                 value: Value::Uint8(m.device_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.left_pco != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 67,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.left_pco),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.right_pco != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 68,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.right_pco),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.left_power_phase.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 69,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.left_power_phase),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.left_power_phase_peak.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 70,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.left_power_phase_peak),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.right_power_phase.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 71,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.right_power_phase),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.right_power_phase_peak.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 72,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.right_power_phase_peak),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 73,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_speed),
-                is_expanded: is_expanded(&state, 73),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 73),
+            });
+        };
         if m.enhanced_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 78,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_altitude),
-                is_expanded: is_expanded(&state, 78),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 78),
+            });
+        };
         if m.battery_soc != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 81,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.battery_soc),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.motor_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 82,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.motor_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.vertical_ratio != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 83,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.vertical_ratio),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.stance_time_balance != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 84,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.stance_time_balance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.step_length != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 85,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.step_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cycle_length16 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 87,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.cycle_length16),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.absolute_pressure != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 91,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.absolute_pressure),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 92,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.next_stop_depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 93,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.next_stop_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.next_stop_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 94,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.next_stop_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time_to_surface != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 95,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.time_to_surface),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ndl_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 96,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.ndl_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.cns_load != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 97,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.cns_load),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.n2_load != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 98,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.n2_load),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.respiration_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 99,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_respiration_rate != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 108,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.enhanced_respiration_rate),
-                is_expanded: is_expanded(&state, 108),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 108),
+            });
+        };
         if m.grit != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 114,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.grit),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.flow != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 115,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.flow),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.current_stress != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 116,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.current_stress),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ebike_travel_range != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 117,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.ebike_travel_range),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ebike_battery_level != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 118,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.ebike_battery_level),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ebike_assist_mode != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 119,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.ebike_assist_mode),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ebike_assist_level_percent != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 120,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.ebike_assist_level_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.air_time_remaining != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 123,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.air_time_remaining),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pressure_sac != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 124,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.pressure_sac),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.volume_sac != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 125,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.volume_sac),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.rmv != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 126,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.rmv),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.ascent_rate != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 127,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.ascent_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.po2 != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 129,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.po2),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.core_temperature != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 139,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.core_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::RECORD,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/respiration_rate.rs
+++ b/rustyfit/src/profile/mesgdef/respiration_rate.rs
@@ -56,6 +56,11 @@ impl RespirationRate {
         self.respiration_rate = unscaled as i16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.respiration_rate != i16::MAX) as usize
+    }
 }
 
 impl Default for RespirationRate {
@@ -67,72 +72,56 @@ impl Default for RespirationRate {
 impl From<&Message> for RespirationRate {
     /// from creates new RespirationRate struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.respiration_rate = field.value.as_i16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            respiration_rate: vals[0].as_i16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<RespirationRate> for Message {
     fn from(m: RespirationRate) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 2];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.respiration_rate != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::RESPIRATION_RATE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/schedule.rs
+++ b/rustyfit/src/profile/mesgdef/schedule.rs
@@ -61,6 +61,16 @@ impl Schedule {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.product != u16::MAX) as usize
+            + (self.serial_number != u32::MIN) as usize
+            + (self.time_created != typedef::DateTime(u32::MAX)) as usize
+            + (self.completed != typedef::Bool(u8::MAX)) as usize
+            + (self.r#type != typedef::Schedule(u8::MAX)) as usize
+            + (self.scheduled_time != typedef::LocalDateTime(u32::MAX)) as usize
+    }
 }
 
 impl Default for Schedule {
@@ -72,122 +82,101 @@ impl Default for Schedule {
 impl From<&Message> for Schedule {
     /// from creates new Schedule struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 7];
-
         const KNOWN_NUMS: [u64; 4] = [127, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.manufacturer = typedef::Manufacturer(field.value.as_u16()),
+                1 => v.product = field.value.as_u16(),
+                2 => v.serial_number = field.value.as_u32z(),
+                3 => v.time_created = typedef::DateTime(field.value.as_u32()),
+                4 => v.completed = typedef::Bool(field.value.as_u8()),
+                5 => v.r#type = typedef::Schedule(field.value.as_u8()),
+                6 => v.scheduled_time = typedef::LocalDateTime(field.value.as_u32()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            manufacturer: typedef::Manufacturer(vals[0].as_u16()),
-            product: vals[1].as_u16(),
-            serial_number: vals[2].as_u32z(),
-            time_created: typedef::DateTime(vals[3].as_u32()),
-            completed: typedef::Bool(vals[4].as_u8()),
-            r#type: typedef::Schedule(vals[5].as_u8()),
-            scheduled_time: typedef::LocalDateTime(vals[6].as_u32()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Schedule> for Message {
     fn from(m: Schedule) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.manufacturer != typedef::Manufacturer(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::MANUFACTURER,
                 value: Value::Uint16(m.manufacturer.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.product != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.product),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.serial_number != u32::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32Z,
                 value: Value::Uint32(m.serial_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time_created != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.time_created.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.completed != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.completed.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.r#type != typedef::Schedule(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SCHEDULE,
                 value: Value::Uint8(m.r#type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.scheduled_time != typedef::LocalDateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::LOCAL_DATE_TIME,
                 value: Value::Uint32(m.scheduled_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SCHEDULE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/sdm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/sdm_profile.rs
@@ -104,6 +104,17 @@ impl SdmProfile {
         self.odometer = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.sdm_ant_id != u16::MIN) as usize
+            + (self.sdm_cal_factor != u16::MAX) as usize
+            + (self.odometer != u32::MAX) as usize
+            + (self.speed_source != typedef::Bool(u8::MAX)) as usize
+            + (self.sdm_ant_id_trans_type != u8::MIN) as usize
+            + (self.odometer_rollover != u8::MAX) as usize
+    }
 }
 
 impl Default for SdmProfile {
@@ -115,132 +126,110 @@ impl Default for SdmProfile {
 impl From<&Message> for SdmProfile {
     /// from creates new SdmProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [191, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.enabled = typedef::Bool(field.value.as_u8()),
+                1 => v.sdm_ant_id = field.value.as_u16z(),
+                2 => v.sdm_cal_factor = field.value.as_u16(),
+                3 => v.odometer = field.value.as_u32(),
+                4 => v.speed_source = typedef::Bool(field.value.as_u8()),
+                5 => v.sdm_ant_id_trans_type = field.value.as_u8z(),
+                7 => v.odometer_rollover = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            enabled: typedef::Bool(vals[0].as_u8()),
-            sdm_ant_id: vals[1].as_u16z(),
-            sdm_cal_factor: vals[2].as_u16(),
-            odometer: vals[3].as_u32(),
-            speed_source: typedef::Bool(vals[4].as_u8()),
-            sdm_ant_id_trans_type: vals[5].as_u8z(),
-            odometer_rollover: vals[7].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SdmProfile> for Message {
     fn from(m: SdmProfile) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 8];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sdm_ant_id != u16::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16Z,
                 value: Value::Uint16(m.sdm_ant_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sdm_cal_factor != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.sdm_cal_factor),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.odometer != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.odometer),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.speed_source != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.speed_source.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sdm_ant_id_trans_type != u8::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT8Z,
                 value: Value::Uint8(m.sdm_ant_id_trans_type),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.odometer_rollover != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.odometer_rollover),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SDM_PROFILE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/segment_file.rs
+++ b/rustyfit/src/profile/mesgdef/segment_file.rs
@@ -74,6 +74,18 @@ impl SegmentFile {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (!self.file_uuid.is_empty()) as usize
+            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.user_profile_primary_key != u32::MAX) as usize
+            + (!self.leader_type.is_empty()) as usize
+            + (!self.leader_group_primary_key.is_empty()) as usize
+            + (!self.leader_activity_id.is_empty()) as usize
+            + (!self.leader_activity_id_string.is_empty()) as usize
+            + (self.default_race_leader != u8::MAX) as usize
+    }
 }
 
 impl Default for SegmentFile {
@@ -85,96 +97,83 @@ impl Default for SegmentFile {
 impl From<&Message> for SegmentFile {
     /// from creates new SegmentFile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [3994, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                1 => v.file_uuid = field.value.as_str().to_owned(),
+                3 => v.enabled = typedef::Bool(field.value.as_u8()),
+                4 => v.user_profile_primary_key = field.value.as_u32(),
+                7 => {
+                    v.leader_type = match &field.value {
+                        Value::VecUint8(v) => {
+                            let mut vs = Vec::with_capacity(v.len());
+                            vs.extend(v.iter().map(|&x| typedef::SegmentLeaderboardType(x)));
+                            vs
+                        }
+                        _ => Vec::new(),
+                    }
+                }
+                8 => v.leader_group_primary_key = field.value.to_vec_u32(),
+                9 => v.leader_activity_id = field.value.to_vec_u32(),
+                10 => v.leader_activity_id_string = field.value.to_vec_string(),
+                11 => v.default_race_leader = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            file_uuid: vals[1].as_str().to_owned(),
-            enabled: typedef::Bool(vals[3].as_u8()),
-            user_profile_primary_key: vals[4].as_u32(),
-            leader_type: match &vals[7] {
-                Value::VecUint8(v) => {
-                    let mut vs = Vec::with_capacity(v.len());
-                    vs.extend(v.iter().map(|&x| typedef::SegmentLeaderboardType(x)));
-                    vs
-                }
-                _ => Vec::new(),
-            },
-            leader_group_primary_key: vals[8].to_vec_u32(),
-            leader_activity_id: vals[9].to_vec_u32(),
-            leader_activity_id_string: vals[10].to_vec_string(),
-            default_race_leader: vals[11].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SegmentFile> for Message {
     fn from(m: SegmentFile) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 9];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.file_uuid.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.file_uuid),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.user_profile_primary_key != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.user_profile_primary_key),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.leader_type.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::SEGMENT_LEADERBOARD_TYPE,
                 value: Value::VecUint8({
@@ -182,55 +181,47 @@ impl From<SegmentFile> for Message {
                     unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), len, capacity) }
                 }),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.leader_group_primary_key.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.leader_group_primary_key),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.leader_activity_id.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.leader_activity_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.leader_activity_id_string.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::STRING,
                 value: Value::VecString(m.leader_activity_id_string),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.default_race_leader != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.default_race_leader),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_FILE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/segment_id.rs
+++ b/rustyfit/src/profile/mesgdef/segment_id.rs
@@ -75,6 +75,18 @@ impl SegmentId {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (!self.name.is_empty()) as usize
+            + (!self.uuid.is_empty()) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.user_profile_primary_key != u32::MAX) as usize
+            + (self.device_id != u32::MAX) as usize
+            + (self.default_race_leader != u8::MAX) as usize
+            + (self.delete_status != typedef::SegmentDeleteStatus(u8::MAX)) as usize
+            + (self.selection_type != typedef::SegmentSelectionType(u8::MAX)) as usize
+    }
 }
 
 impl Default for SegmentId {
@@ -86,142 +98,119 @@ impl Default for SegmentId {
 impl From<&Message> for SegmentId {
     /// from creates new SegmentId struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 9];
-
         const KNOWN_NUMS: [u64; 4] = [511, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.name = field.value.as_str().to_owned(),
+                1 => v.uuid = field.value.as_str().to_owned(),
+                2 => v.sport = typedef::Sport(field.value.as_u8()),
+                3 => v.enabled = typedef::Bool(field.value.as_u8()),
+                4 => v.user_profile_primary_key = field.value.as_u32(),
+                5 => v.device_id = field.value.as_u32(),
+                6 => v.default_race_leader = field.value.as_u8(),
+                7 => v.delete_status = typedef::SegmentDeleteStatus(field.value.as_u8()),
+                8 => v.selection_type = typedef::SegmentSelectionType(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            name: vals[0].as_str().to_owned(),
-            uuid: vals[1].as_str().to_owned(),
-            sport: typedef::Sport(vals[2].as_u8()),
-            enabled: typedef::Bool(vals[3].as_u8()),
-            user_profile_primary_key: vals[4].as_u32(),
-            device_id: vals[5].as_u32(),
-            default_race_leader: vals[6].as_u8(),
-            delete_status: typedef::SegmentDeleteStatus(vals[7].as_u8()),
-            selection_type: typedef::SegmentSelectionType(vals[8].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SegmentId> for Message {
     fn from(m: SegmentId) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 9];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.uuid.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.uuid),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enabled != typedef::Bool(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::BOOL,
                 value: Value::Uint8(m.enabled.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.user_profile_primary_key != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.user_profile_primary_key),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.device_id != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.device_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.default_race_leader != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.default_race_leader),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.delete_status != typedef::SegmentDeleteStatus(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::SEGMENT_DELETE_STATUS,
                 value: Value::Uint8(m.delete_status.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.selection_type != typedef::SegmentSelectionType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::SEGMENT_SELECTION_TYPE,
                 value: Value::Uint8(m.selection_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_ID,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -1426,6 +1426,104 @@ impl SegmentLap {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.event != typedef::Event(u8::MAX)) as usize
+            + (self.event_type != typedef::EventType(u8::MAX)) as usize
+            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_position_lat != i32::MAX) as usize
+            + (self.start_position_long != i32::MAX) as usize
+            + (self.end_position_lat != i32::MAX) as usize
+            + (self.end_position_long != i32::MAX) as usize
+            + (self.total_elapsed_time != u32::MAX) as usize
+            + (self.total_timer_time != u32::MAX) as usize
+            + (self.total_distance != u32::MAX) as usize
+            + (self.total_cycles != u32::MAX) as usize
+            + (self.total_calories != u16::MAX) as usize
+            + (self.total_fat_calories != u16::MAX) as usize
+            + (self.avg_speed != u16::MAX) as usize
+            + (self.max_speed != u16::MAX) as usize
+            + (self.avg_heart_rate != u8::MAX) as usize
+            + (self.max_heart_rate != u8::MAX) as usize
+            + (self.avg_cadence != u8::MAX) as usize
+            + (self.max_cadence != u8::MAX) as usize
+            + (self.avg_power != u16::MAX) as usize
+            + (self.max_power != u16::MAX) as usize
+            + (self.total_ascent != u16::MAX) as usize
+            + (self.total_descent != u16::MAX) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.event_group != u8::MAX) as usize
+            + (self.nec_lat != i32::MAX) as usize
+            + (self.nec_long != i32::MAX) as usize
+            + (self.swc_lat != i32::MAX) as usize
+            + (self.swc_long != i32::MAX) as usize
+            + (!self.name.is_empty()) as usize
+            + (self.normalized_power != u16::MAX) as usize
+            + (self.left_right_balance != typedef::LeftRightBalance100(u16::MAX)) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.total_work != u32::MAX) as usize
+            + (self.avg_altitude != u16::MAX) as usize
+            + (self.max_altitude != u16::MAX) as usize
+            + (self.gps_accuracy != u8::MAX) as usize
+            + (self.avg_grade != i16::MAX) as usize
+            + (self.avg_pos_grade != i16::MAX) as usize
+            + (self.avg_neg_grade != i16::MAX) as usize
+            + (self.max_pos_grade != i16::MAX) as usize
+            + (self.max_neg_grade != i16::MAX) as usize
+            + (self.avg_temperature != i8::MAX) as usize
+            + (self.max_temperature != i8::MAX) as usize
+            + (self.total_moving_time != u32::MAX) as usize
+            + (self.avg_pos_vertical_speed != i16::MAX) as usize
+            + (self.avg_neg_vertical_speed != i16::MAX) as usize
+            + (self.max_pos_vertical_speed != i16::MAX) as usize
+            + (self.max_neg_vertical_speed != i16::MAX) as usize
+            + (!self.time_in_hr_zone.is_empty()) as usize
+            + (!self.time_in_speed_zone.is_empty()) as usize
+            + (!self.time_in_cadence_zone.is_empty()) as usize
+            + (!self.time_in_power_zone.is_empty()) as usize
+            + (self.repetition_num != u16::MAX) as usize
+            + (self.min_altitude != u16::MAX) as usize
+            + (self.min_heart_rate != u8::MAX) as usize
+            + (self.active_time != u32::MAX) as usize
+            + (self.wkt_step_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.sport_event != typedef::SportEvent(u8::MAX)) as usize
+            + (self.avg_left_torque_effectiveness != u8::MAX) as usize
+            + (self.avg_right_torque_effectiveness != u8::MAX) as usize
+            + (self.avg_left_pedal_smoothness != u8::MAX) as usize
+            + (self.avg_right_pedal_smoothness != u8::MAX) as usize
+            + (self.avg_combined_pedal_smoothness != u8::MAX) as usize
+            + (self.status != typedef::SegmentLapStatus(u8::MAX)) as usize
+            + (!self.uuid.is_empty()) as usize
+            + (self.avg_fractional_cadence != u8::MAX) as usize
+            + (self.max_fractional_cadence != u8::MAX) as usize
+            + (self.total_fractional_cycles != u8::MAX) as usize
+            + (self.front_gear_shift_count != u16::MAX) as usize
+            + (self.rear_gear_shift_count != u16::MAX) as usize
+            + (self.time_standing != u32::MAX) as usize
+            + (self.stand_count != u16::MAX) as usize
+            + (self.avg_left_pco != i8::MAX) as usize
+            + (self.avg_right_pco != i8::MAX) as usize
+            + (!self.avg_left_power_phase.is_empty()) as usize
+            + (!self.avg_left_power_phase_peak.is_empty()) as usize
+            + (!self.avg_right_power_phase.is_empty()) as usize
+            + (!self.avg_right_power_phase_peak.is_empty()) as usize
+            + (!self.avg_power_position.is_empty()) as usize
+            + (!self.max_power_position.is_empty()) as usize
+            + (!self.avg_cadence_position.is_empty()) as usize
+            + (!self.max_cadence_position.is_empty()) as usize
+            + (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.total_grit != f32::MAX) as usize
+            + (self.total_flow != f32::MAX) as usize
+            + (self.avg_grit != f32::MAX) as usize
+            + (self.avg_flow != f32::MAX) as usize
+            + (self.total_fractional_ascent != u8::MAX) as usize
+            + (self.total_fractional_descent != u8::MAX) as usize
+            + (self.enhanced_avg_altitude != u32::MAX) as usize
+            + (self.enhanced_max_altitude != u32::MAX) as usize
+            + (self.enhanced_min_altitude != u32::MAX) as usize
+    }
 }
 
 impl Default for SegmentLap {
@@ -1437,1008 +1535,899 @@ impl Default for SegmentLap {
 impl From<&Message> for SegmentLap {
     /// from creates new SegmentLap struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-        let mut state = [0u8; 12];
-
         const KNOWN_NUMS: [u64; 4] = [18446744073709551615, 1056964607, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.event = typedef::Event(field.value.as_u8()),
+                1 => v.event_type = typedef::EventType(field.value.as_u8()),
+                2 => v.start_time = typedef::DateTime(field.value.as_u32()),
+                3 => v.start_position_lat = field.value.as_i32(),
+                4 => v.start_position_long = field.value.as_i32(),
+                5 => v.end_position_lat = field.value.as_i32(),
+                6 => v.end_position_long = field.value.as_i32(),
+                7 => v.total_elapsed_time = field.value.as_u32(),
+                8 => v.total_timer_time = field.value.as_u32(),
+                9 => v.total_distance = field.value.as_u32(),
+                10 => v.total_cycles = field.value.as_u32(),
+                11 => v.total_calories = field.value.as_u16(),
+                12 => v.total_fat_calories = field.value.as_u16(),
+                13 => v.avg_speed = field.value.as_u16(),
+                14 => v.max_speed = field.value.as_u16(),
+                15 => v.avg_heart_rate = field.value.as_u8(),
+                16 => v.max_heart_rate = field.value.as_u8(),
+                17 => v.avg_cadence = field.value.as_u8(),
+                18 => v.max_cadence = field.value.as_u8(),
+                19 => v.avg_power = field.value.as_u16(),
+                20 => v.max_power = field.value.as_u16(),
+                21 => v.total_ascent = field.value.as_u16(),
+                22 => v.total_descent = field.value.as_u16(),
+                23 => v.sport = typedef::Sport(field.value.as_u8()),
+                24 => v.event_group = field.value.as_u8(),
+                25 => v.nec_lat = field.value.as_i32(),
+                26 => v.nec_long = field.value.as_i32(),
+                27 => v.swc_lat = field.value.as_i32(),
+                28 => v.swc_long = field.value.as_i32(),
+                29 => v.name = field.value.as_str().to_owned(),
+                30 => v.normalized_power = field.value.as_u16(),
+                31 => v.left_right_balance = typedef::LeftRightBalance100(field.value.as_u16()),
+                32 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                33 => v.total_work = field.value.as_u32(),
+                34 => v.avg_altitude = field.value.as_u16(),
+                35 => v.max_altitude = field.value.as_u16(),
+                36 => v.gps_accuracy = field.value.as_u8(),
+                37 => v.avg_grade = field.value.as_i16(),
+                38 => v.avg_pos_grade = field.value.as_i16(),
+                39 => v.avg_neg_grade = field.value.as_i16(),
+                40 => v.max_pos_grade = field.value.as_i16(),
+                41 => v.max_neg_grade = field.value.as_i16(),
+                42 => v.avg_temperature = field.value.as_i8(),
+                43 => v.max_temperature = field.value.as_i8(),
+                44 => v.total_moving_time = field.value.as_u32(),
+                45 => v.avg_pos_vertical_speed = field.value.as_i16(),
+                46 => v.avg_neg_vertical_speed = field.value.as_i16(),
+                47 => v.max_pos_vertical_speed = field.value.as_i16(),
+                48 => v.max_neg_vertical_speed = field.value.as_i16(),
+                49 => v.time_in_hr_zone = field.value.to_vec_u32(),
+                50 => v.time_in_speed_zone = field.value.to_vec_u32(),
+                51 => v.time_in_cadence_zone = field.value.to_vec_u32(),
+                52 => v.time_in_power_zone = field.value.to_vec_u32(),
+                53 => v.repetition_num = field.value.as_u16(),
+                54 => v.min_altitude = field.value.as_u16(),
+                55 => v.min_heart_rate = field.value.as_u8(),
+                56 => v.active_time = field.value.as_u32(),
+                57 => v.wkt_step_index = typedef::MessageIndex(field.value.as_u16()),
+                58 => v.sport_event = typedef::SportEvent(field.value.as_u8()),
+                59 => v.avg_left_torque_effectiveness = field.value.as_u8(),
+                60 => v.avg_right_torque_effectiveness = field.value.as_u8(),
+                61 => v.avg_left_pedal_smoothness = field.value.as_u8(),
+                62 => v.avg_right_pedal_smoothness = field.value.as_u8(),
+                63 => v.avg_combined_pedal_smoothness = field.value.as_u8(),
+                64 => v.status = typedef::SegmentLapStatus(field.value.as_u8()),
+                65 => v.uuid = field.value.as_str().to_owned(),
+                66 => v.avg_fractional_cadence = field.value.as_u8(),
+                67 => v.max_fractional_cadence = field.value.as_u8(),
+                68 => v.total_fractional_cycles = field.value.as_u8(),
+                69 => v.front_gear_shift_count = field.value.as_u16(),
+                70 => v.rear_gear_shift_count = field.value.as_u16(),
+                71 => v.time_standing = field.value.as_u32(),
+                72 => v.stand_count = field.value.as_u16(),
+                73 => v.avg_left_pco = field.value.as_i8(),
+                74 => v.avg_right_pco = field.value.as_i8(),
+                75 => v.avg_left_power_phase = field.value.to_vec_u8(),
+                76 => v.avg_left_power_phase_peak = field.value.to_vec_u8(),
+                77 => v.avg_right_power_phase = field.value.to_vec_u8(),
+                78 => v.avg_right_power_phase_peak = field.value.to_vec_u8(),
+                79 => v.avg_power_position = field.value.to_vec_u16(),
+                80 => v.max_power_position = field.value.to_vec_u16(),
+                81 => v.avg_cadence_position = field.value.to_vec_u8(),
+                82 => v.max_cadence_position = field.value.to_vec_u8(),
+                83 => v.manufacturer = typedef::Manufacturer(field.value.as_u16()),
+                84 => v.total_grit = field.value.as_f32(),
+                85 => v.total_flow = field.value.as_f32(),
+                86 => v.avg_grit = field.value.as_f32(),
+                87 => v.avg_flow = field.value.as_f32(),
+                89 => v.total_fractional_ascent = field.value.as_u8(),
+                90 => v.total_fractional_descent = field.value.as_u8(),
+                91 => v.enhanced_avg_altitude = field.value.as_u32(),
+                92 => v.enhanced_max_altitude = field.value.as_u32(),
+                93 => v.enhanced_min_altitude = field.value.as_u32(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 94 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            event: typedef::Event(vals[0].as_u8()),
-            event_type: typedef::EventType(vals[1].as_u8()),
-            start_time: typedef::DateTime(vals[2].as_u32()),
-            start_position_lat: vals[3].as_i32(),
-            start_position_long: vals[4].as_i32(),
-            end_position_lat: vals[5].as_i32(),
-            end_position_long: vals[6].as_i32(),
-            total_elapsed_time: vals[7].as_u32(),
-            total_timer_time: vals[8].as_u32(),
-            total_distance: vals[9].as_u32(),
-            total_cycles: vals[10].as_u32(),
-            total_calories: vals[11].as_u16(),
-            total_fat_calories: vals[12].as_u16(),
-            avg_speed: vals[13].as_u16(),
-            max_speed: vals[14].as_u16(),
-            avg_heart_rate: vals[15].as_u8(),
-            max_heart_rate: vals[16].as_u8(),
-            avg_cadence: vals[17].as_u8(),
-            max_cadence: vals[18].as_u8(),
-            avg_power: vals[19].as_u16(),
-            max_power: vals[20].as_u16(),
-            total_ascent: vals[21].as_u16(),
-            total_descent: vals[22].as_u16(),
-            sport: typedef::Sport(vals[23].as_u8()),
-            event_group: vals[24].as_u8(),
-            nec_lat: vals[25].as_i32(),
-            nec_long: vals[26].as_i32(),
-            swc_lat: vals[27].as_i32(),
-            swc_long: vals[28].as_i32(),
-            name: vals[29].as_str().to_owned(),
-            normalized_power: vals[30].as_u16(),
-            left_right_balance: typedef::LeftRightBalance100(vals[31].as_u16()),
-            sub_sport: typedef::SubSport(vals[32].as_u8()),
-            total_work: vals[33].as_u32(),
-            avg_altitude: vals[34].as_u16(),
-            max_altitude: vals[35].as_u16(),
-            gps_accuracy: vals[36].as_u8(),
-            avg_grade: vals[37].as_i16(),
-            avg_pos_grade: vals[38].as_i16(),
-            avg_neg_grade: vals[39].as_i16(),
-            max_pos_grade: vals[40].as_i16(),
-            max_neg_grade: vals[41].as_i16(),
-            avg_temperature: vals[42].as_i8(),
-            max_temperature: vals[43].as_i8(),
-            total_moving_time: vals[44].as_u32(),
-            avg_pos_vertical_speed: vals[45].as_i16(),
-            avg_neg_vertical_speed: vals[46].as_i16(),
-            max_pos_vertical_speed: vals[47].as_i16(),
-            max_neg_vertical_speed: vals[48].as_i16(),
-            time_in_hr_zone: vals[49].to_vec_u32(),
-            time_in_speed_zone: vals[50].to_vec_u32(),
-            time_in_cadence_zone: vals[51].to_vec_u32(),
-            time_in_power_zone: vals[52].to_vec_u32(),
-            repetition_num: vals[53].as_u16(),
-            min_altitude: vals[54].as_u16(),
-            min_heart_rate: vals[55].as_u8(),
-            active_time: vals[56].as_u32(),
-            wkt_step_index: typedef::MessageIndex(vals[57].as_u16()),
-            sport_event: typedef::SportEvent(vals[58].as_u8()),
-            avg_left_torque_effectiveness: vals[59].as_u8(),
-            avg_right_torque_effectiveness: vals[60].as_u8(),
-            avg_left_pedal_smoothness: vals[61].as_u8(),
-            avg_right_pedal_smoothness: vals[62].as_u8(),
-            avg_combined_pedal_smoothness: vals[63].as_u8(),
-            status: typedef::SegmentLapStatus(vals[64].as_u8()),
-            uuid: vals[65].as_str().to_owned(),
-            avg_fractional_cadence: vals[66].as_u8(),
-            max_fractional_cadence: vals[67].as_u8(),
-            total_fractional_cycles: vals[68].as_u8(),
-            front_gear_shift_count: vals[69].as_u16(),
-            rear_gear_shift_count: vals[70].as_u16(),
-            time_standing: vals[71].as_u32(),
-            stand_count: vals[72].as_u16(),
-            avg_left_pco: vals[73].as_i8(),
-            avg_right_pco: vals[74].as_i8(),
-            avg_left_power_phase: vals[75].to_vec_u8(),
-            avg_left_power_phase_peak: vals[76].to_vec_u8(),
-            avg_right_power_phase: vals[77].to_vec_u8(),
-            avg_right_power_phase_peak: vals[78].to_vec_u8(),
-            avg_power_position: vals[79].to_vec_u16(),
-            max_power_position: vals[80].to_vec_u16(),
-            avg_cadence_position: vals[81].to_vec_u8(),
-            max_cadence_position: vals[82].to_vec_u8(),
-            manufacturer: typedef::Manufacturer(vals[83].as_u16()),
-            total_grit: vals[84].as_f32(),
-            total_flow: vals[85].as_f32(),
-            avg_grit: vals[86].as_f32(),
-            avg_flow: vals[87].as_f32(),
-            total_fractional_ascent: vals[89].as_u8(),
-            total_fractional_descent: vals[90].as_u8(),
-            enhanced_avg_altitude: vals[91].as_u32(),
-            enhanced_max_altitude: vals[92].as_u32(),
-            enhanced_min_altitude: vals[93].as_u32(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SegmentLap> for Message {
     fn from(m: SegmentLap) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 95];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event != typedef::Event(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
                 value: Value::Uint8(m.event.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_type != typedef::EventType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
                 value: Value::Uint8(m.event_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.start_position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.start_position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.end_position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.end_position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_elapsed_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_elapsed_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_timer_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_timer_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_cycles != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_cycles),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fat_calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_fat_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 20,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_ascent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_ascent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_descent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_descent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_group != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.event_group),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.nec_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.nec_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.nec_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 26,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.nec_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.swc_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 27,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.swc_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.swc_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 28,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.swc_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 29,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.normalized_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 30,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.normalized_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.left_right_balance != typedef::LeftRightBalance100(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 31,
                 profile_type: ProfileType::LEFT_RIGHT_BALANCE_100,
                 value: Value::Uint16(m.left_right_balance.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 32,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_work != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 33,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_work),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 34,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 35,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.gps_accuracy != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 36,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.gps_accuracy),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 37,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_pos_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 38,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_pos_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_neg_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 39,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_neg_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_pos_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 40,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_pos_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_neg_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 41,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_neg_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 42,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.avg_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 43,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.max_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_moving_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 44,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_moving_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_pos_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 45,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_pos_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_neg_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 46,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_neg_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_pos_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 47,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_pos_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_neg_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 48,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_neg_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_hr_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 49,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_hr_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_speed_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 50,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_speed_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_cadence_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 51,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_cadence_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_power_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 52,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_power_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.repetition_num != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 53,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.repetition_num),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 54,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.min_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 55,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.min_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 56,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.active_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.wkt_step_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 57,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.wkt_step_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport_event != typedef::SportEvent(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 58,
                 profile_type: ProfileType::SPORT_EVENT,
                 value: Value::Uint8(m.sport_event.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_left_torque_effectiveness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 59,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_left_torque_effectiveness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_right_torque_effectiveness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 60,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_right_torque_effectiveness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_left_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 61,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_left_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_right_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 62,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_right_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_combined_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 63,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_combined_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.status != typedef::SegmentLapStatus(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 64,
                 profile_type: ProfileType::SEGMENT_LAP_STATUS,
                 value: Value::Uint8(m.status.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.uuid.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 65,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.uuid),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_fractional_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 66,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_fractional_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_fractional_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 67,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_fractional_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fractional_cycles != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 68,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_fractional_cycles),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.front_gear_shift_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 69,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.front_gear_shift_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.rear_gear_shift_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 70,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.rear_gear_shift_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time_standing != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 71,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.time_standing),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.stand_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 72,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.stand_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_left_pco != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 73,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.avg_left_pco),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_right_pco != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 74,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.avg_right_pco),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_left_power_phase.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 75,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_left_power_phase),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_left_power_phase_peak.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 76,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_left_power_phase_peak),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_right_power_phase.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 77,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_right_power_phase),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_right_power_phase_peak.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 78,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_right_power_phase_peak),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_power_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 79,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.avg_power_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_power_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 80,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.max_power_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_cadence_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 81,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_cadence_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_cadence_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 82,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.max_cadence_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.manufacturer != typedef::Manufacturer(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 83,
                 profile_type: ProfileType::MANUFACTURER,
                 value: Value::Uint16(m.manufacturer.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_grit != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 84,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.total_grit),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_flow != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 85,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.total_flow),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_grit != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 86,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.avg_grit),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_flow != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 87,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.avg_flow),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fractional_ascent != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 89,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_fractional_ascent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fractional_descent != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 90,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_fractional_descent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_avg_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 91,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_avg_altitude),
-                is_expanded: is_expanded(&state, 91),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 91),
+            });
+        };
         if m.enhanced_max_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 92,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_max_altitude),
-                is_expanded: is_expanded(&state, 92),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 92),
+            });
+        };
         if m.enhanced_min_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 93,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_min_altitude),
-                is_expanded: is_expanded(&state, 93),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 93),
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_LAP,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
+++ b/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
@@ -83,6 +83,16 @@ impl SegmentLeaderboardEntry {
         self.segment_time = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (!self.name.is_empty()) as usize
+            + (self.r#type != typedef::SegmentLeaderboardType(u8::MAX)) as usize
+            + (self.group_primary_key != u32::MAX) as usize
+            + (self.activity_id != u32::MAX) as usize
+            + (self.segment_time != u32::MAX) as usize
+            + (!self.activity_id_string.is_empty()) as usize
+    }
 }
 
 impl Default for SegmentLeaderboardEntry {
@@ -94,122 +104,101 @@ impl Default for SegmentLeaderboardEntry {
 impl From<&Message> for SegmentLeaderboardEntry {
     /// from creates new SegmentLeaderboardEntry struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.name = field.value.as_str().to_owned(),
+                1 => v.r#type = typedef::SegmentLeaderboardType(field.value.as_u8()),
+                2 => v.group_primary_key = field.value.as_u32(),
+                3 => v.activity_id = field.value.as_u32(),
+                4 => v.segment_time = field.value.as_u32(),
+                5 => v.activity_id_string = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            name: vals[0].as_str().to_owned(),
-            r#type: typedef::SegmentLeaderboardType(vals[1].as_u8()),
-            group_primary_key: vals[2].as_u32(),
-            activity_id: vals[3].as_u32(),
-            segment_time: vals[4].as_u32(),
-            activity_id_string: vals[5].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SegmentLeaderboardEntry> for Message {
     fn from(m: SegmentLeaderboardEntry) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.r#type != typedef::SegmentLeaderboardType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SEGMENT_LEADERBOARD_TYPE,
                 value: Value::Uint8(m.r#type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.group_primary_key != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.group_primary_key),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.activity_id != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.activity_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.segment_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.segment_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.activity_id_string.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.activity_id_string),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_LEADERBOARD_ENTRY,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/segment_point.rs
+++ b/rustyfit/src/profile/mesgdef/segment_point.rs
@@ -189,6 +189,16 @@ impl SegmentPoint {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.position_lat != i32::MAX) as usize
+            + (self.position_long != i32::MAX) as usize
+            + (self.distance != u32::MAX) as usize
+            + (self.altitude != u16::MAX) as usize
+            + (!self.leader_time.is_empty()) as usize
+            + (self.enhanced_altitude != u32::MAX) as usize
+    }
 }
 
 impl Default for SegmentPoint {
@@ -200,128 +210,107 @@ impl Default for SegmentPoint {
 impl From<&Message> for SegmentPoint {
     /// from creates new SegmentPoint struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-        let mut state = [0u8; 1];
-
         const KNOWN_NUMS: [u64; 4] = [126, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                1 => v.position_lat = field.value.as_i32(),
+                2 => v.position_long = field.value.as_i32(),
+                3 => v.distance = field.value.as_u32(),
+                4 => v.altitude = field.value.as_u16(),
+                5 => v.leader_time = field.value.to_vec_u32(),
+                6 => v.enhanced_altitude = field.value.as_u32(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 7 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            position_lat: vals[1].as_i32(),
-            position_long: vals[2].as_i32(),
-            distance: vals[3].as_u32(),
-            altitude: vals[4].as_u16(),
-            leader_time: vals[5].to_vec_u32(),
-            enhanced_altitude: vals[6].as_u32(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SegmentPoint> for Message {
     fn from(m: SegmentPoint) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.leader_time.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.leader_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_altitude),
-                is_expanded: is_expanded(&state, 6),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 6),
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SEGMENT_POINT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -2471,6 +2471,167 @@ impl Session {
     pub fn is_expanded(&self, num: u8) -> bool {
         is_expanded(&self.state, num)
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.event != typedef::Event(u8::MAX)) as usize
+            + (self.event_type != typedef::EventType(u8::MAX)) as usize
+            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_position_lat != i32::MAX) as usize
+            + (self.start_position_long != i32::MAX) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.total_elapsed_time != u32::MAX) as usize
+            + (self.total_timer_time != u32::MAX) as usize
+            + (self.total_distance != u32::MAX) as usize
+            + (self.total_cycles != u32::MAX) as usize
+            + (self.total_calories != u16::MAX) as usize
+            + (self.total_fat_calories != u16::MAX) as usize
+            + (self.avg_speed != u16::MAX) as usize
+            + (self.max_speed != u16::MAX) as usize
+            + (self.avg_heart_rate != u8::MAX) as usize
+            + (self.max_heart_rate != u8::MAX) as usize
+            + (self.avg_cadence != u8::MAX) as usize
+            + (self.max_cadence != u8::MAX) as usize
+            + (self.avg_power != u16::MAX) as usize
+            + (self.max_power != u16::MAX) as usize
+            + (self.total_ascent != u16::MAX) as usize
+            + (self.total_descent != u16::MAX) as usize
+            + (self.total_training_effect != u8::MAX) as usize
+            + (self.first_lap_index != u16::MAX) as usize
+            + (self.num_laps != u16::MAX) as usize
+            + (self.event_group != u8::MAX) as usize
+            + (self.trigger != typedef::SessionTrigger(u8::MAX)) as usize
+            + (self.nec_lat != i32::MAX) as usize
+            + (self.nec_long != i32::MAX) as usize
+            + (self.swc_lat != i32::MAX) as usize
+            + (self.swc_long != i32::MAX) as usize
+            + (self.num_lengths != u16::MAX) as usize
+            + (self.normalized_power != u16::MAX) as usize
+            + (self.training_stress_score != u16::MAX) as usize
+            + (self.intensity_factor != u16::MAX) as usize
+            + (self.left_right_balance != typedef::LeftRightBalance100(u16::MAX)) as usize
+            + (self.end_position_lat != i32::MAX) as usize
+            + (self.end_position_long != i32::MAX) as usize
+            + (self.avg_stroke_count != u32::MAX) as usize
+            + (self.avg_stroke_distance != u16::MAX) as usize
+            + (self.swim_stroke != typedef::SwimStroke(u8::MAX)) as usize
+            + (self.pool_length != u16::MAX) as usize
+            + (self.threshold_power != u16::MAX) as usize
+            + (self.pool_length_unit != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.num_active_lengths != u16::MAX) as usize
+            + (self.total_work != u32::MAX) as usize
+            + (self.avg_altitude != u16::MAX) as usize
+            + (self.max_altitude != u16::MAX) as usize
+            + (self.gps_accuracy != u8::MAX) as usize
+            + (self.avg_grade != i16::MAX) as usize
+            + (self.avg_pos_grade != i16::MAX) as usize
+            + (self.avg_neg_grade != i16::MAX) as usize
+            + (self.max_pos_grade != i16::MAX) as usize
+            + (self.max_neg_grade != i16::MAX) as usize
+            + (self.avg_temperature != i8::MAX) as usize
+            + (self.max_temperature != i8::MAX) as usize
+            + (self.total_moving_time != u32::MAX) as usize
+            + (self.avg_pos_vertical_speed != i16::MAX) as usize
+            + (self.avg_neg_vertical_speed != i16::MAX) as usize
+            + (self.max_pos_vertical_speed != i16::MAX) as usize
+            + (self.max_neg_vertical_speed != i16::MAX) as usize
+            + (self.min_heart_rate != u8::MAX) as usize
+            + (!self.time_in_hr_zone.is_empty()) as usize
+            + (!self.time_in_speed_zone.is_empty()) as usize
+            + (!self.time_in_cadence_zone.is_empty()) as usize
+            + (!self.time_in_power_zone.is_empty()) as usize
+            + (self.avg_lap_time != u32::MAX) as usize
+            + (self.best_lap_index != u16::MAX) as usize
+            + (self.min_altitude != u16::MAX) as usize
+            + (self.active_time != u32::MAX) as usize
+            + (self.player_score != u16::MAX) as usize
+            + (self.opponent_score != u16::MAX) as usize
+            + (!self.opponent_name.is_empty()) as usize
+            + (!self.stroke_count.is_empty()) as usize
+            + (!self.zone_count.is_empty()) as usize
+            + (self.max_ball_speed != u16::MAX) as usize
+            + (self.avg_ball_speed != u16::MAX) as usize
+            + (self.avg_vertical_oscillation != u16::MAX) as usize
+            + (self.avg_stance_time_percent != u16::MAX) as usize
+            + (self.avg_stance_time != u16::MAX) as usize
+            + (self.avg_fractional_cadence != u8::MAX) as usize
+            + (self.max_fractional_cadence != u8::MAX) as usize
+            + (self.total_fractional_cycles != u8::MAX) as usize
+            + (!self.avg_total_hemoglobin_conc.is_empty()) as usize
+            + (!self.min_total_hemoglobin_conc.is_empty()) as usize
+            + (!self.max_total_hemoglobin_conc.is_empty()) as usize
+            + (!self.avg_saturated_hemoglobin_percent.is_empty()) as usize
+            + (!self.min_saturated_hemoglobin_percent.is_empty()) as usize
+            + (!self.max_saturated_hemoglobin_percent.is_empty()) as usize
+            + (self.avg_left_torque_effectiveness != u8::MAX) as usize
+            + (self.avg_right_torque_effectiveness != u8::MAX) as usize
+            + (self.avg_left_pedal_smoothness != u8::MAX) as usize
+            + (self.avg_right_pedal_smoothness != u8::MAX) as usize
+            + (self.avg_combined_pedal_smoothness != u8::MAX) as usize
+            + (!self.sport_profile_name.is_empty()) as usize
+            + (self.sport_index != u8::MAX) as usize
+            + (self.time_standing != u32::MAX) as usize
+            + (self.stand_count != u16::MAX) as usize
+            + (self.avg_left_pco != i8::MAX) as usize
+            + (self.avg_right_pco != i8::MAX) as usize
+            + (!self.avg_left_power_phase.is_empty()) as usize
+            + (!self.avg_left_power_phase_peak.is_empty()) as usize
+            + (!self.avg_right_power_phase.is_empty()) as usize
+            + (!self.avg_right_power_phase_peak.is_empty()) as usize
+            + (!self.avg_power_position.is_empty()) as usize
+            + (!self.max_power_position.is_empty()) as usize
+            + (!self.avg_cadence_position.is_empty()) as usize
+            + (!self.max_cadence_position.is_empty()) as usize
+            + (self.enhanced_avg_speed != u32::MAX) as usize
+            + (self.enhanced_max_speed != u32::MAX) as usize
+            + (self.enhanced_avg_altitude != u32::MAX) as usize
+            + (self.enhanced_min_altitude != u32::MAX) as usize
+            + (self.enhanced_max_altitude != u32::MAX) as usize
+            + (self.avg_lev_motor_power != u16::MAX) as usize
+            + (self.max_lev_motor_power != u16::MAX) as usize
+            + (self.lev_battery_consumption != u8::MAX) as usize
+            + (self.avg_vertical_ratio != u16::MAX) as usize
+            + (self.avg_stance_time_balance != u16::MAX) as usize
+            + (self.avg_step_length != u16::MAX) as usize
+            + (self.total_anaerobic_training_effect != u8::MAX) as usize
+            + (self.avg_vam != u16::MAX) as usize
+            + (self.avg_depth != u32::MAX) as usize
+            + (self.max_depth != u32::MAX) as usize
+            + (self.surface_interval != u32::MAX) as usize
+            + (self.start_cns != u8::MAX) as usize
+            + (self.end_cns != u8::MAX) as usize
+            + (self.start_n2 != u16::MAX) as usize
+            + (self.end_n2 != u16::MAX) as usize
+            + (self.avg_respiration_rate != u8::MAX) as usize
+            + (self.max_respiration_rate != u8::MAX) as usize
+            + (self.min_respiration_rate != u8::MAX) as usize
+            + (self.min_temperature != i8::MAX) as usize
+            + (self.o2_toxicity != u16::MAX) as usize
+            + (self.dive_number != u32::MAX) as usize
+            + (self.training_load_peak != i32::MAX) as usize
+            + (self.enhanced_avg_respiration_rate != u16::MAX) as usize
+            + (self.enhanced_max_respiration_rate != u16::MAX) as usize
+            + (self.enhanced_min_respiration_rate != u16::MAX) as usize
+            + (self.total_grit != f32::MAX) as usize
+            + (self.total_flow != f32::MAX) as usize
+            + (self.jump_count != u16::MAX) as usize
+            + (self.avg_grit != f32::MAX) as usize
+            + (self.avg_flow != f32::MAX) as usize
+            + (self.workout_feel != u8::MAX) as usize
+            + (self.workout_rpe != u8::MAX) as usize
+            + (self.avg_spo2 != u8::MAX) as usize
+            + (self.avg_stress != u8::MAX) as usize
+            + (self.metabolic_calories != u16::MAX) as usize
+            + (self.sdrr_hrv != u8::MAX) as usize
+            + (self.rmssd_hrv != u8::MAX) as usize
+            + (self.total_fractional_ascent != u8::MAX) as usize
+            + (self.total_fractional_descent != u8::MAX) as usize
+            + (self.avg_core_temperature != u16::MAX) as usize
+            + (self.min_core_temperature != u16::MAX) as usize
+            + (self.max_core_temperature != u16::MAX) as usize
+    }
 }
 
 impl Default for Session {
@@ -2482,9 +2643,6 @@ impl Default for Session {
 impl From<&Message> for Session {
     /// from creates new Session struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-        let mut state = [0u8; 23];
-
         const KNOWN_NUMS: [u64; 4] = [
             18446742974197919743,
             18446678103011639551,
@@ -2495,1630 +2653,1461 @@ impl From<&Message> for Session {
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.event = typedef::Event(field.value.as_u8()),
+                1 => v.event_type = typedef::EventType(field.value.as_u8()),
+                2 => v.start_time = typedef::DateTime(field.value.as_u32()),
+                3 => v.start_position_lat = field.value.as_i32(),
+                4 => v.start_position_long = field.value.as_i32(),
+                5 => v.sport = typedef::Sport(field.value.as_u8()),
+                6 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                7 => v.total_elapsed_time = field.value.as_u32(),
+                8 => v.total_timer_time = field.value.as_u32(),
+                9 => v.total_distance = field.value.as_u32(),
+                10 => v.total_cycles = field.value.as_u32(),
+                11 => v.total_calories = field.value.as_u16(),
+                13 => v.total_fat_calories = field.value.as_u16(),
+                14 => v.avg_speed = field.value.as_u16(),
+                15 => v.max_speed = field.value.as_u16(),
+                16 => v.avg_heart_rate = field.value.as_u8(),
+                17 => v.max_heart_rate = field.value.as_u8(),
+                18 => v.avg_cadence = field.value.as_u8(),
+                19 => v.max_cadence = field.value.as_u8(),
+                20 => v.avg_power = field.value.as_u16(),
+                21 => v.max_power = field.value.as_u16(),
+                22 => v.total_ascent = field.value.as_u16(),
+                23 => v.total_descent = field.value.as_u16(),
+                24 => v.total_training_effect = field.value.as_u8(),
+                25 => v.first_lap_index = field.value.as_u16(),
+                26 => v.num_laps = field.value.as_u16(),
+                27 => v.event_group = field.value.as_u8(),
+                28 => v.trigger = typedef::SessionTrigger(field.value.as_u8()),
+                29 => v.nec_lat = field.value.as_i32(),
+                30 => v.nec_long = field.value.as_i32(),
+                31 => v.swc_lat = field.value.as_i32(),
+                32 => v.swc_long = field.value.as_i32(),
+                33 => v.num_lengths = field.value.as_u16(),
+                34 => v.normalized_power = field.value.as_u16(),
+                35 => v.training_stress_score = field.value.as_u16(),
+                36 => v.intensity_factor = field.value.as_u16(),
+                37 => v.left_right_balance = typedef::LeftRightBalance100(field.value.as_u16()),
+                38 => v.end_position_lat = field.value.as_i32(),
+                39 => v.end_position_long = field.value.as_i32(),
+                41 => v.avg_stroke_count = field.value.as_u32(),
+                42 => v.avg_stroke_distance = field.value.as_u16(),
+                43 => v.swim_stroke = typedef::SwimStroke(field.value.as_u8()),
+                44 => v.pool_length = field.value.as_u16(),
+                45 => v.threshold_power = field.value.as_u16(),
+                46 => v.pool_length_unit = typedef::DisplayMeasure(field.value.as_u8()),
+                47 => v.num_active_lengths = field.value.as_u16(),
+                48 => v.total_work = field.value.as_u32(),
+                49 => v.avg_altitude = field.value.as_u16(),
+                50 => v.max_altitude = field.value.as_u16(),
+                51 => v.gps_accuracy = field.value.as_u8(),
+                52 => v.avg_grade = field.value.as_i16(),
+                53 => v.avg_pos_grade = field.value.as_i16(),
+                54 => v.avg_neg_grade = field.value.as_i16(),
+                55 => v.max_pos_grade = field.value.as_i16(),
+                56 => v.max_neg_grade = field.value.as_i16(),
+                57 => v.avg_temperature = field.value.as_i8(),
+                58 => v.max_temperature = field.value.as_i8(),
+                59 => v.total_moving_time = field.value.as_u32(),
+                60 => v.avg_pos_vertical_speed = field.value.as_i16(),
+                61 => v.avg_neg_vertical_speed = field.value.as_i16(),
+                62 => v.max_pos_vertical_speed = field.value.as_i16(),
+                63 => v.max_neg_vertical_speed = field.value.as_i16(),
+                64 => v.min_heart_rate = field.value.as_u8(),
+                65 => v.time_in_hr_zone = field.value.to_vec_u32(),
+                66 => v.time_in_speed_zone = field.value.to_vec_u32(),
+                67 => v.time_in_cadence_zone = field.value.to_vec_u32(),
+                68 => v.time_in_power_zone = field.value.to_vec_u32(),
+                69 => v.avg_lap_time = field.value.as_u32(),
+                70 => v.best_lap_index = field.value.as_u16(),
+                71 => v.min_altitude = field.value.as_u16(),
+                78 => v.active_time = field.value.as_u32(),
+                82 => v.player_score = field.value.as_u16(),
+                83 => v.opponent_score = field.value.as_u16(),
+                84 => v.opponent_name = field.value.as_str().to_owned(),
+                85 => v.stroke_count = field.value.to_vec_u16(),
+                86 => v.zone_count = field.value.to_vec_u16(),
+                87 => v.max_ball_speed = field.value.as_u16(),
+                88 => v.avg_ball_speed = field.value.as_u16(),
+                89 => v.avg_vertical_oscillation = field.value.as_u16(),
+                90 => v.avg_stance_time_percent = field.value.as_u16(),
+                91 => v.avg_stance_time = field.value.as_u16(),
+                92 => v.avg_fractional_cadence = field.value.as_u8(),
+                93 => v.max_fractional_cadence = field.value.as_u8(),
+                94 => v.total_fractional_cycles = field.value.as_u8(),
+                95 => v.avg_total_hemoglobin_conc = field.value.to_vec_u16(),
+                96 => v.min_total_hemoglobin_conc = field.value.to_vec_u16(),
+                97 => v.max_total_hemoglobin_conc = field.value.to_vec_u16(),
+                98 => v.avg_saturated_hemoglobin_percent = field.value.to_vec_u16(),
+                99 => v.min_saturated_hemoglobin_percent = field.value.to_vec_u16(),
+                100 => v.max_saturated_hemoglobin_percent = field.value.to_vec_u16(),
+                101 => v.avg_left_torque_effectiveness = field.value.as_u8(),
+                102 => v.avg_right_torque_effectiveness = field.value.as_u8(),
+                103 => v.avg_left_pedal_smoothness = field.value.as_u8(),
+                104 => v.avg_right_pedal_smoothness = field.value.as_u8(),
+                105 => v.avg_combined_pedal_smoothness = field.value.as_u8(),
+                110 => v.sport_profile_name = field.value.as_str().to_owned(),
+                111 => v.sport_index = field.value.as_u8(),
+                112 => v.time_standing = field.value.as_u32(),
+                113 => v.stand_count = field.value.as_u16(),
+                114 => v.avg_left_pco = field.value.as_i8(),
+                115 => v.avg_right_pco = field.value.as_i8(),
+                116 => v.avg_left_power_phase = field.value.to_vec_u8(),
+                117 => v.avg_left_power_phase_peak = field.value.to_vec_u8(),
+                118 => v.avg_right_power_phase = field.value.to_vec_u8(),
+                119 => v.avg_right_power_phase_peak = field.value.to_vec_u8(),
+                120 => v.avg_power_position = field.value.to_vec_u16(),
+                121 => v.max_power_position = field.value.to_vec_u16(),
+                122 => v.avg_cadence_position = field.value.to_vec_u8(),
+                123 => v.max_cadence_position = field.value.to_vec_u8(),
+                124 => v.enhanced_avg_speed = field.value.as_u32(),
+                125 => v.enhanced_max_speed = field.value.as_u32(),
+                126 => v.enhanced_avg_altitude = field.value.as_u32(),
+                127 => v.enhanced_min_altitude = field.value.as_u32(),
+                128 => v.enhanced_max_altitude = field.value.as_u32(),
+                129 => v.avg_lev_motor_power = field.value.as_u16(),
+                130 => v.max_lev_motor_power = field.value.as_u16(),
+                131 => v.lev_battery_consumption = field.value.as_u8(),
+                132 => v.avg_vertical_ratio = field.value.as_u16(),
+                133 => v.avg_stance_time_balance = field.value.as_u16(),
+                134 => v.avg_step_length = field.value.as_u16(),
+                137 => v.total_anaerobic_training_effect = field.value.as_u8(),
+                139 => v.avg_vam = field.value.as_u16(),
+                140 => v.avg_depth = field.value.as_u32(),
+                141 => v.max_depth = field.value.as_u32(),
+                142 => v.surface_interval = field.value.as_u32(),
+                143 => v.start_cns = field.value.as_u8(),
+                144 => v.end_cns = field.value.as_u8(),
+                145 => v.start_n2 = field.value.as_u16(),
+                146 => v.end_n2 = field.value.as_u16(),
+                147 => v.avg_respiration_rate = field.value.as_u8(),
+                148 => v.max_respiration_rate = field.value.as_u8(),
+                149 => v.min_respiration_rate = field.value.as_u8(),
+                150 => v.min_temperature = field.value.as_i8(),
+                155 => v.o2_toxicity = field.value.as_u16(),
+                156 => v.dive_number = field.value.as_u32(),
+                168 => v.training_load_peak = field.value.as_i32(),
+                169 => v.enhanced_avg_respiration_rate = field.value.as_u16(),
+                170 => v.enhanced_max_respiration_rate = field.value.as_u16(),
+                180 => v.enhanced_min_respiration_rate = field.value.as_u16(),
+                181 => v.total_grit = field.value.as_f32(),
+                182 => v.total_flow = field.value.as_f32(),
+                183 => v.jump_count = field.value.as_u16(),
+                186 => v.avg_grit = field.value.as_f32(),
+                187 => v.avg_flow = field.value.as_f32(),
+                192 => v.workout_feel = field.value.as_u8(),
+                193 => v.workout_rpe = field.value.as_u8(),
+                194 => v.avg_spo2 = field.value.as_u8(),
+                195 => v.avg_stress = field.value.as_u8(),
+                196 => v.metabolic_calories = field.value.as_u16(),
+                197 => v.sdrr_hrv = field.value.as_u8(),
+                198 => v.rmssd_hrv = field.value.as_u8(),
+                199 => v.total_fractional_ascent = field.value.as_u8(),
+                200 => v.total_fractional_descent = field.value.as_u8(),
+                208 => v.avg_core_temperature = field.value.as_u16(),
+                209 => v.min_core_temperature = field.value.as_u16(),
+                210 => v.max_core_temperature = field.value.as_u16(),
+                _ => {
+                    v.unknown_fields.push(field.clone());
+                    continue;
+                }
+            };
             if field.is_expanded && field.num < 181 {
-                state[field.num as usize >> 3] |= 1 << (field.num & 7)
+                v.state[field.num as usize >> 3] |= 1 << (field.num & 7)
             }
-            vals[field.num as usize] = &field.value;
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            event: typedef::Event(vals[0].as_u8()),
-            event_type: typedef::EventType(vals[1].as_u8()),
-            start_time: typedef::DateTime(vals[2].as_u32()),
-            start_position_lat: vals[3].as_i32(),
-            start_position_long: vals[4].as_i32(),
-            sport: typedef::Sport(vals[5].as_u8()),
-            sub_sport: typedef::SubSport(vals[6].as_u8()),
-            total_elapsed_time: vals[7].as_u32(),
-            total_timer_time: vals[8].as_u32(),
-            total_distance: vals[9].as_u32(),
-            total_cycles: vals[10].as_u32(),
-            total_calories: vals[11].as_u16(),
-            total_fat_calories: vals[13].as_u16(),
-            avg_speed: vals[14].as_u16(),
-            max_speed: vals[15].as_u16(),
-            avg_heart_rate: vals[16].as_u8(),
-            max_heart_rate: vals[17].as_u8(),
-            avg_cadence: vals[18].as_u8(),
-            max_cadence: vals[19].as_u8(),
-            avg_power: vals[20].as_u16(),
-            max_power: vals[21].as_u16(),
-            total_ascent: vals[22].as_u16(),
-            total_descent: vals[23].as_u16(),
-            total_training_effect: vals[24].as_u8(),
-            first_lap_index: vals[25].as_u16(),
-            num_laps: vals[26].as_u16(),
-            event_group: vals[27].as_u8(),
-            trigger: typedef::SessionTrigger(vals[28].as_u8()),
-            nec_lat: vals[29].as_i32(),
-            nec_long: vals[30].as_i32(),
-            swc_lat: vals[31].as_i32(),
-            swc_long: vals[32].as_i32(),
-            num_lengths: vals[33].as_u16(),
-            normalized_power: vals[34].as_u16(),
-            training_stress_score: vals[35].as_u16(),
-            intensity_factor: vals[36].as_u16(),
-            left_right_balance: typedef::LeftRightBalance100(vals[37].as_u16()),
-            end_position_lat: vals[38].as_i32(),
-            end_position_long: vals[39].as_i32(),
-            avg_stroke_count: vals[41].as_u32(),
-            avg_stroke_distance: vals[42].as_u16(),
-            swim_stroke: typedef::SwimStroke(vals[43].as_u8()),
-            pool_length: vals[44].as_u16(),
-            threshold_power: vals[45].as_u16(),
-            pool_length_unit: typedef::DisplayMeasure(vals[46].as_u8()),
-            num_active_lengths: vals[47].as_u16(),
-            total_work: vals[48].as_u32(),
-            avg_altitude: vals[49].as_u16(),
-            max_altitude: vals[50].as_u16(),
-            gps_accuracy: vals[51].as_u8(),
-            avg_grade: vals[52].as_i16(),
-            avg_pos_grade: vals[53].as_i16(),
-            avg_neg_grade: vals[54].as_i16(),
-            max_pos_grade: vals[55].as_i16(),
-            max_neg_grade: vals[56].as_i16(),
-            avg_temperature: vals[57].as_i8(),
-            max_temperature: vals[58].as_i8(),
-            total_moving_time: vals[59].as_u32(),
-            avg_pos_vertical_speed: vals[60].as_i16(),
-            avg_neg_vertical_speed: vals[61].as_i16(),
-            max_pos_vertical_speed: vals[62].as_i16(),
-            max_neg_vertical_speed: vals[63].as_i16(),
-            min_heart_rate: vals[64].as_u8(),
-            time_in_hr_zone: vals[65].to_vec_u32(),
-            time_in_speed_zone: vals[66].to_vec_u32(),
-            time_in_cadence_zone: vals[67].to_vec_u32(),
-            time_in_power_zone: vals[68].to_vec_u32(),
-            avg_lap_time: vals[69].as_u32(),
-            best_lap_index: vals[70].as_u16(),
-            min_altitude: vals[71].as_u16(),
-            active_time: vals[78].as_u32(),
-            player_score: vals[82].as_u16(),
-            opponent_score: vals[83].as_u16(),
-            opponent_name: vals[84].as_str().to_owned(),
-            stroke_count: vals[85].to_vec_u16(),
-            zone_count: vals[86].to_vec_u16(),
-            max_ball_speed: vals[87].as_u16(),
-            avg_ball_speed: vals[88].as_u16(),
-            avg_vertical_oscillation: vals[89].as_u16(),
-            avg_stance_time_percent: vals[90].as_u16(),
-            avg_stance_time: vals[91].as_u16(),
-            avg_fractional_cadence: vals[92].as_u8(),
-            max_fractional_cadence: vals[93].as_u8(),
-            total_fractional_cycles: vals[94].as_u8(),
-            avg_total_hemoglobin_conc: vals[95].to_vec_u16(),
-            min_total_hemoglobin_conc: vals[96].to_vec_u16(),
-            max_total_hemoglobin_conc: vals[97].to_vec_u16(),
-            avg_saturated_hemoglobin_percent: vals[98].to_vec_u16(),
-            min_saturated_hemoglobin_percent: vals[99].to_vec_u16(),
-            max_saturated_hemoglobin_percent: vals[100].to_vec_u16(),
-            avg_left_torque_effectiveness: vals[101].as_u8(),
-            avg_right_torque_effectiveness: vals[102].as_u8(),
-            avg_left_pedal_smoothness: vals[103].as_u8(),
-            avg_right_pedal_smoothness: vals[104].as_u8(),
-            avg_combined_pedal_smoothness: vals[105].as_u8(),
-            sport_profile_name: vals[110].as_str().to_owned(),
-            sport_index: vals[111].as_u8(),
-            time_standing: vals[112].as_u32(),
-            stand_count: vals[113].as_u16(),
-            avg_left_pco: vals[114].as_i8(),
-            avg_right_pco: vals[115].as_i8(),
-            avg_left_power_phase: vals[116].to_vec_u8(),
-            avg_left_power_phase_peak: vals[117].to_vec_u8(),
-            avg_right_power_phase: vals[118].to_vec_u8(),
-            avg_right_power_phase_peak: vals[119].to_vec_u8(),
-            avg_power_position: vals[120].to_vec_u16(),
-            max_power_position: vals[121].to_vec_u16(),
-            avg_cadence_position: vals[122].to_vec_u8(),
-            max_cadence_position: vals[123].to_vec_u8(),
-            enhanced_avg_speed: vals[124].as_u32(),
-            enhanced_max_speed: vals[125].as_u32(),
-            enhanced_avg_altitude: vals[126].as_u32(),
-            enhanced_min_altitude: vals[127].as_u32(),
-            enhanced_max_altitude: vals[128].as_u32(),
-            avg_lev_motor_power: vals[129].as_u16(),
-            max_lev_motor_power: vals[130].as_u16(),
-            lev_battery_consumption: vals[131].as_u8(),
-            avg_vertical_ratio: vals[132].as_u16(),
-            avg_stance_time_balance: vals[133].as_u16(),
-            avg_step_length: vals[134].as_u16(),
-            total_anaerobic_training_effect: vals[137].as_u8(),
-            avg_vam: vals[139].as_u16(),
-            avg_depth: vals[140].as_u32(),
-            max_depth: vals[141].as_u32(),
-            surface_interval: vals[142].as_u32(),
-            start_cns: vals[143].as_u8(),
-            end_cns: vals[144].as_u8(),
-            start_n2: vals[145].as_u16(),
-            end_n2: vals[146].as_u16(),
-            avg_respiration_rate: vals[147].as_u8(),
-            max_respiration_rate: vals[148].as_u8(),
-            min_respiration_rate: vals[149].as_u8(),
-            min_temperature: vals[150].as_i8(),
-            o2_toxicity: vals[155].as_u16(),
-            dive_number: vals[156].as_u32(),
-            training_load_peak: vals[168].as_i32(),
-            enhanced_avg_respiration_rate: vals[169].as_u16(),
-            enhanced_max_respiration_rate: vals[170].as_u16(),
-            enhanced_min_respiration_rate: vals[180].as_u16(),
-            total_grit: vals[181].as_f32(),
-            total_flow: vals[182].as_f32(),
-            jump_count: vals[183].as_u16(),
-            avg_grit: vals[186].as_f32(),
-            avg_flow: vals[187].as_f32(),
-            workout_feel: vals[192].as_u8(),
-            workout_rpe: vals[193].as_u8(),
-            avg_spo2: vals[194].as_u8(),
-            avg_stress: vals[195].as_u8(),
-            metabolic_calories: vals[196].as_u16(),
-            sdrr_hrv: vals[197].as_u8(),
-            rmssd_hrv: vals[198].as_u8(),
-            total_fractional_ascent: vals[199].as_u8(),
-            total_fractional_descent: vals[200].as_u8(),
-            avg_core_temperature: vals[208].as_u16(),
-            min_core_temperature: vals[209].as_u16(),
-            max_core_temperature: vals[210].as_u16(),
-            state,
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Session> for Message {
     fn from(m: Session) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 158];
-        let mut len = 0usize;
-        let state = m.state;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event != typedef::Event(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
                 value: Value::Uint8(m.event.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_type != typedef::EventType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
                 value: Value::Uint8(m.event_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.start_position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.start_position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_elapsed_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_elapsed_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_timer_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_timer_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_cycles != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_cycles),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fat_calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_fat_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 20,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_ascent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_ascent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_descent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_descent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_training_effect != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_training_effect),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.first_lap_index != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.first_lap_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.num_laps != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 26,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.num_laps),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.event_group != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 27,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.event_group),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.trigger != typedef::SessionTrigger(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 28,
                 profile_type: ProfileType::SESSION_TRIGGER,
                 value: Value::Uint8(m.trigger.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.nec_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 29,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.nec_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.nec_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 30,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.nec_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.swc_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 31,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.swc_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.swc_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 32,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.swc_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.num_lengths != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 33,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.num_lengths),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.normalized_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 34,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.normalized_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.training_stress_score != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 35,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.training_stress_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.intensity_factor != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 36,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.intensity_factor),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.left_right_balance != typedef::LeftRightBalance100(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 37,
                 profile_type: ProfileType::LEFT_RIGHT_BALANCE_100,
                 value: Value::Uint16(m.left_right_balance.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 38,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.end_position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 39,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.end_position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stroke_count != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 41,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.avg_stroke_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stroke_distance != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 42,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_stroke_distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.swim_stroke != typedef::SwimStroke(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 43,
                 profile_type: ProfileType::SWIM_STROKE,
                 value: Value::Uint8(m.swim_stroke.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pool_length != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 44,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.pool_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.threshold_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 45,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.threshold_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pool_length_unit != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 46,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.pool_length_unit.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.num_active_lengths != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 47,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.num_active_lengths),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_work != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 48,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_work),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 49,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 50,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.gps_accuracy != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 51,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.gps_accuracy),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 52,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_pos_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 53,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_pos_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_neg_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 54,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_neg_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_pos_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 55,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_pos_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_neg_grade != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 56,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_neg_grade),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 57,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.avg_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 58,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.max_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_moving_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 59,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_moving_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_pos_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 60,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_pos_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_neg_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 61,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.avg_neg_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_pos_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 62,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_pos_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_neg_vertical_speed != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 63,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.max_neg_vertical_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 64,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.min_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_hr_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 65,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_hr_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_speed_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 66,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_speed_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_cadence_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 67,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_cadence_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_power_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 68,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_power_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_lap_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 69,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.avg_lap_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.best_lap_index != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 70,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.best_lap_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_altitude != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 71,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.min_altitude),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 78,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.active_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.player_score != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 82,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.player_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.opponent_score != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 83,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.opponent_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.opponent_name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 84,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.opponent_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.stroke_count.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 85,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.stroke_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.zone_count.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 86,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.zone_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_ball_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 87,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_ball_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_ball_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 88,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_ball_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_vertical_oscillation != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 89,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_vertical_oscillation),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stance_time_percent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 90,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_stance_time_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stance_time != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 91,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_stance_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_fractional_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 92,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_fractional_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_fractional_cadence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 93,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_fractional_cadence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fractional_cycles != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 94,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_fractional_cycles),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_total_hemoglobin_conc.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 95,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.avg_total_hemoglobin_conc),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.min_total_hemoglobin_conc.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 96,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.min_total_hemoglobin_conc),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_total_hemoglobin_conc.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 97,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.max_total_hemoglobin_conc),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_saturated_hemoglobin_percent.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 98,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.avg_saturated_hemoglobin_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.min_saturated_hemoglobin_percent.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 99,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.min_saturated_hemoglobin_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_saturated_hemoglobin_percent.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 100,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.max_saturated_hemoglobin_percent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_left_torque_effectiveness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 101,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_left_torque_effectiveness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_right_torque_effectiveness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 102,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_right_torque_effectiveness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_left_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 103,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_left_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_right_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 104,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_right_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_combined_pedal_smoothness != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 105,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_combined_pedal_smoothness),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.sport_profile_name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 110,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.sport_profile_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport_index != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 111,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.sport_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time_standing != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 112,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.time_standing),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.stand_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 113,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.stand_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_left_pco != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 114,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.avg_left_pco),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_right_pco != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 115,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.avg_right_pco),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_left_power_phase.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 116,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_left_power_phase),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_left_power_phase_peak.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 117,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_left_power_phase_peak),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_right_power_phase.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 118,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_right_power_phase),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_right_power_phase_peak.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 119,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_right_power_phase_peak),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_power_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 120,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.avg_power_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_power_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 121,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.max_power_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.avg_cadence_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 122,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.avg_cadence_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.max_cadence_position.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 123,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.max_cadence_position),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_avg_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 124,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_avg_speed),
-                is_expanded: is_expanded(&state, 124),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 124),
+            });
+        };
         if m.enhanced_max_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 125,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_max_speed),
-                is_expanded: is_expanded(&state, 125),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 125),
+            });
+        };
         if m.enhanced_avg_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 126,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_avg_altitude),
-                is_expanded: is_expanded(&state, 126),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 126),
+            });
+        };
         if m.enhanced_min_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 127,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_min_altitude),
-                is_expanded: is_expanded(&state, 127),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 127),
+            });
+        };
         if m.enhanced_max_altitude != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 128,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.enhanced_max_altitude),
-                is_expanded: is_expanded(&state, 128),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 128),
+            });
+        };
         if m.avg_lev_motor_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 129,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_lev_motor_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_lev_motor_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 130,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_lev_motor_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.lev_battery_consumption != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 131,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.lev_battery_consumption),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_vertical_ratio != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 132,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_vertical_ratio),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stance_time_balance != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 133,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_stance_time_balance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_step_length != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 134,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_step_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_anaerobic_training_effect != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 137,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_anaerobic_training_effect),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_vam != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 139,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_vam),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 140,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.avg_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_depth != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 141,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.max_depth),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.surface_interval != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 142,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.surface_interval),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_cns != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 143,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.start_cns),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_cns != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 144,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.end_cns),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_n2 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 145,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.start_n2),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_n2 != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 146,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.end_n2),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_respiration_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 147,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_respiration_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 148,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_respiration_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 149,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.min_respiration_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 150,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.min_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.o2_toxicity != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 155,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.o2_toxicity),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.dive_number != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 156,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.dive_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.training_load_peak != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 168,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.training_load_peak),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.enhanced_avg_respiration_rate != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 169,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.enhanced_avg_respiration_rate),
-                is_expanded: is_expanded(&state, 169),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 169),
+            });
+        };
         if m.enhanced_max_respiration_rate != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 170,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.enhanced_max_respiration_rate),
-                is_expanded: is_expanded(&state, 170),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 170),
+            });
+        };
         if m.enhanced_min_respiration_rate != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 180,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.enhanced_min_respiration_rate),
-                is_expanded: is_expanded(&state, 180),
-            };
-            len += 1;
-        }
+                is_expanded: is_expanded(&m.state, 180),
+            });
+        };
         if m.total_grit != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 181,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.total_grit),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_flow != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 182,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.total_flow),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.jump_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 183,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.jump_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_grit != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 186,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.avg_grit),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_flow != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 187,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.avg_flow),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.workout_feel != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 192,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.workout_feel),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.workout_rpe != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 193,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.workout_rpe),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_spo2 != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 194,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_spo2),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_stress != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 195,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_stress),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.metabolic_calories != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 196,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.metabolic_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sdrr_hrv != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 197,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.sdrr_hrv),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.rmssd_hrv != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 198,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.rmssd_hrv),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fractional_ascent != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 199,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_fractional_ascent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_fractional_descent != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 200,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.total_fractional_descent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_core_temperature != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 208,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.avg_core_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.min_core_temperature != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 209,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.min_core_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_core_temperature != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 210,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.max_core_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SESSION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/set.rs
+++ b/rustyfit/src/profile/mesgdef/set.rs
@@ -116,6 +116,20 @@ impl Set {
         self.weight = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.duration != u32::MAX) as usize
+            + (self.repetitions != u16::MAX) as usize
+            + (self.weight != u16::MAX) as usize
+            + (self.set_type != typedef::SetType(u8::MAX)) as usize
+            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+            + (!self.category.is_empty()) as usize
+            + (!self.category_subtype.is_empty()) as usize
+            + (self.weight_display_unit != typedef::FitBaseUnit(u16::MAX)) as usize
+            + (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.wkt_step_index != typedef::MessageIndex(u16::MAX)) as usize
+    }
 }
 
 impl Default for Set {
@@ -127,116 +141,101 @@ impl Default for Set {
 impl From<&Message> for Set {
     /// from creates new Set struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [4089, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.duration = field.value.as_u32(),
+                3 => v.repetitions = field.value.as_u16(),
+                4 => v.weight = field.value.as_u16(),
+                5 => v.set_type = typedef::SetType(field.value.as_u8()),
+                6 => v.start_time = typedef::DateTime(field.value.as_u32()),
+                7 => {
+                    v.category = match &field.value {
+                        Value::VecUint16(v) => {
+                            let mut vs = Vec::with_capacity(v.len());
+                            vs.extend(v.iter().map(|&x| typedef::ExerciseCategory(x)));
+                            vs
+                        }
+                        _ => Vec::new(),
+                    }
+                }
+                8 => v.category_subtype = field.value.to_vec_u16(),
+                9 => v.weight_display_unit = typedef::FitBaseUnit(field.value.as_u16()),
+                10 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                11 => v.wkt_step_index = typedef::MessageIndex(field.value.as_u16()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[254].as_u32()),
-            duration: vals[0].as_u32(),
-            repetitions: vals[3].as_u16(),
-            weight: vals[4].as_u16(),
-            set_type: typedef::SetType(vals[5].as_u8()),
-            start_time: typedef::DateTime(vals[6].as_u32()),
-            category: match &vals[7] {
-                Value::VecUint16(v) => {
-                    let mut vs = Vec::with_capacity(v.len());
-                    vs.extend(v.iter().map(|&x| typedef::ExerciseCategory(x)));
-                    vs
-                }
-                _ => Vec::new(),
-            },
-            category_subtype: vals[8].to_vec_u16(),
-            weight_display_unit: typedef::FitBaseUnit(vals[9].as_u16()),
-            message_index: typedef::MessageIndex(vals[10].as_u16()),
-            wkt_step_index: typedef::MessageIndex(vals[11].as_u16()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Set> for Message {
     fn from(m: Set) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 11];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.duration != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.duration),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.repetitions != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.repetitions),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weight != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.weight),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.set_type != typedef::SetType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SET_TYPE,
                 value: Value::Uint8(m.set_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.category.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::EXERCISE_CATEGORY,
                 value: Value::VecUint16({
@@ -244,55 +243,47 @@ impl From<Set> for Message {
                     unsafe { Vec::from_raw_parts(ptr.cast::<u16>(), len, capacity) }
                 }),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.category_subtype.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.category_subtype),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weight_display_unit != typedef::FitBaseUnit(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::FIT_BASE_UNIT,
                 value: Value::Uint16(m.weight_display_unit.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.wkt_step_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.wkt_step_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SET,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
+++ b/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
@@ -51,6 +51,14 @@ impl SkinTempOvernight {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+            + (self.average_deviation != f32::MAX) as usize
+            + (self.average_7_day_deviation != f32::MAX) as usize
+            + (self.nightly_value != f32::MAX) as usize
+    }
 }
 
 impl Default for SkinTempOvernight {
@@ -62,102 +70,83 @@ impl Default for SkinTempOvernight {
 impl From<&Message> for SkinTempOvernight {
     /// from creates new SkinTempOvernight struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [23, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.local_timestamp = typedef::LocalDateTime(field.value.as_u32()),
+                1 => v.average_deviation = field.value.as_f32(),
+                2 => v.average_7_day_deviation = field.value.as_f32(),
+                4 => v.nightly_value = field.value.as_f32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            local_timestamp: typedef::LocalDateTime(vals[0].as_u32()),
-            average_deviation: vals[1].as_f32(),
-            average_7_day_deviation: vals[2].as_f32(),
-            nightly_value: vals[4].as_f32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SkinTempOvernight> for Message {
     fn from(m: SkinTempOvernight) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::LOCAL_DATE_TIME,
                 value: Value::Uint32(m.local_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.average_deviation != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.average_deviation),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.average_7_day_deviation != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.average_7_day_deviation),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.nightly_value != f32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::FLOAT32,
                 value: Value::Float32(m.nightly_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SKIN_TEMP_OVERNIGHT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/slave_device.rs
+++ b/rustyfit/src/profile/mesgdef/slave_device.rs
@@ -36,6 +36,11 @@ impl SlaveDevice {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.product != u16::MAX) as usize
+    }
 }
 
 impl Default for SlaveDevice {
@@ -47,72 +52,56 @@ impl Default for SlaveDevice {
 impl From<&Message> for SlaveDevice {
     /// from creates new SlaveDevice struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 2];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.manufacturer = typedef::Manufacturer(field.value.as_u16()),
+                1 => v.product = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            manufacturer: typedef::Manufacturer(vals[0].as_u16()),
-            product: vals[1].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SlaveDevice> for Message {
     fn from(m: SlaveDevice) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 2];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.manufacturer != typedef::Manufacturer(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::MANUFACTURER,
                 value: Value::Uint16(m.manufacturer.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.product != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.product),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SLAVE_DEVICE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/sleep_assessment.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_assessment.rs
@@ -117,6 +117,23 @@ impl SleepAssessment {
         self.average_stress_during_sleep = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.combined_awake_score != u8::MAX) as usize
+            + (self.awake_time_score != u8::MAX) as usize
+            + (self.awakenings_count_score != u8::MAX) as usize
+            + (self.deep_sleep_score != u8::MAX) as usize
+            + (self.sleep_duration_score != u8::MAX) as usize
+            + (self.light_sleep_score != u8::MAX) as usize
+            + (self.overall_sleep_score != u8::MAX) as usize
+            + (self.sleep_quality_score != u8::MAX) as usize
+            + (self.sleep_recovery_score != u8::MAX) as usize
+            + (self.rem_sleep_score != u8::MAX) as usize
+            + (self.sleep_restlessness_score != u8::MAX) as usize
+            + (self.awakenings_count != u8::MAX) as usize
+            + (self.interruptions_score != u8::MAX) as usize
+            + (self.average_stress_during_sleep != u16::MAX) as usize
+    }
 }
 
 impl Default for SleepAssessment {
@@ -128,192 +145,164 @@ impl Default for SleepAssessment {
 impl From<&Message> for SleepAssessment {
     /// from creates new SleepAssessment struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 16];
-
         const KNOWN_NUMS: [u64; 4] = [53247, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.combined_awake_score = field.value.as_u8(),
+                1 => v.awake_time_score = field.value.as_u8(),
+                2 => v.awakenings_count_score = field.value.as_u8(),
+                3 => v.deep_sleep_score = field.value.as_u8(),
+                4 => v.sleep_duration_score = field.value.as_u8(),
+                5 => v.light_sleep_score = field.value.as_u8(),
+                6 => v.overall_sleep_score = field.value.as_u8(),
+                7 => v.sleep_quality_score = field.value.as_u8(),
+                8 => v.sleep_recovery_score = field.value.as_u8(),
+                9 => v.rem_sleep_score = field.value.as_u8(),
+                10 => v.sleep_restlessness_score = field.value.as_u8(),
+                11 => v.awakenings_count = field.value.as_u8(),
+                14 => v.interruptions_score = field.value.as_u8(),
+                15 => v.average_stress_during_sleep = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            combined_awake_score: vals[0].as_u8(),
-            awake_time_score: vals[1].as_u8(),
-            awakenings_count_score: vals[2].as_u8(),
-            deep_sleep_score: vals[3].as_u8(),
-            sleep_duration_score: vals[4].as_u8(),
-            light_sleep_score: vals[5].as_u8(),
-            overall_sleep_score: vals[6].as_u8(),
-            sleep_quality_score: vals[7].as_u8(),
-            sleep_recovery_score: vals[8].as_u8(),
-            rem_sleep_score: vals[9].as_u8(),
-            sleep_restlessness_score: vals[10].as_u8(),
-            awakenings_count: vals[11].as_u8(),
-            interruptions_score: vals[14].as_u8(),
-            average_stress_during_sleep: vals[15].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SleepAssessment> for Message {
     fn from(m: SleepAssessment) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 14];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.combined_awake_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.combined_awake_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.awake_time_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.awake_time_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.awakenings_count_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.awakenings_count_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.deep_sleep_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.deep_sleep_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sleep_duration_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.sleep_duration_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.light_sleep_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.light_sleep_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.overall_sleep_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.overall_sleep_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sleep_quality_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.sleep_quality_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sleep_recovery_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.sleep_recovery_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.rem_sleep_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.rem_sleep_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sleep_restlessness_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.sleep_restlessness_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.awakenings_count != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.awakenings_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.interruptions_score != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.interruptions_score),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.average_stress_during_sleep != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.average_stress_during_sleep),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SLEEP_ASSESSMENT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
@@ -36,6 +36,11 @@ impl SleepDisruptionOvernightSeverity {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.severity != typedef::SleepDisruptionSeverity(u8::MAX)) as usize
+    }
 }
 
 impl Default for SleepDisruptionOvernightSeverity {
@@ -47,72 +52,56 @@ impl Default for SleepDisruptionOvernightSeverity {
 impl From<&Message> for SleepDisruptionOvernightSeverity {
     /// from creates new SleepDisruptionOvernightSeverity struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.severity = typedef::SleepDisruptionSeverity(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            severity: typedef::SleepDisruptionSeverity(vals[0].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SleepDisruptionOvernightSeverity> for Message {
     fn from(m: SleepDisruptionOvernightSeverity) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 2];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.severity != typedef::SleepDisruptionSeverity(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SLEEP_DISRUPTION_SEVERITY,
                 value: Value::Uint8(m.severity.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SLEEP_DISRUPTION_OVERNIGHT_SEVERITY,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
@@ -40,6 +40,12 @@ impl SleepDisruptionSeverityPeriod {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.severity != typedef::SleepDisruptionSeverity(u8::MAX)) as usize
+    }
 }
 
 impl Default for SleepDisruptionSeverityPeriod {
@@ -51,82 +57,65 @@ impl Default for SleepDisruptionSeverityPeriod {
 impl From<&Message> for SleepDisruptionSeverityPeriod {
     /// from creates new SleepDisruptionSeverityPeriod struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.severity = typedef::SleepDisruptionSeverity(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            severity: typedef::SleepDisruptionSeverity(vals[0].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SleepDisruptionSeverityPeriod> for Message {
     fn from(m: SleepDisruptionSeverityPeriod) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.severity != typedef::SleepDisruptionSeverity(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SLEEP_DISRUPTION_SEVERITY,
                 value: Value::Uint8(m.severity.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SLEEP_DISRUPTION_SEVERITY_PERIOD,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/sleep_level.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_level.rs
@@ -37,6 +37,11 @@ impl SleepLevel {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.sleep_level != typedef::SleepLevel(u8::MAX)) as usize
+    }
 }
 
 impl Default for SleepLevel {
@@ -48,72 +53,56 @@ impl Default for SleepLevel {
 impl From<&Message> for SleepLevel {
     /// from creates new SleepLevel struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [1, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.sleep_level = typedef::SleepLevel(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            sleep_level: typedef::SleepLevel(vals[0].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SleepLevel> for Message {
     fn from(m: SleepLevel) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 2];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sleep_level != typedef::SleepLevel(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SLEEP_LEVEL,
                 value: Value::Uint8(m.sleep_level.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SLEEP_LEVEL,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/software.rs
+++ b/rustyfit/src/profile/mesgdef/software.rs
@@ -62,6 +62,12 @@ impl Software {
         self.version = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.version != u16::MAX) as usize
+            + (!self.part_number.is_empty()) as usize
+    }
 }
 
 impl Default for Software {
@@ -73,82 +79,65 @@ impl Default for Software {
 impl From<&Message> for Software {
     /// from creates new Software struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [40, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                3 => v.version = field.value.as_u16(),
+                5 => v.part_number = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            version: vals[3].as_u16(),
-            part_number: vals[5].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Software> for Message {
     fn from(m: Software) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.version != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.version),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.part_number.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.part_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SOFTWARE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/speed_zone.rs
+++ b/rustyfit/src/profile/mesgdef/speed_zone.rs
@@ -62,6 +62,12 @@ impl SpeedZone {
         self.high_value = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.high_value != u16::MAX) as usize
+            + (!self.name.is_empty()) as usize
+    }
 }
 
 impl Default for SpeedZone {
@@ -73,82 +79,65 @@ impl Default for SpeedZone {
 impl From<&Message> for SpeedZone {
     /// from creates new SpeedZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.high_value = field.value.as_u16(),
+                1 => v.name = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            high_value: vals[0].as_u16(),
-            name: vals[1].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SpeedZone> for Message {
     fn from(m: SpeedZone) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.high_value != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.high_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SPEED_ZONE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/split.rs
+++ b/rustyfit/src/profile/mesgdef/split.rs
@@ -316,6 +316,29 @@ impl Split {
         self.total_moving_time = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.split_type != typedef::SplitType(u8::MAX)) as usize
+            + (self.total_elapsed_time != u32::MAX) as usize
+            + (self.total_timer_time != u32::MAX) as usize
+            + (self.total_distance != u32::MAX) as usize
+            + (self.avg_speed != u32::MAX) as usize
+            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.total_ascent != u16::MAX) as usize
+            + (self.total_descent != u16::MAX) as usize
+            + (self.start_position_lat != i32::MAX) as usize
+            + (self.start_position_long != i32::MAX) as usize
+            + (self.end_position_lat != i32::MAX) as usize
+            + (self.end_position_long != i32::MAX) as usize
+            + (self.max_speed != u32::MAX) as usize
+            + (self.avg_vert_speed != i32::MAX) as usize
+            + (self.end_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.total_calories != u32::MAX) as usize
+            + (self.start_elevation != u32::MAX) as usize
+            + (self.active_time != u32::MAX) as usize
+            + (self.total_moving_time != u32::MAX) as usize
+    }
 }
 
 impl Default for Split {
@@ -327,252 +350,218 @@ impl Default for Split {
 impl From<&Message> for Split {
     /// from creates new Split struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [534798879, 70368744195072, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.split_type = typedef::SplitType(field.value.as_u8()),
+                1 => v.total_elapsed_time = field.value.as_u32(),
+                2 => v.total_timer_time = field.value.as_u32(),
+                3 => v.total_distance = field.value.as_u32(),
+                4 => v.avg_speed = field.value.as_u32(),
+                9 => v.start_time = typedef::DateTime(field.value.as_u32()),
+                13 => v.total_ascent = field.value.as_u16(),
+                14 => v.total_descent = field.value.as_u16(),
+                21 => v.start_position_lat = field.value.as_i32(),
+                22 => v.start_position_long = field.value.as_i32(),
+                23 => v.end_position_lat = field.value.as_i32(),
+                24 => v.end_position_long = field.value.as_i32(),
+                25 => v.max_speed = field.value.as_u32(),
+                26 => v.avg_vert_speed = field.value.as_i32(),
+                27 => v.end_time = typedef::DateTime(field.value.as_u32()),
+                28 => v.total_calories = field.value.as_u32(),
+                74 => v.start_elevation = field.value.as_u32(),
+                78 => v.active_time = field.value.as_u32(),
+                110 => v.total_moving_time = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            split_type: typedef::SplitType(vals[0].as_u8()),
-            total_elapsed_time: vals[1].as_u32(),
-            total_timer_time: vals[2].as_u32(),
-            total_distance: vals[3].as_u32(),
-            avg_speed: vals[4].as_u32(),
-            start_time: typedef::DateTime(vals[9].as_u32()),
-            total_ascent: vals[13].as_u16(),
-            total_descent: vals[14].as_u16(),
-            start_position_lat: vals[21].as_i32(),
-            start_position_long: vals[22].as_i32(),
-            end_position_lat: vals[23].as_i32(),
-            end_position_long: vals[24].as_i32(),
-            max_speed: vals[25].as_u32(),
-            avg_vert_speed: vals[26].as_i32(),
-            end_time: typedef::DateTime(vals[27].as_u32()),
-            total_calories: vals[28].as_u32(),
-            start_elevation: vals[74].as_u32(),
-            active_time: vals[78].as_u32(),
-            total_moving_time: vals[110].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Split> for Message {
     fn from(m: Split) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 20];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.split_type != typedef::SplitType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPLIT_TYPE,
                 value: Value::Uint8(m.split_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_elapsed_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_elapsed_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_timer_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_timer_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.avg_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_ascent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_ascent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_descent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_descent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.start_position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.start_position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_position_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.end_position_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_position_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.end_position_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.max_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_vert_speed != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 26,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.avg_vert_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 27,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.end_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_calories != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 28,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_elevation != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 74,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.start_elevation),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 78,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.active_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_moving_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 110,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_moving_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SPLIT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/split_summary.rs
+++ b/rustyfit/src/profile/mesgdef/split_summary.rs
@@ -233,6 +233,24 @@ impl SplitSummary {
         self.total_moving_time = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.split_type != typedef::SplitType(u8::MAX)) as usize
+            + (self.num_splits != u16::MAX) as usize
+            + (self.total_timer_time != u32::MAX) as usize
+            + (self.total_distance != u32::MAX) as usize
+            + (self.avg_speed != u32::MAX) as usize
+            + (self.max_speed != u32::MAX) as usize
+            + (self.total_ascent != u16::MAX) as usize
+            + (self.total_descent != u16::MAX) as usize
+            + (self.avg_heart_rate != u8::MAX) as usize
+            + (self.max_heart_rate != u8::MAX) as usize
+            + (self.avg_vert_speed != i32::MAX) as usize
+            + (self.total_calories != u32::MAX) as usize
+            + (self.active_time != u32::MAX) as usize
+            + (self.total_moving_time != u32::MAX) as usize
+    }
 }
 
 impl Default for SplitSummary {
@@ -244,202 +262,173 @@ impl Default for SplitSummary {
 impl From<&Message> for SplitSummary {
     /// from creates new SplitSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [16377, 8194, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.split_type = typedef::SplitType(field.value.as_u8()),
+                3 => v.num_splits = field.value.as_u16(),
+                4 => v.total_timer_time = field.value.as_u32(),
+                5 => v.total_distance = field.value.as_u32(),
+                6 => v.avg_speed = field.value.as_u32(),
+                7 => v.max_speed = field.value.as_u32(),
+                8 => v.total_ascent = field.value.as_u16(),
+                9 => v.total_descent = field.value.as_u16(),
+                10 => v.avg_heart_rate = field.value.as_u8(),
+                11 => v.max_heart_rate = field.value.as_u8(),
+                12 => v.avg_vert_speed = field.value.as_i32(),
+                13 => v.total_calories = field.value.as_u32(),
+                65 => v.active_time = field.value.as_u32(),
+                77 => v.total_moving_time = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            split_type: typedef::SplitType(vals[0].as_u8()),
-            num_splits: vals[3].as_u16(),
-            total_timer_time: vals[4].as_u32(),
-            total_distance: vals[5].as_u32(),
-            avg_speed: vals[6].as_u32(),
-            max_speed: vals[7].as_u32(),
-            total_ascent: vals[8].as_u16(),
-            total_descent: vals[9].as_u16(),
-            avg_heart_rate: vals[10].as_u8(),
-            max_heart_rate: vals[11].as_u8(),
-            avg_vert_speed: vals[12].as_i32(),
-            total_calories: vals[13].as_u32(),
-            active_time: vals[65].as_u32(),
-            total_moving_time: vals[77].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<SplitSummary> for Message {
     fn from(m: SplitSummary) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 15];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.split_type != typedef::SplitType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPLIT_TYPE,
                 value: Value::Uint8(m.split_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.num_splits != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.num_splits),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_timer_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_timer_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.avg_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.max_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_ascent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_ascent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_descent != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.total_descent),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.avg_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.avg_vert_speed != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.avg_vert_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_calories != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 65,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.active_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.total_moving_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 77,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.total_moving_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SPLIT_SUMMARY,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/spo2_data.rs
@@ -47,6 +47,13 @@ impl Spo2Data {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.reading_spo2 != u8::MAX) as usize
+            + (self.reading_confidence != u8::MAX) as usize
+            + (self.mode != typedef::Spo2MeasurementType(u8::MAX)) as usize
+    }
 }
 
 impl Default for Spo2Data {
@@ -58,92 +65,74 @@ impl Default for Spo2Data {
 impl From<&Message> for Spo2Data {
     /// from creates new Spo2Data struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.reading_spo2 = field.value.as_u8(),
+                1 => v.reading_confidence = field.value.as_u8(),
+                2 => v.mode = typedef::Spo2MeasurementType(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            reading_spo2: vals[0].as_u8(),
-            reading_confidence: vals[1].as_u8(),
-            mode: typedef::Spo2MeasurementType(vals[2].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Spo2Data> for Message {
     fn from(m: Spo2Data) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.reading_spo2 != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.reading_spo2),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.reading_confidence != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.reading_confidence),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mode != typedef::Spo2MeasurementType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SPO2_MEASUREMENT_TYPE,
                 value: Value::Uint8(m.mode.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SPO2_DATA,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/sport.rs
+++ b/rustyfit/src/profile/mesgdef/sport.rs
@@ -42,6 +42,12 @@ impl Sport {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (!self.name.is_empty()) as usize
+    }
 }
 
 impl Default for Sport {
@@ -53,82 +59,65 @@ impl Default for Sport {
 impl From<&Message> for Sport {
     /// from creates new Sport struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 4];
-
         const KNOWN_NUMS: [u64; 4] = [11, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.sport = typedef::Sport(field.value.as_u8()),
+                1 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                3 => v.name = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            sport: typedef::Sport(vals[0].as_u8()),
-            sub_sport: typedef::SubSport(vals[1].as_u8()),
-            name: vals[3].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Sport> for Message {
     fn from(m: Sport) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::SPORT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/stress_level.rs
+++ b/rustyfit/src/profile/mesgdef/stress_level.rs
@@ -37,6 +37,11 @@ impl StressLevel {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.stress_level_value != i16::MAX) as usize
+            + (self.stress_level_time != typedef::DateTime(u32::MAX)) as usize
+    }
 }
 
 impl Default for StressLevel {
@@ -48,72 +53,56 @@ impl Default for StressLevel {
 impl From<&Message> for StressLevel {
     /// from creates new StressLevel struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 2];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.stress_level_value = field.value.as_i16(),
+                1 => v.stress_level_time = typedef::DateTime(field.value.as_u32()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            stress_level_value: vals[0].as_i16(),
-            stress_level_time: typedef::DateTime(vals[1].as_u32()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<StressLevel> for Message {
     fn from(m: StressLevel) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 2];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.stress_level_value != i16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SINT16,
                 value: Value::Int16(m.stress_level_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.stress_level_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.stress_level_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::STRESS_LEVEL,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/tank_summary.rs
+++ b/rustyfit/src/profile/mesgdef/tank_summary.rs
@@ -110,6 +110,14 @@ impl TankSummary {
         self.volume_used = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.sensor != typedef::AntChannelId(u32::MIN)) as usize
+            + (self.start_pressure != u16::MAX) as usize
+            + (self.end_pressure != u16::MAX) as usize
+            + (self.volume_used != u32::MAX) as usize
+    }
 }
 
 impl Default for TankSummary {
@@ -121,102 +129,83 @@ impl Default for TankSummary {
 impl From<&Message> for TankSummary {
     /// from creates new TankSummary struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [15, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.sensor = typedef::AntChannelId(field.value.as_u32z()),
+                1 => v.start_pressure = field.value.as_u16(),
+                2 => v.end_pressure = field.value.as_u16(),
+                3 => v.volume_used = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            sensor: typedef::AntChannelId(vals[0].as_u32z()),
-            start_pressure: vals[1].as_u16(),
-            end_pressure: vals[2].as_u16(),
-            volume_used: vals[3].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<TankSummary> for Message {
     fn from(m: TankSummary) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sensor != typedef::AntChannelId(u32::MIN) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::ANT_CHANNEL_ID,
                 value: Value::Uint32(m.sensor.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_pressure != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.start_pressure),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_pressure != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.end_pressure),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.volume_used != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.volume_used),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::TANK_SUMMARY,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/tank_update.rs
+++ b/rustyfit/src/profile/mesgdef/tank_update.rs
@@ -62,6 +62,12 @@ impl TankUpdate {
         self.pressure = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.sensor != typedef::AntChannelId(u32::MIN)) as usize
+            + (self.pressure != u16::MAX) as usize
+    }
 }
 
 impl Default for TankUpdate {
@@ -73,82 +79,65 @@ impl Default for TankUpdate {
 impl From<&Message> for TankUpdate {
     /// from creates new TankUpdate struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.sensor = typedef::AntChannelId(field.value.as_u32z()),
+                1 => v.pressure = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            sensor: typedef::AntChannelId(vals[0].as_u32z()),
-            pressure: vals[1].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<TankUpdate> for Message {
     fn from(m: TankUpdate) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sensor != typedef::AntChannelId(u32::MIN) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::ANT_CHANNEL_ID,
                 value: Value::Uint32(m.sensor.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pressure != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.pressure),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::TANK_UPDATE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
@@ -88,6 +88,16 @@ impl ThreeDSensorCalibration {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.sensor_type != typedef::SensorType(u8::MAX)) as usize
+            + (self.calibration_factor != u32::MAX) as usize
+            + (self.calibration_divisor != u32::MAX) as usize
+            + (self.level_shift != u32::MAX) as usize
+            + (self.offset_cal != [i32::MAX; 3]) as usize
+            + (self.orientation_matrix != [i32::MAX; 9]) as usize
+    }
 }
 
 impl Default for ThreeDSensorCalibration {
@@ -99,140 +109,123 @@ impl Default for ThreeDSensorCalibration {
 impl From<&Message> for ThreeDSensorCalibration {
     /// from creates new ThreeDSensorCalibration struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.sensor_type = typedef::SensorType(field.value.as_u8()),
+                1 => v.calibration_factor = field.value.as_u32(),
+                2 => v.calibration_divisor = field.value.as_u32(),
+                3 => v.level_shift = field.value.as_u32(),
+                4 => {
+                    v.offset_cal = match &field.value {
+                        Value::VecInt32(v) => {
+                            let mut arr = [i32::MAX; 3];
+                            for (i, x) in v.iter().take(3).enumerate() {
+                                arr[i] = *x;
+                            }
+                            arr
+                        }
+                        _ => [i32::MAX; 3],
+                    }
+                }
+                5 => {
+                    v.orientation_matrix = match &field.value {
+                        Value::VecInt32(v) => {
+                            let mut arr = [i32::MAX; 9];
+                            for (i, x) in v.iter().take(9).enumerate() {
+                                arr[i] = *x;
+                            }
+                            arr
+                        }
+                        _ => [i32::MAX; 9],
+                    }
+                }
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            sensor_type: typedef::SensorType(vals[0].as_u8()),
-            calibration_factor: vals[1].as_u32(),
-            calibration_divisor: vals[2].as_u32(),
-            level_shift: vals[3].as_u32(),
-            offset_cal: match &vals[4] {
-                Value::VecInt32(v) => {
-                    let mut arr = [i32::MAX; 3];
-                    for (i, x) in v.iter().take(3).enumerate() {
-                        arr[i] = *x;
-                    }
-                    arr
-                }
-                _ => [i32::MAX; 3],
-            },
-            orientation_matrix: match &vals[5] {
-                Value::VecInt32(v) => {
-                    let mut arr = [i32::MAX; 9];
-                    for (i, x) in v.iter().take(9).enumerate() {
-                        arr[i] = *x;
-                    }
-                    arr
-                }
-                _ => [i32::MAX; 9],
-            },
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ThreeDSensorCalibration> for Message {
     fn from(m: ThreeDSensorCalibration) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sensor_type != typedef::SensorType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SENSOR_TYPE,
                 value: Value::Uint8(m.sensor_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.calibration_factor != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.calibration_factor),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.calibration_divisor != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.calibration_divisor),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.level_shift != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.level_shift),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.offset_cal != [i32::MAX; 3] {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SINT32,
                 value: Value::VecInt32(Vec::from(&m.offset_cal)),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.orientation_matrix != [i32::MAX; 9] {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SINT32,
                 value: Value::VecInt32(Vec::from(&m.orientation_matrix)),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::THREE_D_SENSOR_CALIBRATION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/time_in_zone.rs
+++ b/rustyfit/src/profile/mesgdef/time_in_zone.rs
@@ -255,6 +255,26 @@ impl TimeInZone {
         }
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.reference_mesg != typedef::MesgNum(u16::MAX)) as usize
+            + (self.reference_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (!self.time_in_hr_zone.is_empty()) as usize
+            + (!self.time_in_speed_zone.is_empty()) as usize
+            + (!self.time_in_cadence_zone.is_empty()) as usize
+            + (!self.time_in_power_zone.is_empty()) as usize
+            + (!self.hr_zone_high_boundary.is_empty()) as usize
+            + (!self.speed_zone_high_boundary.is_empty()) as usize
+            + (!self.cadence_zone_high_boundary.is_empty()) as usize
+            + (!self.power_zone_high_boundary.is_empty()) as usize
+            + (self.hr_calc_type != typedef::HrZoneCalc(u8::MAX)) as usize
+            + (self.max_heart_rate != u8::MAX) as usize
+            + (self.resting_heart_rate != u8::MAX) as usize
+            + (self.threshold_heart_rate != u8::MAX) as usize
+            + (self.pwr_calc_type != typedef::PwrZoneCalc(u8::MAX)) as usize
+            + (self.functional_threshold_power != u16::MAX) as usize
+    }
 }
 
 impl Default for TimeInZone {
@@ -266,222 +286,191 @@ impl Default for TimeInZone {
 impl From<&Message> for TimeInZone {
     /// from creates new TimeInZone struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [65535, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.reference_mesg = typedef::MesgNum(field.value.as_u16()),
+                1 => v.reference_index = typedef::MessageIndex(field.value.as_u16()),
+                2 => v.time_in_hr_zone = field.value.to_vec_u32(),
+                3 => v.time_in_speed_zone = field.value.to_vec_u32(),
+                4 => v.time_in_cadence_zone = field.value.to_vec_u32(),
+                5 => v.time_in_power_zone = field.value.to_vec_u32(),
+                6 => v.hr_zone_high_boundary = field.value.to_vec_u8(),
+                7 => v.speed_zone_high_boundary = field.value.to_vec_u16(),
+                8 => v.cadence_zone_high_boundary = field.value.to_vec_u8(),
+                9 => v.power_zone_high_boundary = field.value.to_vec_u16(),
+                10 => v.hr_calc_type = typedef::HrZoneCalc(field.value.as_u8()),
+                11 => v.max_heart_rate = field.value.as_u8(),
+                12 => v.resting_heart_rate = field.value.as_u8(),
+                13 => v.threshold_heart_rate = field.value.as_u8(),
+                14 => v.pwr_calc_type = typedef::PwrZoneCalc(field.value.as_u8()),
+                15 => v.functional_threshold_power = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            reference_mesg: typedef::MesgNum(vals[0].as_u16()),
-            reference_index: typedef::MessageIndex(vals[1].as_u16()),
-            time_in_hr_zone: vals[2].to_vec_u32(),
-            time_in_speed_zone: vals[3].to_vec_u32(),
-            time_in_cadence_zone: vals[4].to_vec_u32(),
-            time_in_power_zone: vals[5].to_vec_u32(),
-            hr_zone_high_boundary: vals[6].to_vec_u8(),
-            speed_zone_high_boundary: vals[7].to_vec_u16(),
-            cadence_zone_high_boundary: vals[8].to_vec_u8(),
-            power_zone_high_boundary: vals[9].to_vec_u16(),
-            hr_calc_type: typedef::HrZoneCalc(vals[10].as_u8()),
-            max_heart_rate: vals[11].as_u8(),
-            resting_heart_rate: vals[12].as_u8(),
-            threshold_heart_rate: vals[13].as_u8(),
-            pwr_calc_type: typedef::PwrZoneCalc(vals[14].as_u8()),
-            functional_threshold_power: vals[15].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<TimeInZone> for Message {
     fn from(m: TimeInZone) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 17];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.reference_mesg != typedef::MesgNum(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::MESG_NUM,
                 value: Value::Uint16(m.reference_mesg.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.reference_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.reference_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_hr_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_hr_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_speed_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_speed_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_cadence_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_cadence_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.time_in_power_zone.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::VecUint32(m.time_in_power_zone),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.hr_zone_high_boundary.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.hr_zone_high_boundary),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.speed_zone_high_boundary.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.speed_zone_high_boundary),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.cadence_zone_high_boundary.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT8,
                 value: Value::VecUint8(m.cadence_zone_high_boundary),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.power_zone_high_boundary.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
                 value: Value::VecUint16(m.power_zone_high_boundary),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hr_calc_type != typedef::HrZoneCalc(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::HR_ZONE_CALC,
                 value: Value::Uint8(m.hr_calc_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.max_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.resting_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.resting_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.threshold_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.threshold_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pwr_calc_type != typedef::PwrZoneCalc(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::PWR_ZONE_CALC,
                 value: Value::Uint8(m.pwr_calc_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.functional_threshold_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.functional_threshold_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::TIME_IN_ZONE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
+++ b/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
@@ -101,6 +101,16 @@ impl TimestampCorrelation {
         self.fractional_system_timestamp = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.fractional_timestamp != u16::MAX) as usize
+            + (self.system_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.fractional_system_timestamp != u16::MAX) as usize
+            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (self.system_timestamp_ms != u16::MAX) as usize
+    }
 }
 
 impl Default for TimestampCorrelation {
@@ -112,122 +122,101 @@ impl Default for TimestampCorrelation {
 impl From<&Message> for TimestampCorrelation {
     /// from creates new TimestampCorrelation struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.fractional_timestamp = field.value.as_u16(),
+                1 => v.system_timestamp = typedef::DateTime(field.value.as_u32()),
+                2 => v.fractional_system_timestamp = field.value.as_u16(),
+                3 => v.local_timestamp = typedef::LocalDateTime(field.value.as_u32()),
+                4 => v.timestamp_ms = field.value.as_u16(),
+                5 => v.system_timestamp_ms = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            fractional_timestamp: vals[0].as_u16(),
-            system_timestamp: typedef::DateTime(vals[1].as_u32()),
-            fractional_system_timestamp: vals[2].as_u16(),
-            local_timestamp: typedef::LocalDateTime(vals[3].as_u32()),
-            timestamp_ms: vals[4].as_u16(),
-            system_timestamp_ms: vals[5].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<TimestampCorrelation> for Message {
     fn from(m: TimestampCorrelation) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.fractional_timestamp != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.fractional_timestamp),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.system_timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.system_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.fractional_system_timestamp != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.fractional_system_timestamp),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::LOCAL_DATE_TIME,
                 value: Value::Uint32(m.local_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.system_timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.system_timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::TIMESTAMP_CORRELATION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/totals.rs
+++ b/rustyfit/src/profile/mesgdef/totals.rs
@@ -74,6 +74,19 @@ impl Totals {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timer_time != u32::MAX) as usize
+            + (self.distance != u32::MAX) as usize
+            + (self.calories != u32::MAX) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.elapsed_time != u32::MAX) as usize
+            + (self.sessions != u16::MAX) as usize
+            + (self.active_time != u32::MAX) as usize
+            + (self.sport_index != u8::MAX) as usize
+    }
 }
 
 impl Default for Totals {
@@ -85,152 +98,128 @@ impl Default for Totals {
 impl From<&Message> for Totals {
     /// from creates new Totals struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [639, 0, 0, 6917529027641081856];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timer_time = field.value.as_u32(),
+                1 => v.distance = field.value.as_u32(),
+                2 => v.calories = field.value.as_u32(),
+                3 => v.sport = typedef::Sport(field.value.as_u8()),
+                4 => v.elapsed_time = field.value.as_u32(),
+                5 => v.sessions = field.value.as_u16(),
+                6 => v.active_time = field.value.as_u32(),
+                9 => v.sport_index = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timer_time: vals[0].as_u32(),
-            distance: vals[1].as_u32(),
-            calories: vals[2].as_u32(),
-            sport: typedef::Sport(vals[3].as_u8()),
-            elapsed_time: vals[4].as_u32(),
-            sessions: vals[5].as_u16(),
-            active_time: vals[6].as_u32(),
-            sport_index: vals[9].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Totals> for Message {
     fn from(m: Totals) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 10];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timer_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.timer_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.calories != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.calories),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.elapsed_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.elapsed_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sessions != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.sessions),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.active_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport_index != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.sport_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::TOTALS,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/training_file.rs
+++ b/rustyfit/src/profile/mesgdef/training_file.rs
@@ -53,6 +53,15 @@ impl TrainingFile {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.r#type != typedef::File(u8::MAX)) as usize
+            + (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.product != u16::MAX) as usize
+            + (self.serial_number != u32::MIN) as usize
+            + (self.time_created != typedef::DateTime(u32::MAX)) as usize
+    }
 }
 
 impl Default for TrainingFile {
@@ -64,112 +73,92 @@ impl Default for TrainingFile {
 impl From<&Message> for TrainingFile {
     /// from creates new TrainingFile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.r#type = typedef::File(field.value.as_u8()),
+                1 => v.manufacturer = typedef::Manufacturer(field.value.as_u16()),
+                2 => v.product = field.value.as_u16(),
+                3 => v.serial_number = field.value.as_u32z(),
+                4 => v.time_created = typedef::DateTime(field.value.as_u32()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            r#type: typedef::File(vals[0].as_u8()),
-            manufacturer: typedef::Manufacturer(vals[1].as_u16()),
-            product: vals[2].as_u16(),
-            serial_number: vals[3].as_u32z(),
-            time_created: typedef::DateTime(vals[4].as_u32()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<TrainingFile> for Message {
     fn from(m: TrainingFile) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.r#type != typedef::File(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
                 value: Value::Uint8(m.r#type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.manufacturer != typedef::Manufacturer(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MANUFACTURER,
                 value: Value::Uint16(m.manufacturer.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.product != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.product),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.serial_number != u32::MIN {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT32Z,
                 value: Value::Uint32(m.serial_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.time_created != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.time_created.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::TRAINING_FILE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/training_settings.rs
+++ b/rustyfit/src/profile/mesgdef/training_settings.rs
@@ -105,6 +105,13 @@ impl TrainingSettings {
         self.precise_target_speed = unscaled as u32;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.target_distance != u32::MAX) as usize
+            + (self.target_speed != u16::MAX) as usize
+            + (self.target_time != u32::MAX) as usize
+            + (self.precise_target_speed != u32::MAX) as usize
+    }
 }
 
 impl Default for TrainingSettings {
@@ -116,92 +123,74 @@ impl Default for TrainingSettings {
 impl From<&Message> for TrainingSettings {
     /// from creates new TrainingSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 154];
-
         const KNOWN_NUMS: [u64; 4] = [15032385536, 0, 33554432, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                31 => v.target_distance = field.value.as_u32(),
+                32 => v.target_speed = field.value.as_u16(),
+                33 => v.target_time = field.value.as_u32(),
+                153 => v.precise_target_speed = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            target_distance: vals[31].as_u32(),
-            target_speed: vals[32].as_u16(),
-            target_time: vals[33].as_u32(),
-            precise_target_speed: vals[153].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<TrainingSettings> for Message {
     fn from(m: TrainingSettings) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 4];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.target_distance != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 31,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.target_distance),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.target_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 32,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.target_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.target_time != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 33,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.target_time),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.precise_target_speed != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 153,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.precise_target_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::TRAINING_SETTINGS,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/user_profile.rs
+++ b/rustyfit/src/profile/mesgdef/user_profile.rs
@@ -235,6 +235,38 @@ impl UserProfile {
         self.user_walking_step_length = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (!self.friendly_name.is_empty()) as usize
+            + (self.gender != typedef::Gender(u8::MAX)) as usize
+            + (self.age != u8::MAX) as usize
+            + (self.height != u8::MAX) as usize
+            + (self.weight != u16::MAX) as usize
+            + (self.language != typedef::Language(u8::MAX)) as usize
+            + (self.elev_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.weight_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.resting_heart_rate != u8::MAX) as usize
+            + (self.default_max_running_heart_rate != u8::MAX) as usize
+            + (self.default_max_biking_heart_rate != u8::MAX) as usize
+            + (self.default_max_heart_rate != u8::MAX) as usize
+            + (self.hr_setting != typedef::DisplayHeart(u8::MAX)) as usize
+            + (self.speed_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.dist_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.power_setting != typedef::DisplayPower(u8::MAX)) as usize
+            + (self.activity_class != typedef::ActivityClass(u8::MAX)) as usize
+            + (self.position_setting != typedef::DisplayPosition(u8::MAX)) as usize
+            + (self.temperature_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.local_id != typedef::UserLocalId(u16::MAX)) as usize
+            + (self.global_id != [u8::MAX; 6]) as usize
+            + (self.wake_time != typedef::LocaltimeIntoDay(u32::MAX)) as usize
+            + (self.sleep_time != typedef::LocaltimeIntoDay(u32::MAX)) as usize
+            + (self.height_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.user_running_step_length != u16::MAX) as usize
+            + (self.user_walking_step_length != u16::MAX) as usize
+            + (self.depth_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.dive_count != u32::MAX) as usize
+    }
 }
 
 impl Default for UserProfile {
@@ -246,351 +278,310 @@ impl Default for UserProfile {
 impl From<&Message> for UserProfile {
     /// from creates new UserProfile struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [703695778447359, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.friendly_name = field.value.as_str().to_owned(),
+                1 => v.gender = typedef::Gender(field.value.as_u8()),
+                2 => v.age = field.value.as_u8(),
+                3 => v.height = field.value.as_u8(),
+                4 => v.weight = field.value.as_u16(),
+                5 => v.language = typedef::Language(field.value.as_u8()),
+                6 => v.elev_setting = typedef::DisplayMeasure(field.value.as_u8()),
+                7 => v.weight_setting = typedef::DisplayMeasure(field.value.as_u8()),
+                8 => v.resting_heart_rate = field.value.as_u8(),
+                9 => v.default_max_running_heart_rate = field.value.as_u8(),
+                10 => v.default_max_biking_heart_rate = field.value.as_u8(),
+                11 => v.default_max_heart_rate = field.value.as_u8(),
+                12 => v.hr_setting = typedef::DisplayHeart(field.value.as_u8()),
+                13 => v.speed_setting = typedef::DisplayMeasure(field.value.as_u8()),
+                14 => v.dist_setting = typedef::DisplayMeasure(field.value.as_u8()),
+                16 => v.power_setting = typedef::DisplayPower(field.value.as_u8()),
+                17 => v.activity_class = typedef::ActivityClass(field.value.as_u8()),
+                18 => v.position_setting = typedef::DisplayPosition(field.value.as_u8()),
+                21 => v.temperature_setting = typedef::DisplayMeasure(field.value.as_u8()),
+                22 => v.local_id = typedef::UserLocalId(field.value.as_u16()),
+                23 => {
+                    v.global_id = match &field.value {
+                        Value::VecUint8(v) => {
+                            let mut arr = [u8::MAX; 6];
+                            for (i, x) in v.iter().take(6).enumerate() {
+                                arr[i] = *x;
+                            }
+                            arr
+                        }
+                        _ => [u8::MAX; 6],
+                    }
+                }
+                28 => v.wake_time = typedef::LocaltimeIntoDay(field.value.as_u32()),
+                29 => v.sleep_time = typedef::LocaltimeIntoDay(field.value.as_u32()),
+                30 => v.height_setting = typedef::DisplayMeasure(field.value.as_u8()),
+                31 => v.user_running_step_length = field.value.as_u16(),
+                32 => v.user_walking_step_length = field.value.as_u16(),
+                47 => v.depth_setting = typedef::DisplayMeasure(field.value.as_u8()),
+                49 => v.dive_count = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            friendly_name: vals[0].as_str().to_owned(),
-            gender: typedef::Gender(vals[1].as_u8()),
-            age: vals[2].as_u8(),
-            height: vals[3].as_u8(),
-            weight: vals[4].as_u16(),
-            language: typedef::Language(vals[5].as_u8()),
-            elev_setting: typedef::DisplayMeasure(vals[6].as_u8()),
-            weight_setting: typedef::DisplayMeasure(vals[7].as_u8()),
-            resting_heart_rate: vals[8].as_u8(),
-            default_max_running_heart_rate: vals[9].as_u8(),
-            default_max_biking_heart_rate: vals[10].as_u8(),
-            default_max_heart_rate: vals[11].as_u8(),
-            hr_setting: typedef::DisplayHeart(vals[12].as_u8()),
-            speed_setting: typedef::DisplayMeasure(vals[13].as_u8()),
-            dist_setting: typedef::DisplayMeasure(vals[14].as_u8()),
-            power_setting: typedef::DisplayPower(vals[16].as_u8()),
-            activity_class: typedef::ActivityClass(vals[17].as_u8()),
-            position_setting: typedef::DisplayPosition(vals[18].as_u8()),
-            temperature_setting: typedef::DisplayMeasure(vals[21].as_u8()),
-            local_id: typedef::UserLocalId(vals[22].as_u16()),
-            global_id: match &vals[23] {
-                Value::VecUint8(v) => {
-                    let mut arr = [u8::MAX; 6];
-                    for (i, x) in v.iter().take(6).enumerate() {
-                        arr[i] = *x;
-                    }
-                    arr
-                }
-                _ => [u8::MAX; 6],
-            },
-            wake_time: typedef::LocaltimeIntoDay(vals[28].as_u32()),
-            sleep_time: typedef::LocaltimeIntoDay(vals[29].as_u32()),
-            height_setting: typedef::DisplayMeasure(vals[30].as_u8()),
-            user_running_step_length: vals[31].as_u16(),
-            user_walking_step_length: vals[32].as_u16(),
-            depth_setting: typedef::DisplayMeasure(vals[47].as_u8()),
-            dive_count: vals[49].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<UserProfile> for Message {
     fn from(m: UserProfile) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 29];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.friendly_name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.friendly_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.gender != typedef::Gender(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::GENDER,
                 value: Value::Uint8(m.gender.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.age != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.age),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.height != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.height),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weight != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.weight),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.language != typedef::Language(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::LANGUAGE,
                 value: Value::Uint8(m.language.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.elev_setting != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.elev_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weight_setting != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.weight_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.resting_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.resting_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.default_max_running_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.default_max_running_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.default_max_biking_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.default_max_biking_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.default_max_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.default_max_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hr_setting != typedef::DisplayHeart(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::DISPLAY_HEART,
                 value: Value::Uint8(m.hr_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.speed_setting != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.speed_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.dist_setting != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.dist_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.power_setting != typedef::DisplayPower(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::DISPLAY_POWER,
                 value: Value::Uint8(m.power_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.activity_class != typedef::ActivityClass(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::ACTIVITY_CLASS,
                 value: Value::Uint8(m.activity_class.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.position_setting != typedef::DisplayPosition(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::DISPLAY_POSITION,
                 value: Value::Uint8(m.position_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.temperature_setting != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.temperature_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.local_id != typedef::UserLocalId(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::USER_LOCAL_ID,
                 value: Value::Uint16(m.local_id.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.global_id != [u8::MAX; 6] {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::BYTE,
                 value: Value::VecUint8(Vec::from(&m.global_id)),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.wake_time != typedef::LocaltimeIntoDay(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 28,
                 profile_type: ProfileType::LOCALTIME_INTO_DAY,
                 value: Value::Uint32(m.wake_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sleep_time != typedef::LocaltimeIntoDay(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 29,
                 profile_type: ProfileType::LOCALTIME_INTO_DAY,
                 value: Value::Uint32(m.sleep_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.height_setting != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 30,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.height_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.user_running_step_length != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 31,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.user_running_step_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.user_walking_step_length != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 32,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.user_walking_step_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.depth_setting != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 47,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.depth_setting.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.dive_count != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 49,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.dive_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::USER_PROFILE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/video.rs
+++ b/rustyfit/src/profile/mesgdef/video.rs
@@ -43,6 +43,12 @@ impl Video {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (!self.url.is_empty()) as usize
+            + (!self.hosting_provider.is_empty()) as usize
+            + (self.duration != u32::MAX) as usize
+    }
 }
 
 impl Default for Video {
@@ -54,82 +60,65 @@ impl Default for Video {
 impl From<&Message> for Video {
     /// from creates new Video struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 3];
-
         const KNOWN_NUMS: [u64; 4] = [7, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.url = field.value.as_str().to_owned(),
+                1 => v.hosting_provider = field.value.as_str().to_owned(),
+                2 => v.duration = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            url: vals[0].as_str().to_owned(),
-            hosting_provider: vals[1].as_str().to_owned(),
-            duration: vals[2].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Video> for Message {
     fn from(m: Video) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if !m.url.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.url),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.hosting_provider.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.hosting_provider),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.duration != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.duration),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::VIDEO,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/video_clip.rs
+++ b/rustyfit/src/profile/mesgdef/video_clip.rs
@@ -58,6 +58,16 @@ impl VideoClip {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.clip_number != u16::MAX) as usize
+            + (self.start_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_timestamp_ms != u16::MAX) as usize
+            + (self.end_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.end_timestamp_ms != u16::MAX) as usize
+            + (self.clip_start != u32::MAX) as usize
+            + (self.clip_end != u32::MAX) as usize
+    }
 }
 
 impl Default for VideoClip {
@@ -69,122 +79,101 @@ impl Default for VideoClip {
 impl From<&Message> for VideoClip {
     /// from creates new VideoClip struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 8];
-
         const KNOWN_NUMS: [u64; 4] = [223, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                0 => v.clip_number = field.value.as_u16(),
+                1 => v.start_timestamp = typedef::DateTime(field.value.as_u32()),
+                2 => v.start_timestamp_ms = field.value.as_u16(),
+                3 => v.end_timestamp = typedef::DateTime(field.value.as_u32()),
+                4 => v.end_timestamp_ms = field.value.as_u16(),
+                6 => v.clip_start = field.value.as_u32(),
+                7 => v.clip_end = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            clip_number: vals[0].as_u16(),
-            start_timestamp: typedef::DateTime(vals[1].as_u32()),
-            start_timestamp_ms: vals[2].as_u16(),
-            end_timestamp: typedef::DateTime(vals[3].as_u32()),
-            end_timestamp_ms: vals[4].as_u16(),
-            clip_start: vals[6].as_u32(),
-            clip_end: vals[7].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<VideoClip> for Message {
     fn from(m: VideoClip) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.clip_number != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.clip_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.start_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.start_timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.start_timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.end_timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.end_timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.end_timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.clip_start != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.clip_start),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.clip_end != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.clip_end),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::VIDEO_CLIP,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/video_description.rs
+++ b/rustyfit/src/profile/mesgdef/video_description.rs
@@ -44,6 +44,12 @@ impl VideoDescription {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.message_count != u16::MAX) as usize
+            + (!self.text.is_empty()) as usize
+    }
 }
 
 impl Default for VideoDescription {
@@ -55,82 +61,65 @@ impl Default for VideoDescription {
 impl From<&Message> for VideoDescription {
     /// from creates new VideoDescription struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.message_count = field.value.as_u16(),
+                1 => v.text = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            message_count: vals[0].as_u16(),
-            text: vals[1].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<VideoDescription> for Message {
     fn from(m: VideoDescription) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.message_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.message_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.text.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.text),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::VIDEO_DESCRIPTION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/video_frame.rs
+++ b/rustyfit/src/profile/mesgdef/video_frame.rs
@@ -43,6 +43,12 @@ impl VideoFrame {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.timestamp_ms != u16::MAX) as usize
+            + (self.frame_number != u32::MAX) as usize
+    }
 }
 
 impl Default for VideoFrame {
@@ -54,82 +60,65 @@ impl Default for VideoFrame {
 impl From<&Message> for VideoFrame {
     /// from creates new VideoFrame struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.timestamp_ms = field.value.as_u16(),
+                1 => v.frame_number = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            timestamp_ms: vals[0].as_u16(),
-            frame_number: vals[1].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<VideoFrame> for Message {
     fn from(m: VideoFrame) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.timestamp_ms != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.timestamp_ms),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.frame_number != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.frame_number),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::VIDEO_FRAME,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/video_title.rs
+++ b/rustyfit/src/profile/mesgdef/video_title.rs
@@ -44,6 +44,12 @@ impl VideoTitle {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.message_count != u16::MAX) as usize
+            + (!self.text.is_empty()) as usize
+    }
 }
 
 impl Default for VideoTitle {
@@ -55,82 +61,65 @@ impl Default for VideoTitle {
 impl From<&Message> for VideoTitle {
     /// from creates new VideoTitle struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.message_count = field.value.as_u16(),
+                1 => v.text = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            message_count: vals[0].as_u16(),
-            text: vals[1].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<VideoTitle> for Message {
     fn from(m: VideoTitle) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.message_count != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.message_count),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.text.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.text),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::VIDEO_TITLE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/watchface_settings.rs
+++ b/rustyfit/src/profile/mesgdef/watchface_settings.rs
@@ -40,6 +40,12 @@ impl WatchfaceSettings {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.mode != typedef::WatchfaceMode(u8::MAX)) as usize
+            + (self.layout != u8::MAX) as usize
+    }
 }
 
 impl Default for WatchfaceSettings {
@@ -51,82 +57,65 @@ impl Default for WatchfaceSettings {
 impl From<&Message> for WatchfaceSettings {
     /// from creates new WatchfaceSettings struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [3, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.mode = typedef::WatchfaceMode(field.value.as_u8()),
+                1 => v.layout = field.value.as_u8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            mode: typedef::WatchfaceMode(vals[0].as_u8()),
-            layout: vals[1].as_u8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<WatchfaceSettings> for Message {
     fn from(m: WatchfaceSettings) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 3];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.mode != typedef::WatchfaceMode(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::WATCHFACE_MODE,
                 value: Value::Uint8(m.mode.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.layout != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::BYTE,
                 value: Value::Uint8(m.layout),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::WATCHFACE_SETTINGS,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/weather_alert.rs
+++ b/rustyfit/src/profile/mesgdef/weather_alert.rs
@@ -59,6 +59,15 @@ impl WeatherAlert {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (!self.report_id.is_empty()) as usize
+            + (self.issue_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.expire_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.severity != typedef::WeatherSeverity(u8::MAX)) as usize
+            + (self.r#type != typedef::WeatherSevereType(u8::MAX)) as usize
+    }
 }
 
 impl Default for WeatherAlert {
@@ -70,112 +79,92 @@ impl Default for WeatherAlert {
 impl From<&Message> for WeatherAlert {
     /// from creates new WeatherAlert struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [31, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.report_id = field.value.as_str().to_owned(),
+                1 => v.issue_time = typedef::DateTime(field.value.as_u32()),
+                2 => v.expire_time = typedef::DateTime(field.value.as_u32()),
+                3 => v.severity = typedef::WeatherSeverity(field.value.as_u8()),
+                4 => v.r#type = typedef::WeatherSevereType(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            report_id: vals[0].as_str().to_owned(),
-            issue_time: typedef::DateTime(vals[1].as_u32()),
-            expire_time: typedef::DateTime(vals[2].as_u32()),
-            severity: typedef::WeatherSeverity(vals[3].as_u8()),
-            r#type: typedef::WeatherSevereType(vals[4].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<WeatherAlert> for Message {
     fn from(m: WeatherAlert) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 6];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.report_id.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.report_id),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.issue_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.issue_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.expire_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.expire_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.severity != typedef::WeatherSeverity(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::WEATHER_SEVERITY,
                 value: Value::Uint8(m.severity.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.r#type != typedef::WeatherSevereType(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::WEATHER_SEVERE_TYPE,
                 value: Value::Uint8(m.r#type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::WEATHER_ALERT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -137,6 +137,25 @@ impl WeatherConditions {
         self.wind_speed = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.weather_report != typedef::WeatherReport(u8::MAX)) as usize
+            + (self.temperature != i8::MAX) as usize
+            + (self.condition != typedef::WeatherStatus(u8::MAX)) as usize
+            + (self.wind_direction != u16::MAX) as usize
+            + (self.wind_speed != u16::MAX) as usize
+            + (self.precipitation_probability != u8::MAX) as usize
+            + (self.temperature_feels_like != i8::MAX) as usize
+            + (self.relative_humidity != u8::MAX) as usize
+            + (!self.location.is_empty()) as usize
+            + (self.observed_at_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.observed_location_lat != i32::MAX) as usize
+            + (self.observed_location_long != i32::MAX) as usize
+            + (self.day_of_week != typedef::DayOfWeek(u8::MAX)) as usize
+            + (self.high_temperature != i8::MAX) as usize
+            + (self.low_temperature != i8::MAX) as usize
+    }
 }
 
 impl Default for WeatherConditions {
@@ -148,212 +167,182 @@ impl Default for WeatherConditions {
 impl From<&Message> for WeatherConditions {
     /// from creates new WeatherConditions struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [32767, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.weather_report = typedef::WeatherReport(field.value.as_u8()),
+                1 => v.temperature = field.value.as_i8(),
+                2 => v.condition = typedef::WeatherStatus(field.value.as_u8()),
+                3 => v.wind_direction = field.value.as_u16(),
+                4 => v.wind_speed = field.value.as_u16(),
+                5 => v.precipitation_probability = field.value.as_u8(),
+                6 => v.temperature_feels_like = field.value.as_i8(),
+                7 => v.relative_humidity = field.value.as_u8(),
+                8 => v.location = field.value.as_str().to_owned(),
+                9 => v.observed_at_time = typedef::DateTime(field.value.as_u32()),
+                10 => v.observed_location_lat = field.value.as_i32(),
+                11 => v.observed_location_long = field.value.as_i32(),
+                12 => v.day_of_week = typedef::DayOfWeek(field.value.as_u8()),
+                13 => v.high_temperature = field.value.as_i8(),
+                14 => v.low_temperature = field.value.as_i8(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            weather_report: typedef::WeatherReport(vals[0].as_u8()),
-            temperature: vals[1].as_i8(),
-            condition: typedef::WeatherStatus(vals[2].as_u8()),
-            wind_direction: vals[3].as_u16(),
-            wind_speed: vals[4].as_u16(),
-            precipitation_probability: vals[5].as_u8(),
-            temperature_feels_like: vals[6].as_i8(),
-            relative_humidity: vals[7].as_u8(),
-            location: vals[8].as_str().to_owned(),
-            observed_at_time: typedef::DateTime(vals[9].as_u32()),
-            observed_location_lat: vals[10].as_i32(),
-            observed_location_long: vals[11].as_i32(),
-            day_of_week: typedef::DayOfWeek(vals[12].as_u8()),
-            high_temperature: vals[13].as_i8(),
-            low_temperature: vals[14].as_i8(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<WeatherConditions> for Message {
     fn from(m: WeatherConditions) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 16];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weather_report != typedef::WeatherReport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::WEATHER_REPORT,
                 value: Value::Uint8(m.weather_report.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.condition != typedef::WeatherStatus(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::WEATHER_STATUS,
                 value: Value::Uint8(m.condition.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.wind_direction != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.wind_direction),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.wind_speed != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.wind_speed),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.precipitation_probability != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.precipitation_probability),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.temperature_feels_like != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.temperature_feels_like),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.relative_humidity != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.relative_humidity),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.location.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.location),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.observed_at_time != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.observed_at_time.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.observed_location_lat != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.observed_location_lat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.observed_location_long != i32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::SINT32,
                 value: Value::Int32(m.observed_location_long),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.day_of_week != typedef::DayOfWeek(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::DAY_OF_WEEK,
                 value: Value::Uint8(m.day_of_week.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.high_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.high_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.low_temperature != i8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::SINT8,
                 value: Value::Int8(m.low_temperature),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::WEATHER_CONDITIONS,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/weight_scale.rs
+++ b/rustyfit/src/profile/mesgdef/weight_scale.rs
@@ -267,6 +267,23 @@ impl WeightScale {
         self.bmi = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.weight != typedef::Weight(u16::MAX)) as usize
+            + (self.percent_fat != u16::MAX) as usize
+            + (self.percent_hydration != u16::MAX) as usize
+            + (self.visceral_fat_mass != u16::MAX) as usize
+            + (self.bone_mass != u16::MAX) as usize
+            + (self.muscle_mass != u16::MAX) as usize
+            + (self.basal_met != u16::MAX) as usize
+            + (self.physique_rating != u8::MAX) as usize
+            + (self.active_met != u16::MAX) as usize
+            + (self.metabolic_age != u8::MAX) as usize
+            + (self.visceral_fat_rating != u8::MAX) as usize
+            + (self.user_profile_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.bmi != u16::MAX) as usize
+    }
 }
 
 impl Default for WeightScale {
@@ -278,192 +295,164 @@ impl Default for WeightScale {
 impl From<&Message> for WeightScale {
     /// from creates new WeightScale struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 254];
-
         const KNOWN_NUMS: [u64; 4] = [16319, 0, 0, 2305843009213693952];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                253 => v.timestamp = typedef::DateTime(field.value.as_u32()),
+                0 => v.weight = typedef::Weight(field.value.as_u16()),
+                1 => v.percent_fat = field.value.as_u16(),
+                2 => v.percent_hydration = field.value.as_u16(),
+                3 => v.visceral_fat_mass = field.value.as_u16(),
+                4 => v.bone_mass = field.value.as_u16(),
+                5 => v.muscle_mass = field.value.as_u16(),
+                7 => v.basal_met = field.value.as_u16(),
+                8 => v.physique_rating = field.value.as_u8(),
+                9 => v.active_met = field.value.as_u16(),
+                10 => v.metabolic_age = field.value.as_u8(),
+                11 => v.visceral_fat_rating = field.value.as_u8(),
+                12 => v.user_profile_index = typedef::MessageIndex(field.value.as_u16()),
+                13 => v.bmi = field.value.as_u16(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            timestamp: typedef::DateTime(vals[253].as_u32()),
-            weight: typedef::Weight(vals[0].as_u16()),
-            percent_fat: vals[1].as_u16(),
-            percent_hydration: vals[2].as_u16(),
-            visceral_fat_mass: vals[3].as_u16(),
-            bone_mass: vals[4].as_u16(),
-            muscle_mass: vals[5].as_u16(),
-            basal_met: vals[7].as_u16(),
-            physique_rating: vals[8].as_u8(),
-            active_met: vals[9].as_u16(),
-            metabolic_age: vals[10].as_u8(),
-            visceral_fat_rating: vals[11].as_u8(),
-            user_profile_index: typedef::MessageIndex(vals[12].as_u16()),
-            bmi: vals[13].as_u16(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<WeightScale> for Message {
     fn from(m: WeightScale) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 14];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.timestamp != typedef::DateTime(u32::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
                 value: Value::Uint32(m.timestamp.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weight != typedef::Weight(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::WEIGHT,
                 value: Value::Uint16(m.weight.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.percent_fat != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.percent_fat),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.percent_hydration != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.percent_hydration),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.visceral_fat_mass != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.visceral_fat_mass),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bone_mass != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.bone_mass),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.muscle_mass != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.muscle_mass),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.basal_met != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.basal_met),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.physique_rating != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.physique_rating),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.active_met != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.active_met),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.metabolic_age != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.metabolic_age),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.visceral_fat_rating != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.visceral_fat_rating),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.user_profile_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.user_profile_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.bmi != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.bmi),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::WEIGHT_SCALE,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/workout.rs
+++ b/rustyfit/src/profile/mesgdef/workout.rs
@@ -89,6 +89,18 @@ impl Workout {
         self.pool_length = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.capabilities != typedef::WorkoutCapabilities(u32::MIN)) as usize
+            + (self.num_valid_steps != u16::MAX) as usize
+            + (!self.wkt_name.is_empty()) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.pool_length != u16::MAX) as usize
+            + (self.pool_length_unit != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (!self.wkt_description.is_empty()) as usize
+    }
 }
 
 impl Default for Workout {
@@ -100,142 +112,119 @@ impl Default for Workout {
 impl From<&Message> for Workout {
     /// from creates new Workout struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [182640, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                4 => v.sport = typedef::Sport(field.value.as_u8()),
+                5 => v.capabilities = typedef::WorkoutCapabilities(field.value.as_u32z()),
+                6 => v.num_valid_steps = field.value.as_u16(),
+                8 => v.wkt_name = field.value.as_str().to_owned(),
+                11 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                14 => v.pool_length = field.value.as_u16(),
+                15 => v.pool_length_unit = typedef::DisplayMeasure(field.value.as_u8()),
+                17 => v.wkt_description = field.value.as_str().to_owned(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            sport: typedef::Sport(vals[4].as_u8()),
-            capabilities: typedef::WorkoutCapabilities(vals[5].as_u32z()),
-            num_valid_steps: vals[6].as_u16(),
-            wkt_name: vals[8].as_str().to_owned(),
-            sub_sport: typedef::SubSport(vals[11].as_u8()),
-            pool_length: vals[14].as_u16(),
-            pool_length_unit: typedef::DisplayMeasure(vals[15].as_u8()),
-            wkt_description: vals[17].as_str().to_owned(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<Workout> for Message {
     fn from(m: Workout) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 9];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.capabilities != typedef::WorkoutCapabilities(u32::MIN) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::WORKOUT_CAPABILITIES,
                 value: Value::Uint32(m.capabilities.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.num_valid_steps != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.num_valid_steps),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.wkt_name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.wkt_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pool_length != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.pool_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pool_length_unit != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.pool_length_unit.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.wkt_description.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.wkt_description),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::WORKOUT,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/workout_session.rs
+++ b/rustyfit/src/profile/mesgdef/workout_session.rs
@@ -76,6 +76,16 @@ impl WorkoutSession {
         self.pool_length = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.num_valid_steps != u16::MAX) as usize
+            + (self.first_step_index != u16::MAX) as usize
+            + (self.pool_length != u16::MAX) as usize
+            + (self.pool_length_unit != typedef::DisplayMeasure(u8::MAX)) as usize
+    }
 }
 
 impl Default for WorkoutSession {
@@ -87,122 +97,101 @@ impl Default for WorkoutSession {
 impl From<&Message> for WorkoutSession {
     /// from creates new WorkoutSession struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [63, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.sport = typedef::Sport(field.value.as_u8()),
+                1 => v.sub_sport = typedef::SubSport(field.value.as_u8()),
+                2 => v.num_valid_steps = field.value.as_u16(),
+                3 => v.first_step_index = field.value.as_u16(),
+                4 => v.pool_length = field.value.as_u16(),
+                5 => v.pool_length_unit = typedef::DisplayMeasure(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            sport: typedef::Sport(vals[0].as_u8()),
-            sub_sport: typedef::SubSport(vals[1].as_u8()),
-            num_valid_steps: vals[2].as_u16(),
-            first_step_index: vals[3].as_u16(),
-            pool_length: vals[4].as_u16(),
-            pool_length_unit: typedef::DisplayMeasure(vals[5].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<WorkoutSession> for Message {
     fn from(m: WorkoutSession) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 7];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sport != typedef::Sport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPORT,
                 value: Value::Uint8(m.sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.sub_sport != typedef::SubSport(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SUB_SPORT,
                 value: Value::Uint8(m.sub_sport.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.num_valid_steps != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.num_valid_steps),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.first_step_index != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.first_step_index),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pool_length != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.pool_length),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pool_length_unit != typedef::DisplayMeasure(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::DISPLAY_MEASURE,
                 value: Value::Uint8(m.pool_length_unit.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::WORKOUT_SESSION,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/workout_step.rs
+++ b/rustyfit/src/profile/mesgdef/workout_step.rs
@@ -126,6 +126,28 @@ impl WorkoutStep {
         self.exercise_weight = unscaled as u16;
         self
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (!self.wkt_step_name.is_empty()) as usize
+            + (self.duration_type != typedef::WktStepDuration(u8::MAX)) as usize
+            + (self.duration_value != u32::MAX) as usize
+            + (self.target_type != typedef::WktStepTarget(u8::MAX)) as usize
+            + (self.target_value != u32::MAX) as usize
+            + (self.custom_target_value_low != u32::MAX) as usize
+            + (self.custom_target_value_high != u32::MAX) as usize
+            + (self.intensity != typedef::Intensity(u8::MAX)) as usize
+            + (!self.notes.is_empty()) as usize
+            + (self.equipment != typedef::WorkoutEquipment(u8::MAX)) as usize
+            + (self.exercise_category != typedef::ExerciseCategory(u16::MAX)) as usize
+            + (self.exercise_name != u16::MAX) as usize
+            + (self.exercise_weight != u16::MAX) as usize
+            + (self.weight_display_unit != typedef::FitBaseUnit(u16::MAX)) as usize
+            + (self.secondary_target_type != typedef::WktStepTarget(u8::MAX)) as usize
+            + (self.secondary_target_value != u32::MAX) as usize
+            + (self.secondary_custom_target_value_low != u32::MAX) as usize
+            + (self.secondary_custom_target_value_high != u32::MAX) as usize
+    }
 }
 
 impl Default for WorkoutStep {
@@ -137,242 +159,209 @@ impl Default for WorkoutStep {
 impl From<&Message> for WorkoutStep {
     /// from creates new WorkoutStep struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 255];
-
         const KNOWN_NUMS: [u64; 4] = [7880703, 0, 0, 4611686018427387904];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                254 => v.message_index = typedef::MessageIndex(field.value.as_u16()),
+                0 => v.wkt_step_name = field.value.as_str().to_owned(),
+                1 => v.duration_type = typedef::WktStepDuration(field.value.as_u8()),
+                2 => v.duration_value = field.value.as_u32(),
+                3 => v.target_type = typedef::WktStepTarget(field.value.as_u8()),
+                4 => v.target_value = field.value.as_u32(),
+                5 => v.custom_target_value_low = field.value.as_u32(),
+                6 => v.custom_target_value_high = field.value.as_u32(),
+                7 => v.intensity = typedef::Intensity(field.value.as_u8()),
+                8 => v.notes = field.value.as_str().to_owned(),
+                9 => v.equipment = typedef::WorkoutEquipment(field.value.as_u8()),
+                10 => v.exercise_category = typedef::ExerciseCategory(field.value.as_u16()),
+                11 => v.exercise_name = field.value.as_u16(),
+                12 => v.exercise_weight = field.value.as_u16(),
+                13 => v.weight_display_unit = typedef::FitBaseUnit(field.value.as_u16()),
+                19 => v.secondary_target_type = typedef::WktStepTarget(field.value.as_u8()),
+                20 => v.secondary_target_value = field.value.as_u32(),
+                21 => v.secondary_custom_target_value_low = field.value.as_u32(),
+                22 => v.secondary_custom_target_value_high = field.value.as_u32(),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            message_index: typedef::MessageIndex(vals[254].as_u16()),
-            wkt_step_name: vals[0].as_str().to_owned(),
-            duration_type: typedef::WktStepDuration(vals[1].as_u8()),
-            duration_value: vals[2].as_u32(),
-            target_type: typedef::WktStepTarget(vals[3].as_u8()),
-            target_value: vals[4].as_u32(),
-            custom_target_value_low: vals[5].as_u32(),
-            custom_target_value_high: vals[6].as_u32(),
-            intensity: typedef::Intensity(vals[7].as_u8()),
-            notes: vals[8].as_str().to_owned(),
-            equipment: typedef::WorkoutEquipment(vals[9].as_u8()),
-            exercise_category: typedef::ExerciseCategory(vals[10].as_u16()),
-            exercise_name: vals[11].as_u16(),
-            exercise_weight: vals[12].as_u16(),
-            weight_display_unit: typedef::FitBaseUnit(vals[13].as_u16()),
-            secondary_target_type: typedef::WktStepTarget(vals[19].as_u8()),
-            secondary_target_value: vals[20].as_u32(),
-            secondary_custom_target_value_low: vals[21].as_u32(),
-            secondary_custom_target_value_high: vals[22].as_u32(),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<WorkoutStep> for Message {
     fn from(m: WorkoutStep) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 19];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.message_index != typedef::MessageIndex(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
                 value: Value::Uint16(m.message_index.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.wkt_step_name.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.wkt_step_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.duration_type != typedef::WktStepDuration(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::WKT_STEP_DURATION,
                 value: Value::Uint8(m.duration_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.duration_value != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.duration_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.target_type != typedef::WktStepTarget(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::WKT_STEP_TARGET,
                 value: Value::Uint8(m.target_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.target_value != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.target_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.custom_target_value_low != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.custom_target_value_low),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.custom_target_value_high != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.custom_target_value_high),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.intensity != typedef::Intensity(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::INTENSITY,
                 value: Value::Uint8(m.intensity.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if !m.notes.is_empty() {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::STRING,
                 value: Value::String(m.notes),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.equipment != typedef::WorkoutEquipment(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::WORKOUT_EQUIPMENT,
                 value: Value::Uint8(m.equipment.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.exercise_category != typedef::ExerciseCategory(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::EXERCISE_CATEGORY,
                 value: Value::Uint16(m.exercise_category.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.exercise_name != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.exercise_name),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.exercise_weight != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.exercise_weight),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.weight_display_unit != typedef::FitBaseUnit(u16::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::FIT_BASE_UNIT,
                 value: Value::Uint16(m.weight_display_unit.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.secondary_target_type != typedef::WktStepTarget(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::WKT_STEP_TARGET,
                 value: Value::Uint8(m.secondary_target_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.secondary_target_value != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 20,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.secondary_target_value),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.secondary_custom_target_value_low != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.secondary_custom_target_value_low),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.secondary_custom_target_value_high != u32::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::UINT32,
                 value: Value::Uint32(m.secondary_custom_target_value_high),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::WORKOUT_STEP,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }

--- a/rustyfit/src/profile/mesgdef/zones_target.rs
+++ b/rustyfit/src/profile/mesgdef/zones_target.rs
@@ -48,6 +48,14 @@ impl ZonesTarget {
             developer_fields: Vec::new(),
         }
     }
+
+    fn count_valid_fields(&self) -> usize {
+        (self.max_heart_rate != u8::MAX) as usize
+            + (self.threshold_heart_rate != u8::MAX) as usize
+            + (self.functional_threshold_power != u16::MAX) as usize
+            + (self.hr_calc_type != typedef::HrZoneCalc(u8::MAX)) as usize
+            + (self.pwr_calc_type != typedef::PwrZoneCalc(u8::MAX)) as usize
+    }
 }
 
 impl Default for ZonesTarget {
@@ -59,102 +67,83 @@ impl Default for ZonesTarget {
 impl From<&Message> for ZonesTarget {
     /// from creates new ZonesTarget struct based on given mesg.
     fn from(mesg: &Message) -> Self {
-        let mut vals = [const { &Value::Invalid }; 8];
-
         const KNOWN_NUMS: [u64; 4] = [174, 0, 0, 0];
         let mut n = 0u64;
         for field in &mesg.fields {
             n += (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 ^ 1
         }
-        let mut unknown_fields = Vec::<Field>::with_capacity(n as usize);
+
+        let mut v = Self::new();
+        v.unknown_fields = Vec::<Field>::with_capacity(n as usize);
+        v.developer_fields = mesg.developer_fields.clone();
 
         for field in &mesg.fields {
-            if (KNOWN_NUMS[field.num as usize >> 6] >> (field.num & 63)) & 1 == 0 {
-                unknown_fields.push(field.clone());
-                continue;
-            }
-            vals[field.num as usize] = &field.value;
+            match field.num {
+                1 => v.max_heart_rate = field.value.as_u8(),
+                2 => v.threshold_heart_rate = field.value.as_u8(),
+                3 => v.functional_threshold_power = field.value.as_u16(),
+                5 => v.hr_calc_type = typedef::HrZoneCalc(field.value.as_u8()),
+                7 => v.pwr_calc_type = typedef::PwrZoneCalc(field.value.as_u8()),
+                _ => v.unknown_fields.push(field.clone()),
+            };
         }
 
-        Self {
-            max_heart_rate: vals[1].as_u8(),
-            threshold_heart_rate: vals[2].as_u8(),
-            functional_threshold_power: vals[3].as_u16(),
-            hr_calc_type: typedef::HrZoneCalc(vals[5].as_u8()),
-            pwr_calc_type: typedef::PwrZoneCalc(vals[7].as_u8()),
-            unknown_fields,
-            developer_fields: mesg.developer_fields.clone(),
-        }
+        v
     }
 }
 
 impl From<ZonesTarget> for Message {
     fn from(m: ZonesTarget) -> Self {
-        let mut arr = [const {
-            Field {
-                num: 0,
-                profile_type: ProfileType(0),
-                value: Value::Invalid,
-                is_expanded: false,
-            }
-        }; 5];
-        let mut len = 0usize;
+        let mut fields =
+            Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
         if m.max_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.max_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.threshold_heart_rate != u8::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::UINT8,
                 value: Value::Uint8(m.threshold_heart_rate),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.functional_threshold_power != u16::MAX {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::UINT16,
                 value: Value::Uint16(m.functional_threshold_power),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.hr_calc_type != typedef::HrZoneCalc(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::HR_ZONE_CALC,
                 value: Value::Uint8(m.hr_calc_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
         if m.pwr_calc_type != typedef::PwrZoneCalc(u8::MAX) {
-            arr[len] = Field {
+            fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::PWR_ZONE_CALC,
                 value: Value::Uint8(m.pwr_calc_type.0),
                 is_expanded: false,
-            };
-            len += 1;
-        }
+            });
+        };
+
+        fields.extend_from_slice(&m.unknown_fields);
 
         Self {
             header: 0,
             num: typedef::MesgNum::ZONES_TARGET,
-            fields: {
-                let mut fields = Vec::<Field>::with_capacity(len + m.unknown_fields.len());
-                fields.extend_from_slice(&arr[..len]);
-                fields.extend_from_slice(&m.unknown_fields);
-                fields
-            },
+            fields,
             developer_fields: m.developer_fields,
         }
     }


### PR DESCRIPTION
Previous `mesgdef` implementation uses a lot of stack memory in the lens of embedded development, the calculation from variables on 64-bit machine is estimated as follows:
### From\<&Message\> for Record
```rs
------------------------ BEFORE -----------------------
vals                = 2032 bytes (8 * 254)
state               = 14 bytes
n                   = 8 bytes
unknown_fields      = 24 bytes
size_of::<Record>   = 352 bytes
            TOTAL   = 2430 bytes

------------------------ AFTER ------------------------
n                   = 8 bytes
size_of::<Record>   = 352 bytes
            TOTAL   = 360 bytes
```

### From\<Record\> for Message
```rs
------------------------ BEFORE -----------------------
arr                 = 3360 bytes (40 * 84 fields)
len                 = 8 bytes
state               = 14 bytes
Message             = 56 bytes
            TOTAL   = 3438 bytes

------------------------ AFTER ------------------------
Message             = 56 bytes
            TOTAL   = 56 bytes

```


That's for `Record` which has 84 fields, the number will be higher for `Session` with 158 fields:
```rs
arr                 = 6320 bytes (40 * 158 fields)
state               = 24 bytes
size_of::<Session>  = 896 bytes
```

This PR removes the intermediate variables used for the conversion, that was originally came from optimization result in the Go code but it turned out not working well in Rust. 

By improving memory efficiency, `mesgdef` can potentially be used on MCU's environment. 

This also improve compute performance as shown in this benchmark:

### Benchmark (criterion)
```python
mesgdef From<&Message>  time:   [153.83 ns 155.53 ns 157.55 ns]
                        change: [−34.222% −33.050% −31.930%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

mesgdef From<Record>    time:   [169.00 ns 171.65 ns 174.22 ns]
                        change: [−64.997% −64.219% −63.288%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
```
