### PR TITLE
fix: semconv returns incorrect value

### DIFF
--- a/rustyfit/src/semconv.rs
+++ b/rustyfit/src/semconv.rs
@@ -1,4 +1,4 @@
-const PI_RADIANS: f64 = (1 << 31) as f64;
+const PI_RADIANS: f64 = (1u32 << 31) as f64;
 const CONVERSION_FACTOR: f64 = 180.0 / PI_RADIANS;
 
 /// Converts semicircles to degrees. It returns f64 invalid when value is invalid.
@@ -15,4 +15,27 @@ pub fn to_semicircles(degrees: f64) -> i32 {
         return i32::MAX;
     }
     (degrees / CONVERSION_FACTOR) as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::semconv;
+
+    #[test]
+    fn test_to_degrees() {
+        let lat: i32 = 424480360;
+        assert_eq!(semconv::to_degrees(lat), 35.579532757401466);
+
+        let long: i32 = -940295581;
+        assert_eq!(semconv::to_degrees(long), -78.81466512568295);
+    }
+
+    #[test]
+    fn test_to_semicircles() {
+        let lat: f64 = 35.579532757401466;
+        assert_eq!(semconv::to_semicircles(lat), 424480360);
+
+        let long: f64 = -78.81466512568295;
+        assert_eq!(semconv::to_semicircles(long), -940295581);
+    }
 }


### PR DESCRIPTION
I didn't know that literal integer in rust is inferred as i32 when what I actually want is u32. And it silently overflows to negative value. `Clippy` doesn't return warning or error either. I should have added test to this package, but I didn't.