### PR TITLE
refactor: omit data_type from proto::FileHeader and update DecoderEvent

### DIFF
--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -135,8 +135,7 @@ impl Decoder {
             reader,
             decoder: self,
             state: State::FileHeader,
-            file_header: FileHeader::default(),
-            crc: 0,
+            data_size: 0,
         }
     }
 
@@ -247,7 +246,6 @@ impl Decoder {
             protocol_version: ProtocolVersion(self.buf[1]),
             profile_version: u16::from_le_bytes([self.buf[2], self.buf[3]]),
             data_size: u32::from_le_bytes(self.buf[4..8].try_into().unwrap()),
-            data_type: FileHeader::DATA_TYPE,
             crc,
         }))
     }
@@ -786,13 +784,13 @@ impl Default for Builder {
 #[derive(Debug)]
 pub enum Event<'a> {
     /// Returned when the `StreamDecoder` encounter a `FileHeader`.
-    FileHeader(&'a FileHeader),
+    FileHeader(FileHeader),
     /// Returned when the `StreamDecoder` encounter a `MessageDefinition`.
     MessageDefinition(&'a MessageDefinition),
     /// Returned when the `StreamDecoder` encounter a `Message`.
     Message(&'a Message),
     /// Returned when the `StreamDecoder` encounter a `File`'s CRC.
-    Crc(&'a u16),
+    Crc(u16),
 }
 
 enum State {
@@ -806,8 +804,7 @@ pub struct Stream<'a, R> {
     reader: R,
     decoder: &'a mut Decoder,
     state: State,
-    file_header: FileHeader,
-    crc: u16,
+    data_size: u32,
 }
 
 impl<'a, R: Read> Stream<'a, R> {
@@ -821,17 +818,17 @@ impl<'a, R: Read> Stream<'a, R> {
 
                     let result = self.decoder.decode_file_header(&mut self.reader);
                     self.decoder.options.checksum = checksum; // restore checksum
-                    self.file_header = match result? {
-                        Some(file_header) => file_header,
+                    self.data_size = match result? {
+                        Some(file_header) => file_header.data_size,
                         None => break,
                     };
 
                     self.state = State::Message;
                 }
                 State::Message => {
-                    while self.decoder.cur < self.file_header.data_size {
+                    while self.decoder.cur < self.data_size {
                         let buf = &mut self.decoder.buf[..256];
-                        let remaining = self.file_header.data_size - self.decoder.cur;
+                        let remaining = self.data_size - self.decoder.cur;
                         let n = (remaining as usize).min(buf.len());
                         self.reader.read_exact(&mut buf[..n])?;
                         self.decoder.cur += n as u32;
@@ -875,12 +872,13 @@ impl<'a, R: Read> StreamingIterator for Stream<'a, R> {
     fn next(&mut self) -> Option<Result<Event<'_>, Error<R::Error>>> {
         match self.state {
             State::FileHeader => {
-                self.file_header = match self.decoder.decode_file_header(&mut self.reader) {
+                let file_header = match self.decoder.decode_file_header(&mut self.reader) {
                     Ok(file_header) => file_header,
                     Err(err) => return Some(Err(err)),
                 }?;
+                self.data_size = file_header.data_size;
                 self.state = State::Message;
-                Some(Ok(Event::FileHeader(&self.file_header)))
+                Some(Ok(Event::FileHeader(file_header)))
             }
             State::Message => {
                 if let Err(err) = self.decoder.read_exact_inc(&mut self.reader, 1) {
@@ -934,20 +932,20 @@ impl<'a, R: Read> StreamingIterator for Stream<'a, R> {
                     return Some(Err(err));
                 }
 
-                if self.decoder.cur >= self.file_header.data_size {
+                if self.decoder.cur >= self.data_size {
                     self.state = State::Crc;
                 }
 
                 Some(Ok(Event::Message(&self.decoder.mesg)))
             }
             State::Crc => {
-                self.crc = match self.decoder.decode_crc(&mut self.reader) {
+                let crc = match self.decoder.decode_crc(&mut self.reader) {
                     Ok(crc) => crc,
                     Err(err) => return Some(Err(err)),
                 };
                 self.decoder.reset();
                 self.state = State::FileHeader;
-                Some(Ok(Event::Crc(&self.crc)))
+                Some(Ok(Event::Crc(crc)))
             }
         }
     }
@@ -985,7 +983,6 @@ mod tests {
             protocol_version: ProtocolVersion::V2,
             profile_version: 2132,
             data_size: 642262,
-            data_type: FileHeader::DATA_TYPE,
             crc: 12856,
         };
 

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -196,8 +196,6 @@ impl Encoder {
             file_header.profile_version = PROFILE_VERSION;
         }
 
-        file_header.data_type = FileHeader::DATA_TYPE;
-
         let n = write_file_header(&mut self.buf, file_header);
 
         writer.write_all(&self.buf[..n])?;
@@ -703,7 +701,6 @@ impl<'a, W: Write + Seek> Stream<'a, W> {
             protocol_version,
             profile_version: PROFILE_VERSION,
             data_size: self.encoder.data_size,
-            data_type: FileHeader::DATA_TYPE,
             crc: 0, // calculated
         };
 
@@ -1200,8 +1197,8 @@ mod tests {
             protocol_version: ProtocolVersion::V1, // [16]
             profile_version: 21205,                // [212, 82]
             data_size: 0,                          // [1, 0, 0, 0] updated
-            data_type: FileHeader::DATA_TYPE,      // [46, 70, 73, 84]
-            crc: 0,                                // [83, 147] updated
+            // data_type: ".FIT" / [46, 70, 73, 84]
+            crc: 0, // [83, 147] updated
         };
 
         enc.update_file_header(&mut ws, &mut file_header).unwrap();

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -30,8 +30,10 @@ pub struct FileHeader {
     pub profile_version: u16,
     /// The size of the messages in bytes (this field will be automatically updated by the encoder)
     pub data_size: u32,
-    /// String marker `.FIT`. Any user-provided value is automatically overwritten with `FileHeader::DATA_TYPE` during encoding.
-    pub data_type: &'static str,
+    // ----
+    // This section contains omitted `data_type` field since the value is always constant ".FIT".
+    // During encoding, the value will be automatically filled with `FileHeader::DATA_TYPE`.
+    // ----
     /// Cyclic Redundancy Check 16-bit value to ensure the integrity of the file header.
     /// (this field will be automatically updated by the encoder)
     pub crc: u16,


### PR DESCRIPTION
Field `data_type` is always constant value ".FIT", so  there is no need to define it, reducing struct's size from 32 to 12 bytes.

Also, since FileHeader and CRC derive Copy trait and it's small enough (12 byte and 2 bytes respectively) we don't need to return it as reference in `DecoderEvent`, return as value is more efficient.