### PR TITLE
refactor: convertions methods now return Option<T>

### DIFF
--- a/fitgen/internal/profile/mesgdef/mesgdef.tmpl
+++ b/fitgen/internal/profile/mesgdef/mesgdef.tmpl
@@ -82,8 +82,8 @@ impl {{ .Name }} {
 
     {{ range .Fields -}}
     {{ if eq .Units "semicircles" }}
-        /// Returns `{{ .Name }}` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-        pub fn {{ .Name }}_degrees(&self) -> f64 {
+        /// Returns `{{ .Name }}` in degrees instead of semicircles. It returns `None` when value is valid.
+        pub fn {{ .Name }}_degrees(&self) -> Option<f64> {
             semconv::to_degrees(self.{{ .Name }})
         }
     {{ end }}
@@ -91,27 +91,30 @@ impl {{ .Name }} {
 
     {{ range .Fields -}}
     {{ if not (and (eq .Scale 1.0) (eq .Offset 0.0)) -}}
-        /// Returns `{{ .Name }}` in its scaled value. It returns invalid f64 when value is valid.
+        /// Returns `{{ .Name }}` in its scaled value. It returns `None` when value is valid.
         {{ if not .Array -}}
-        pub fn {{ .Name }}_scaled(&self) -> f64 {
+        pub fn {{ .Name }}_scaled(&self) -> Option<f64> {
             if self.{{ .Name }} == {{ .InvalidValue }} {
-                return f64::from_bits(u64::MAX);
+                return None;
             }
-            self.{{ .Name0 }} as f64/{{ formatFloat .Scale }} - {{ formatFloat .Offset }}
+            Some(self.{{ .Name0 }} as f64/{{ formatFloat .Scale }} - {{ formatFloat .Offset }})
         }
         {{ else if eq .FixedArraySize 0 -}}
-        pub fn {{ .Name }}_scaled(&self) -> Vec<f64> {
+        pub fn {{ .Name }}_scaled(&self) -> Option<Vec<f64>> {
             if {{ .IfSelfEqualInvalid }} {
-                return Vec::new();
+                return None;
             }
             let mut v = Vec::with_capacity(self.{{ .Name }}.len());
             for &x in &self.{{ .Name }} {
                 v.push(x as f64/{{ formatFloat .Scale }} - {{ formatFloat .Offset }})
             }
-            v
+            Some(v)
         }
         {{ else -}}
-        pub fn {{ .Name }}_scaled(&self) -> [f64; {{ .FixedArraySize }}] {
+        pub fn {{ .Name }}_scaled(&self) -> Option<[f64; {{ .FixedArraySize }}]> {
+            if {{ .IfSelfEqualInvalid }} {
+                return None;
+            }
             let mut v = [f64::from_bits(u64::MAX); {{ .FixedArraySize }}];
             for (i, &x) in self.{{ .Name }}.iter().enumerate() {
                 if x == {{ .BaseType0Invalid }} {
@@ -119,7 +122,7 @@ impl {{ .Name }} {
                 }
                 v[i] = x as f64/{{ formatFloat .Scale }} - {{ formatFloat .Offset }};
             }
-            v
+            Some(v)
         }
         {{ end }}
 
@@ -135,12 +138,11 @@ impl {{ .Name }} {
             self
         }
         {{ else if eq .FixedArraySize 0 -}}
-        pub fn set_{{ .Name }}_scaled(&mut self, v: &Vec<f64>) -> &mut {{ $.Name }} {
+        pub fn set_{{ .Name }}_scaled(&mut self, v: &[f64]) -> &mut {{ $.Name }} {
+            self.{{ .Name }} = Vec::with_capacity(v.len());
             if v.is_empty() {
-                self.{{ .Name }} = Vec::new();
                 return self;
             }
-            self.{{ .Name }} = Vec::with_capacity(v.len());
             for &x in v{
                 let unscaled = (x + {{ formatFloat .Offset }}) * {{ formatFloat .Scale }};
                 if unscaled.is_nan() || unscaled.is_infinite() || unscaled > {{ .MaxValue }} as f64 {

--- a/rustyfit/src/profile/mesgdef/aad_accel_features.rs
+++ b/rustyfit/src/profile/mesgdef/aad_accel_features.rs
@@ -58,12 +58,12 @@ impl AadAccelFeatures {
         }
     }
 
-    /// Returns `time_above_threshold` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_above_threshold_scaled(&self) -> f64 {
+    /// Returns `time_above_threshold` in its scaled value. It returns `None` when value is valid.
+    pub fn time_above_threshold_scaled(&self) -> Option<f64> {
         if self.time_above_threshold == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.time_above_threshold as f64 / 25.0 - 0.0
+        Some(self.time_above_threshold as f64 / 25.0 - 0.0)
     }
 
     /// Set `time_above_threshold` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/activity.rs
+++ b/rustyfit/src/profile/mesgdef/activity.rs
@@ -63,12 +63,12 @@ impl Activity {
         }
     }
 
-    /// Returns `total_timer_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_timer_time_scaled(&self) -> f64 {
+    /// Returns `total_timer_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_timer_time_scaled(&self) -> Option<f64> {
         if self.total_timer_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_timer_time as f64 / 1000.0 - 0.0
+        Some(self.total_timer_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/ant_rx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_rx.rs
@@ -64,12 +64,12 @@ impl AntRx {
         }
     }
 
-    /// Returns `fractional_timestamp` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn fractional_timestamp_scaled(&self) -> f64 {
+    /// Returns `fractional_timestamp` in its scaled value. It returns `None` when value is valid.
+    pub fn fractional_timestamp_scaled(&self) -> Option<f64> {
         if self.fractional_timestamp == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.fractional_timestamp as f64 / 32768.0 - 0.0
+        Some(self.fractional_timestamp as f64 / 32768.0 - 0.0)
     }
 
     /// Set `fractional_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/ant_tx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_tx.rs
@@ -64,12 +64,12 @@ impl AntTx {
         }
     }
 
-    /// Returns `fractional_timestamp` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn fractional_timestamp_scaled(&self) -> f64 {
+    /// Returns `fractional_timestamp` in its scaled value. It returns `None` when value is valid.
+    pub fn fractional_timestamp_scaled(&self) -> Option<f64> {
         if self.fractional_timestamp == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.fractional_timestamp as f64 / 32768.0 - 0.0
+        Some(self.fractional_timestamp as f64 / 32768.0 - 0.0)
     }
 
     /// Set `fractional_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/aviation_attitude.rs
+++ b/rustyfit/src/profile/mesgdef/aviation_attitude.rs
@@ -87,25 +87,24 @@ impl AviationAttitude {
         }
     }
 
-    /// Returns `pitch` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn pitch_scaled(&self) -> Vec<f64> {
+    /// Returns `pitch` in its scaled value. It returns `None` when value is valid.
+    pub fn pitch_scaled(&self) -> Option<Vec<f64>> {
         if self.pitch.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.pitch.len());
         for &x in &self.pitch {
             v.push(x as f64 / 10430.38 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `pitch` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_pitch_scaled(&mut self, v: &Vec<f64>) -> &mut AviationAttitude {
+    pub fn set_pitch_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+        self.pitch = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.pitch = Vec::new();
             return self;
         }
-        self.pitch = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 10430.38;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
@@ -117,25 +116,24 @@ impl AviationAttitude {
         self
     }
 
-    /// Returns `roll` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn roll_scaled(&self) -> Vec<f64> {
+    /// Returns `roll` in its scaled value. It returns `None` when value is valid.
+    pub fn roll_scaled(&self) -> Option<Vec<f64>> {
         if self.roll.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.roll.len());
         for &x in &self.roll {
             v.push(x as f64 / 10430.38 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `roll` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_roll_scaled(&mut self, v: &Vec<f64>) -> &mut AviationAttitude {
+    pub fn set_roll_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+        self.roll = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.roll = Vec::new();
             return self;
         }
-        self.roll = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 10430.38;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
@@ -147,25 +145,24 @@ impl AviationAttitude {
         self
     }
 
-    /// Returns `accel_lateral` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn accel_lateral_scaled(&self) -> Vec<f64> {
+    /// Returns `accel_lateral` in its scaled value. It returns `None` when value is valid.
+    pub fn accel_lateral_scaled(&self) -> Option<Vec<f64>> {
         if self.accel_lateral.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.accel_lateral.len());
         for &x in &self.accel_lateral {
             v.push(x as f64 / 100.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `accel_lateral` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_lateral_scaled(&mut self, v: &Vec<f64>) -> &mut AviationAttitude {
+    pub fn set_accel_lateral_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+        self.accel_lateral = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.accel_lateral = Vec::new();
             return self;
         }
-        self.accel_lateral = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 100.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
@@ -177,25 +174,24 @@ impl AviationAttitude {
         self
     }
 
-    /// Returns `accel_normal` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn accel_normal_scaled(&self) -> Vec<f64> {
+    /// Returns `accel_normal` in its scaled value. It returns `None` when value is valid.
+    pub fn accel_normal_scaled(&self) -> Option<Vec<f64>> {
         if self.accel_normal.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.accel_normal.len());
         for &x in &self.accel_normal {
             v.push(x as f64 / 100.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `accel_normal` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_normal_scaled(&mut self, v: &Vec<f64>) -> &mut AviationAttitude {
+    pub fn set_accel_normal_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+        self.accel_normal = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.accel_normal = Vec::new();
             return self;
         }
-        self.accel_normal = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 100.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
@@ -207,25 +203,24 @@ impl AviationAttitude {
         self
     }
 
-    /// Returns `turn_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn turn_rate_scaled(&self) -> Vec<f64> {
+    /// Returns `turn_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn turn_rate_scaled(&self) -> Option<Vec<f64>> {
         if self.turn_rate.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.turn_rate.len());
         for &x in &self.turn_rate {
             v.push(x as f64 / 1024.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `turn_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_turn_rate_scaled(&mut self, v: &Vec<f64>) -> &mut AviationAttitude {
+    pub fn set_turn_rate_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+        self.turn_rate = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.turn_rate = Vec::new();
             return self;
         }
-        self.turn_rate = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1024.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
@@ -237,25 +232,24 @@ impl AviationAttitude {
         self
     }
 
-    /// Returns `track` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn track_scaled(&self) -> Vec<f64> {
+    /// Returns `track` in its scaled value. It returns `None` when value is valid.
+    pub fn track_scaled(&self) -> Option<Vec<f64>> {
         if self.track.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.track.len());
         for &x in &self.track {
             v.push(x as f64 / 10430.38 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `track` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_track_scaled(&mut self, v: &Vec<f64>) -> &mut AviationAttitude {
+    pub fn set_track_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+        self.track = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.track = Vec::new();
             return self;
         }
-        self.track = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 10430.38;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/bike_profile.rs
+++ b/rustyfit/src/profile/mesgdef/bike_profile.rs
@@ -178,12 +178,12 @@ impl BikeProfile {
         }
     }
 
-    /// Returns `odometer` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn odometer_scaled(&self) -> f64 {
+    /// Returns `odometer` in its scaled value. It returns `None` when value is valid.
+    pub fn odometer_scaled(&self) -> Option<f64> {
         if self.odometer == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.odometer as f64 / 100.0 - 0.0
+        Some(self.odometer as f64 / 100.0 - 0.0)
     }
 
     /// Set `odometer` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -197,12 +197,12 @@ impl BikeProfile {
         self
     }
 
-    /// Returns `custom_wheelsize` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn custom_wheelsize_scaled(&self) -> f64 {
+    /// Returns `custom_wheelsize` in its scaled value. It returns `None` when value is valid.
+    pub fn custom_wheelsize_scaled(&self) -> Option<f64> {
         if self.custom_wheelsize == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.custom_wheelsize as f64 / 1000.0 - 0.0
+        Some(self.custom_wheelsize as f64 / 1000.0 - 0.0)
     }
 
     /// Set `custom_wheelsize` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -216,12 +216,12 @@ impl BikeProfile {
         self
     }
 
-    /// Returns `auto_wheelsize` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn auto_wheelsize_scaled(&self) -> f64 {
+    /// Returns `auto_wheelsize` in its scaled value. It returns `None` when value is valid.
+    pub fn auto_wheelsize_scaled(&self) -> Option<f64> {
         if self.auto_wheelsize == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.auto_wheelsize as f64 / 1000.0 - 0.0
+        Some(self.auto_wheelsize as f64 / 1000.0 - 0.0)
     }
 
     /// Set `auto_wheelsize` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -235,12 +235,12 @@ impl BikeProfile {
         self
     }
 
-    /// Returns `bike_weight` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn bike_weight_scaled(&self) -> f64 {
+    /// Returns `bike_weight` in its scaled value. It returns `None` when value is valid.
+    pub fn bike_weight_scaled(&self) -> Option<f64> {
         if self.bike_weight == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.bike_weight as f64 / 10.0 - 0.0
+        Some(self.bike_weight as f64 / 10.0 - 0.0)
     }
 
     /// Set `bike_weight` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -254,12 +254,12 @@ impl BikeProfile {
         self
     }
 
-    /// Returns `power_cal_factor` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn power_cal_factor_scaled(&self) -> f64 {
+    /// Returns `power_cal_factor` in its scaled value. It returns `None` when value is valid.
+    pub fn power_cal_factor_scaled(&self) -> Option<f64> {
         if self.power_cal_factor == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.power_cal_factor as f64 / 10.0 - 0.0
+        Some(self.power_cal_factor as f64 / 10.0 - 0.0)
     }
 
     /// Set `power_cal_factor` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -273,12 +273,12 @@ impl BikeProfile {
         self
     }
 
-    /// Returns `crank_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn crank_length_scaled(&self) -> f64 {
+    /// Returns `crank_length` in its scaled value. It returns `None` when value is valid.
+    pub fn crank_length_scaled(&self) -> Option<f64> {
         if self.crank_length == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.crank_length as f64 / 2.0 - -110.0
+        Some(self.crank_length as f64 / 2.0 - -110.0)
     }
 
     /// Set `crank_length` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
@@ -42,12 +42,12 @@ impl ChronoShotData {
         }
     }
 
-    /// Returns `shot_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn shot_speed_scaled(&self) -> f64 {
+    /// Returns `shot_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn shot_speed_scaled(&self) -> Option<f64> {
         if self.shot_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.shot_speed as f64 / 1000.0 - 0.0
+        Some(self.shot_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `shot_speed` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
@@ -66,12 +66,12 @@ impl ChronoShotSession {
         }
     }
 
-    /// Returns `min_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_speed_scaled(&self) -> f64 {
+    /// Returns `min_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn min_speed_scaled(&self) -> Option<f64> {
         if self.min_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.min_speed as f64 / 1000.0 - 0.0
+        Some(self.min_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `min_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -85,12 +85,12 @@ impl ChronoShotSession {
         self
     }
 
-    /// Returns `max_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_speed_scaled(&self) -> f64 {
+    /// Returns `max_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_speed_scaled(&self) -> Option<f64> {
         if self.max_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_speed as f64 / 1000.0 - 0.0
+        Some(self.max_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -104,12 +104,12 @@ impl ChronoShotSession {
         self
     }
 
-    /// Returns `avg_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_speed_scaled(&self) -> f64 {
+    /// Returns `avg_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_speed_scaled(&self) -> Option<f64> {
         if self.avg_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -123,12 +123,12 @@ impl ChronoShotSession {
         self
     }
 
-    /// Returns `grain_weight` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn grain_weight_scaled(&self) -> f64 {
+    /// Returns `grain_weight` in its scaled value. It returns `None` when value is valid.
+    pub fn grain_weight_scaled(&self) -> Option<f64> {
         if self.grain_weight == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.grain_weight as f64 / 10.0 - 0.0
+        Some(self.grain_weight as f64 / 10.0 - 0.0)
     }
 
     /// Set `grain_weight` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -142,12 +142,12 @@ impl ChronoShotSession {
         self
     }
 
-    /// Returns `standard_deviation` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn standard_deviation_scaled(&self) -> f64 {
+    /// Returns `standard_deviation` in its scaled value. It returns `None` when value is valid.
+    pub fn standard_deviation_scaled(&self) -> Option<f64> {
         if self.standard_deviation == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.standard_deviation as f64 / 1000.0 - 0.0
+        Some(self.standard_deviation as f64 / 1000.0 - 0.0)
     }
 
     /// Set `standard_deviation` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/climb_pro.rs
+++ b/rustyfit/src/profile/mesgdef/climb_pro.rs
@@ -62,13 +62,13 @@ impl ClimbPro {
         }
     }
 
-    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_lat_degrees(&self) -> f64 {
+    /// Returns `position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_lat)
     }
 
-    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_long_degrees(&self) -> f64 {
+    /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
     }
 

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -67,22 +67,22 @@ impl CoursePoint {
         }
     }
 
-    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_lat_degrees(&self) -> f64 {
+    /// Returns `position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_lat)
     }
 
-    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_long_degrees(&self) -> f64 {
+    /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
     }
 
-    /// Returns `distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn distance_scaled(&self) -> f64 {
+    /// Returns `distance` in its scaled value. It returns `None` when value is valid.
+    pub fn distance_scaled(&self) -> Option<f64> {
         if self.distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.distance as f64 / 100.0 - 0.0
+        Some(self.distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `distance` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
@@ -50,12 +50,12 @@ impl DeviceAuxBatteryInfo {
         }
     }
 
-    /// Returns `battery_voltage` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn battery_voltage_scaled(&self) -> f64 {
+    /// Returns `battery_voltage` in its scaled value. It returns `None` when value is valid.
+    pub fn battery_voltage_scaled(&self) -> Option<f64> {
         if self.battery_voltage == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.battery_voltage as f64 / 256.0 - 0.0
+        Some(self.battery_voltage as f64 / 256.0 - 0.0)
     }
 
     /// Set `battery_voltage` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/device_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_info.rs
@@ -118,12 +118,12 @@ impl DeviceInfo {
         }
     }
 
-    /// Returns `software_version` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn software_version_scaled(&self) -> f64 {
+    /// Returns `software_version` in its scaled value. It returns `None` when value is valid.
+    pub fn software_version_scaled(&self) -> Option<f64> {
         if self.software_version == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.software_version as f64 / 100.0 - 0.0
+        Some(self.software_version as f64 / 100.0 - 0.0)
     }
 
     /// Set `software_version` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -137,12 +137,12 @@ impl DeviceInfo {
         self
     }
 
-    /// Returns `battery_voltage` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn battery_voltage_scaled(&self) -> f64 {
+    /// Returns `battery_voltage` in its scaled value. It returns `None` when value is valid.
+    pub fn battery_voltage_scaled(&self) -> Option<f64> {
         if self.battery_voltage == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.battery_voltage as f64 / 256.0 - 0.0
+        Some(self.battery_voltage as f64 / 256.0 - 0.0)
     }
 
     /// Set `battery_voltage` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/device_settings.rs
+++ b/rustyfit/src/profile/mesgdef/device_settings.rs
@@ -146,25 +146,24 @@ impl DeviceSettings {
         }
     }
 
-    /// Returns `time_zone_offset` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_zone_offset_scaled(&self) -> Vec<f64> {
+    /// Returns `time_zone_offset` in its scaled value. It returns `None` when value is valid.
+    pub fn time_zone_offset_scaled(&self) -> Option<Vec<f64>> {
         if self.time_zone_offset.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_zone_offset.len());
         for &x in &self.time_zone_offset {
             v.push(x as f64 / 4.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_zone_offset` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_zone_offset_scaled(&mut self, v: &Vec<f64>) -> &mut DeviceSettings {
+    pub fn set_time_zone_offset_scaled(&mut self, v: &[f64]) -> &mut DeviceSettings {
+        self.time_zone_offset = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_zone_offset = Vec::new();
             return self;
         }
-        self.time_zone_offset = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 4.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i8::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/dive_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_alarm.rs
@@ -94,12 +94,12 @@ impl DiveAlarm {
         }
     }
 
-    /// Returns `depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn depth_scaled(&self) -> f64 {
+    /// Returns `depth` in its scaled value. It returns `None` when value is valid.
+    pub fn depth_scaled(&self) -> Option<f64> {
         if self.depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.depth as f64 / 1000.0 - 0.0
+        Some(self.depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -113,12 +113,12 @@ impl DiveAlarm {
         self
     }
 
-    /// Returns `speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn speed_scaled(&self) -> f64 {
+    /// Returns `speed` in its scaled value. It returns `None` when value is valid.
+    pub fn speed_scaled(&self) -> Option<f64> {
         if self.speed == i32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.speed as f64 / 1000.0 - 0.0
+        Some(self.speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `speed` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
@@ -94,12 +94,12 @@ impl DiveApneaAlarm {
         }
     }
 
-    /// Returns `depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn depth_scaled(&self) -> f64 {
+    /// Returns `depth` in its scaled value. It returns `None` when value is valid.
+    pub fn depth_scaled(&self) -> Option<f64> {
         if self.depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.depth as f64 / 1000.0 - 0.0
+        Some(self.depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -113,12 +113,12 @@ impl DiveApneaAlarm {
         self
     }
 
-    /// Returns `speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn speed_scaled(&self) -> f64 {
+    /// Returns `speed` in its scaled value. It returns `None` when value is valid.
+    pub fn speed_scaled(&self) -> Option<f64> {
         if self.speed == i32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.speed as f64 / 1000.0 - 0.0
+        Some(self.speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `speed` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/dive_settings.rs
+++ b/rustyfit/src/profile/mesgdef/dive_settings.rs
@@ -191,12 +191,12 @@ impl DiveSettings {
         }
     }
 
-    /// Returns `po2_warn` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn po2_warn_scaled(&self) -> f64 {
+    /// Returns `po2_warn` in its scaled value. It returns `None` when value is valid.
+    pub fn po2_warn_scaled(&self) -> Option<f64> {
         if self.po2_warn == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.po2_warn as f64 / 100.0 - 0.0
+        Some(self.po2_warn as f64 / 100.0 - 0.0)
     }
 
     /// Set `po2_warn` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -210,12 +210,12 @@ impl DiveSettings {
         self
     }
 
-    /// Returns `po2_critical` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn po2_critical_scaled(&self) -> f64 {
+    /// Returns `po2_critical` in its scaled value. It returns `None` when value is valid.
+    pub fn po2_critical_scaled(&self) -> Option<f64> {
         if self.po2_critical == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.po2_critical as f64 / 100.0 - 0.0
+        Some(self.po2_critical as f64 / 100.0 - 0.0)
     }
 
     /// Set `po2_critical` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -229,12 +229,12 @@ impl DiveSettings {
         self
     }
 
-    /// Returns `po2_deco` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn po2_deco_scaled(&self) -> f64 {
+    /// Returns `po2_deco` in its scaled value. It returns `None` when value is valid.
+    pub fn po2_deco_scaled(&self) -> Option<f64> {
         if self.po2_deco == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.po2_deco as f64 / 100.0 - 0.0
+        Some(self.po2_deco as f64 / 100.0 - 0.0)
     }
 
     /// Set `po2_deco` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -248,12 +248,12 @@ impl DiveSettings {
         self
     }
 
-    /// Returns `ccr_low_setpoint` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn ccr_low_setpoint_scaled(&self) -> f64 {
+    /// Returns `ccr_low_setpoint` in its scaled value. It returns `None` when value is valid.
+    pub fn ccr_low_setpoint_scaled(&self) -> Option<f64> {
         if self.ccr_low_setpoint == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.ccr_low_setpoint as f64 / 100.0 - 0.0
+        Some(self.ccr_low_setpoint as f64 / 100.0 - 0.0)
     }
 
     /// Set `ccr_low_setpoint` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -267,12 +267,12 @@ impl DiveSettings {
         self
     }
 
-    /// Returns `ccr_low_setpoint_depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn ccr_low_setpoint_depth_scaled(&self) -> f64 {
+    /// Returns `ccr_low_setpoint_depth` in its scaled value. It returns `None` when value is valid.
+    pub fn ccr_low_setpoint_depth_scaled(&self) -> Option<f64> {
         if self.ccr_low_setpoint_depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.ccr_low_setpoint_depth as f64 / 1000.0 - 0.0
+        Some(self.ccr_low_setpoint_depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `ccr_low_setpoint_depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -286,12 +286,12 @@ impl DiveSettings {
         self
     }
 
-    /// Returns `ccr_high_setpoint` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn ccr_high_setpoint_scaled(&self) -> f64 {
+    /// Returns `ccr_high_setpoint` in its scaled value. It returns `None` when value is valid.
+    pub fn ccr_high_setpoint_scaled(&self) -> Option<f64> {
         if self.ccr_high_setpoint == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.ccr_high_setpoint as f64 / 100.0 - 0.0
+        Some(self.ccr_high_setpoint as f64 / 100.0 - 0.0)
     }
 
     /// Set `ccr_high_setpoint` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -305,12 +305,12 @@ impl DiveSettings {
         self
     }
 
-    /// Returns `ccr_high_setpoint_depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn ccr_high_setpoint_depth_scaled(&self) -> f64 {
+    /// Returns `ccr_high_setpoint_depth` in its scaled value. It returns `None` when value is valid.
+    pub fn ccr_high_setpoint_depth_scaled(&self) -> Option<f64> {
         if self.ccr_high_setpoint_depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.ccr_high_setpoint_depth as f64 / 1000.0 - 0.0
+        Some(self.ccr_high_setpoint_depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `ccr_high_setpoint_depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -324,12 +324,12 @@ impl DiveSettings {
         self
     }
 
-    /// Returns `last_stop_multiple` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn last_stop_multiple_scaled(&self) -> f64 {
+    /// Returns `last_stop_multiple` in its scaled value. It returns `None` when value is valid.
+    pub fn last_stop_multiple_scaled(&self) -> Option<f64> {
         if self.last_stop_multiple == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.last_stop_multiple as f64 / 10.0 - 0.0
+        Some(self.last_stop_multiple as f64 / 10.0 - 0.0)
     }
 
     /// Set `last_stop_multiple` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/dive_summary.rs
+++ b/rustyfit/src/profile/mesgdef/dive_summary.rs
@@ -141,12 +141,12 @@ impl DiveSummary {
         }
     }
 
-    /// Returns `avg_depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_depth_scaled(&self) -> f64 {
+    /// Returns `avg_depth` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_depth_scaled(&self) -> Option<f64> {
         if self.avg_depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_depth as f64 / 1000.0 - 0.0
+        Some(self.avg_depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -160,12 +160,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `max_depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_depth_scaled(&self) -> f64 {
+    /// Returns `max_depth` in its scaled value. It returns `None` when value is valid.
+    pub fn max_depth_scaled(&self) -> Option<f64> {
         if self.max_depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_depth as f64 / 1000.0 - 0.0
+        Some(self.max_depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -179,12 +179,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `bottom_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn bottom_time_scaled(&self) -> f64 {
+    /// Returns `bottom_time` in its scaled value. It returns `None` when value is valid.
+    pub fn bottom_time_scaled(&self) -> Option<f64> {
         if self.bottom_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.bottom_time as f64 / 1000.0 - 0.0
+        Some(self.bottom_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `bottom_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -198,12 +198,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `avg_pressure_sac` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_pressure_sac_scaled(&self) -> f64 {
+    /// Returns `avg_pressure_sac` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_pressure_sac_scaled(&self) -> Option<f64> {
         if self.avg_pressure_sac == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_pressure_sac as f64 / 100.0 - 0.0
+        Some(self.avg_pressure_sac as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_pressure_sac` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -217,12 +217,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `avg_volume_sac` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_volume_sac_scaled(&self) -> f64 {
+    /// Returns `avg_volume_sac` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_volume_sac_scaled(&self) -> Option<f64> {
         if self.avg_volume_sac == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_volume_sac as f64 / 100.0 - 0.0
+        Some(self.avg_volume_sac as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_volume_sac` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -236,12 +236,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `avg_rmv` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_rmv_scaled(&self) -> f64 {
+    /// Returns `avg_rmv` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_rmv_scaled(&self) -> Option<f64> {
         if self.avg_rmv == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_rmv as f64 / 100.0 - 0.0
+        Some(self.avg_rmv as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_rmv` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -255,12 +255,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `descent_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn descent_time_scaled(&self) -> f64 {
+    /// Returns `descent_time` in its scaled value. It returns `None` when value is valid.
+    pub fn descent_time_scaled(&self) -> Option<f64> {
         if self.descent_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.descent_time as f64 / 1000.0 - 0.0
+        Some(self.descent_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `descent_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -274,12 +274,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `ascent_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn ascent_time_scaled(&self) -> f64 {
+    /// Returns `ascent_time` in its scaled value. It returns `None` when value is valid.
+    pub fn ascent_time_scaled(&self) -> Option<f64> {
         if self.ascent_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.ascent_time as f64 / 1000.0 - 0.0
+        Some(self.ascent_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `ascent_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -293,12 +293,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `avg_ascent_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_ascent_rate_scaled(&self) -> f64 {
+    /// Returns `avg_ascent_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_ascent_rate_scaled(&self) -> Option<f64> {
         if self.avg_ascent_rate == i32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_ascent_rate as f64 / 1000.0 - 0.0
+        Some(self.avg_ascent_rate as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_ascent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -312,12 +312,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `avg_descent_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_descent_rate_scaled(&self) -> f64 {
+    /// Returns `avg_descent_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_descent_rate_scaled(&self) -> Option<f64> {
         if self.avg_descent_rate == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_descent_rate as f64 / 1000.0 - 0.0
+        Some(self.avg_descent_rate as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_descent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -331,12 +331,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `max_ascent_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_ascent_rate_scaled(&self) -> f64 {
+    /// Returns `max_ascent_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn max_ascent_rate_scaled(&self) -> Option<f64> {
         if self.max_ascent_rate == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_ascent_rate as f64 / 1000.0 - 0.0
+        Some(self.max_ascent_rate as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_ascent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -350,12 +350,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `max_descent_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_descent_rate_scaled(&self) -> f64 {
+    /// Returns `max_descent_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn max_descent_rate_scaled(&self) -> Option<f64> {
         if self.max_descent_rate == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_descent_rate as f64 / 1000.0 - 0.0
+        Some(self.max_descent_rate as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_descent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -369,12 +369,12 @@ impl DiveSummary {
         self
     }
 
-    /// Returns `hang_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn hang_time_scaled(&self) -> f64 {
+    /// Returns `hang_time` in its scaled value. It returns `None` when value is valid.
+    pub fn hang_time_scaled(&self) -> Option<f64> {
         if self.hang_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.hang_time as f64 / 1000.0 - 0.0
+        Some(self.hang_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `hang_time` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/event.rs
+++ b/rustyfit/src/profile/mesgdef/event.rs
@@ -129,12 +129,12 @@ impl Event {
         }
     }
 
-    /// Returns `radar_threat_avg_approach_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn radar_threat_avg_approach_speed_scaled(&self) -> f64 {
+    /// Returns `radar_threat_avg_approach_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn radar_threat_avg_approach_speed_scaled(&self) -> Option<f64> {
         if self.radar_threat_avg_approach_speed == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.radar_threat_avg_approach_speed as f64 / 10.0 - 0.0
+        Some(self.radar_threat_avg_approach_speed as f64 / 10.0 - 0.0)
     }
 
     /// Set `radar_threat_avg_approach_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -148,12 +148,12 @@ impl Event {
         self
     }
 
-    /// Returns `radar_threat_max_approach_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn radar_threat_max_approach_speed_scaled(&self) -> f64 {
+    /// Returns `radar_threat_max_approach_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn radar_threat_max_approach_speed_scaled(&self) -> Option<f64> {
         if self.radar_threat_max_approach_speed == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.radar_threat_max_approach_speed as f64 / 10.0 - 0.0
+        Some(self.radar_threat_max_approach_speed as f64 / 10.0 - 0.0)
     }
 
     /// Set `radar_threat_max_approach_speed` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -75,22 +75,22 @@ impl GpsMetadata {
         }
     }
 
-    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_lat_degrees(&self) -> f64 {
+    /// Returns `position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_lat)
     }
 
-    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_long_degrees(&self) -> f64 {
+    /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
     }
 
-    /// Returns `enhanced_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -104,12 +104,12 @@ impl GpsMetadata {
         self
     }
 
-    /// Returns `enhanced_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_speed_scaled(&self) -> f64 {
+    /// Returns `enhanced_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_speed_scaled(&self) -> Option<f64> {
         if self.enhanced_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_speed as f64 / 1000.0 - 0.0
+        Some(self.enhanced_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `enhanced_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -123,12 +123,12 @@ impl GpsMetadata {
         self
     }
 
-    /// Returns `heading` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn heading_scaled(&self) -> f64 {
+    /// Returns `heading` in its scaled value. It returns `None` when value is valid.
+    pub fn heading_scaled(&self) -> Option<f64> {
         if self.heading == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.heading as f64 / 100.0 - 0.0
+        Some(self.heading as f64 / 100.0 - 0.0)
     }
 
     /// Set `heading` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -142,8 +142,11 @@ impl GpsMetadata {
         self
     }
 
-    /// Returns `velocity` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn velocity_scaled(&self) -> [f64; 3] {
+    /// Returns `velocity` in its scaled value. It returns `None` when value is valid.
+    pub fn velocity_scaled(&self) -> Option<[f64; 3]> {
+        if self.velocity == [i16::MAX; 3] {
+            return None;
+        }
         let mut v = [f64::from_bits(u64::MAX); 3];
         for (i, &x) in self.velocity.iter().enumerate() {
             if x == i16::MAX {
@@ -151,7 +154,7 @@ impl GpsMetadata {
             }
             v[i] = x as f64 / 100.0 - 0.0;
         }
-        v
+        Some(v)
     }
 
     /// Set `velocity` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/hr.rs
+++ b/rustyfit/src/profile/mesgdef/hr.rs
@@ -67,12 +67,12 @@ impl Hr {
         }
     }
 
-    /// Returns `fractional_timestamp` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn fractional_timestamp_scaled(&self) -> f64 {
+    /// Returns `fractional_timestamp` in its scaled value. It returns `None` when value is valid.
+    pub fn fractional_timestamp_scaled(&self) -> Option<f64> {
         if self.fractional_timestamp == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.fractional_timestamp as f64 / 32768.0 - 0.0
+        Some(self.fractional_timestamp as f64 / 32768.0 - 0.0)
     }
 
     /// Set `fractional_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -86,12 +86,12 @@ impl Hr {
         self
     }
 
-    /// Returns `time256` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time256_scaled(&self) -> f64 {
+    /// Returns `time256` in its scaled value. It returns `None` when value is valid.
+    pub fn time256_scaled(&self) -> Option<f64> {
         if self.time256 == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.time256 as f64 / 256.0 - 0.0
+        Some(self.time256 as f64 / 256.0 - 0.0)
     }
 
     /// Set `time256` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -105,25 +105,24 @@ impl Hr {
         self
     }
 
-    /// Returns `event_timestamp` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn event_timestamp_scaled(&self) -> Vec<f64> {
+    /// Returns `event_timestamp` in its scaled value. It returns `None` when value is valid.
+    pub fn event_timestamp_scaled(&self) -> Option<Vec<f64>> {
         if self.event_timestamp.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.event_timestamp.len());
         for &x in &self.event_timestamp {
             v.push(x as f64 / 1024.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `event_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_event_timestamp_scaled(&mut self, v: &Vec<f64>) -> &mut Hr {
+    pub fn set_event_timestamp_scaled(&mut self, v: &[f64]) -> &mut Hr {
+        self.event_timestamp = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.event_timestamp = Vec::new();
             return self;
         }
-        self.event_timestamp = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1024.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/hrv.rs
+++ b/rustyfit/src/profile/mesgdef/hrv.rs
@@ -34,25 +34,24 @@ impl Hrv {
         }
     }
 
-    /// Returns `time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_scaled(&self) -> Vec<f64> {
+    /// Returns `time` in its scaled value. It returns `None` when value is valid.
+    pub fn time_scaled(&self) -> Option<Vec<f64>> {
         if self.time.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time.len());
         for &x in &self.time {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_scaled(&mut self, v: &Vec<f64>) -> &mut Hrv {
+    pub fn set_time_scaled(&mut self, v: &[f64]) -> &mut Hrv {
+        self.time = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time = Vec::new();
             return self;
         }
-        self.time = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
@@ -67,12 +67,12 @@ impl HrvStatusSummary {
         }
     }
 
-    /// Returns `weekly_average` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn weekly_average_scaled(&self) -> f64 {
+    /// Returns `weekly_average` in its scaled value. It returns `None` when value is valid.
+    pub fn weekly_average_scaled(&self) -> Option<f64> {
         if self.weekly_average == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.weekly_average as f64 / 128.0 - 0.0
+        Some(self.weekly_average as f64 / 128.0 - 0.0)
     }
 
     /// Set `weekly_average` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -86,12 +86,12 @@ impl HrvStatusSummary {
         self
     }
 
-    /// Returns `last_night_average` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn last_night_average_scaled(&self) -> f64 {
+    /// Returns `last_night_average` in its scaled value. It returns `None` when value is valid.
+    pub fn last_night_average_scaled(&self) -> Option<f64> {
         if self.last_night_average == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.last_night_average as f64 / 128.0 - 0.0
+        Some(self.last_night_average as f64 / 128.0 - 0.0)
     }
 
     /// Set `last_night_average` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -105,12 +105,12 @@ impl HrvStatusSummary {
         self
     }
 
-    /// Returns `last_night_5_min_high` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn last_night_5_min_high_scaled(&self) -> f64 {
+    /// Returns `last_night_5_min_high` in its scaled value. It returns `None` when value is valid.
+    pub fn last_night_5_min_high_scaled(&self) -> Option<f64> {
         if self.last_night_5_min_high == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.last_night_5_min_high as f64 / 128.0 - 0.0
+        Some(self.last_night_5_min_high as f64 / 128.0 - 0.0)
     }
 
     /// Set `last_night_5_min_high` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -124,12 +124,12 @@ impl HrvStatusSummary {
         self
     }
 
-    /// Returns `baseline_low_upper` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn baseline_low_upper_scaled(&self) -> f64 {
+    /// Returns `baseline_low_upper` in its scaled value. It returns `None` when value is valid.
+    pub fn baseline_low_upper_scaled(&self) -> Option<f64> {
         if self.baseline_low_upper == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.baseline_low_upper as f64 / 128.0 - 0.0
+        Some(self.baseline_low_upper as f64 / 128.0 - 0.0)
     }
 
     /// Set `baseline_low_upper` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -143,12 +143,12 @@ impl HrvStatusSummary {
         self
     }
 
-    /// Returns `baseline_balanced_lower` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn baseline_balanced_lower_scaled(&self) -> f64 {
+    /// Returns `baseline_balanced_lower` in its scaled value. It returns `None` when value is valid.
+    pub fn baseline_balanced_lower_scaled(&self) -> Option<f64> {
         if self.baseline_balanced_lower == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.baseline_balanced_lower as f64 / 128.0 - 0.0
+        Some(self.baseline_balanced_lower as f64 / 128.0 - 0.0)
     }
 
     /// Set `baseline_balanced_lower` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -162,12 +162,12 @@ impl HrvStatusSummary {
         self
     }
 
-    /// Returns `baseline_balanced_upper` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn baseline_balanced_upper_scaled(&self) -> f64 {
+    /// Returns `baseline_balanced_upper` in its scaled value. It returns `None` when value is valid.
+    pub fn baseline_balanced_upper_scaled(&self) -> Option<f64> {
         if self.baseline_balanced_upper == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.baseline_balanced_upper as f64 / 128.0 - 0.0
+        Some(self.baseline_balanced_upper as f64 / 128.0 - 0.0)
     }
 
     /// Set `baseline_balanced_upper` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/hrv_value.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_value.rs
@@ -38,12 +38,12 @@ impl HrvValue {
         }
     }
 
-    /// Returns `value` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn value_scaled(&self) -> f64 {
+    /// Returns `value` in its scaled value. It returns `None` when value is valid.
+    pub fn value_scaled(&self) -> Option<f64> {
         if self.value == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.value as f64 / 128.0 - 0.0
+        Some(self.value as f64 / 128.0 - 0.0)
     }
 
     /// Set `value` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
@@ -64,25 +64,24 @@ impl HsaAccelerometerData {
         }
     }
 
-    /// Returns `accel_x` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn accel_x_scaled(&self) -> Vec<f64> {
+    /// Returns `accel_x` in its scaled value. It returns `None` when value is valid.
+    pub fn accel_x_scaled(&self) -> Option<Vec<f64>> {
         if self.accel_x.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.accel_x.len());
         for &x in &self.accel_x {
             v.push(x as f64 / 1.024 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `accel_x` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_x_scaled(&mut self, v: &Vec<f64>) -> &mut HsaAccelerometerData {
+    pub fn set_accel_x_scaled(&mut self, v: &[f64]) -> &mut HsaAccelerometerData {
+        self.accel_x = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.accel_x = Vec::new();
             return self;
         }
-        self.accel_x = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1.024;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
@@ -94,25 +93,24 @@ impl HsaAccelerometerData {
         self
     }
 
-    /// Returns `accel_y` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn accel_y_scaled(&self) -> Vec<f64> {
+    /// Returns `accel_y` in its scaled value. It returns `None` when value is valid.
+    pub fn accel_y_scaled(&self) -> Option<Vec<f64>> {
         if self.accel_y.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.accel_y.len());
         for &x in &self.accel_y {
             v.push(x as f64 / 1.024 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `accel_y` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_y_scaled(&mut self, v: &Vec<f64>) -> &mut HsaAccelerometerData {
+    pub fn set_accel_y_scaled(&mut self, v: &[f64]) -> &mut HsaAccelerometerData {
+        self.accel_y = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.accel_y = Vec::new();
             return self;
         }
-        self.accel_y = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1.024;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
@@ -124,25 +122,24 @@ impl HsaAccelerometerData {
         self
     }
 
-    /// Returns `accel_z` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn accel_z_scaled(&self) -> Vec<f64> {
+    /// Returns `accel_z` in its scaled value. It returns `None` when value is valid.
+    pub fn accel_z_scaled(&self) -> Option<Vec<f64>> {
         if self.accel_z.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.accel_z.len());
         for &x in &self.accel_z {
             v.push(x as f64 / 1.024 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `accel_z` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_z_scaled(&mut self, v: &Vec<f64>) -> &mut HsaAccelerometerData {
+    pub fn set_accel_z_scaled(&mut self, v: &[f64]) -> &mut HsaAccelerometerData {
+        self.accel_z = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.accel_z = Vec::new();
             return self;
         }
-        self.accel_z = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1.024;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
@@ -64,25 +64,24 @@ impl HsaGyroscopeData {
         }
     }
 
-    /// Returns `gyro_x` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn gyro_x_scaled(&self) -> Vec<f64> {
+    /// Returns `gyro_x` in its scaled value. It returns `None` when value is valid.
+    pub fn gyro_x_scaled(&self) -> Option<Vec<f64>> {
         if self.gyro_x.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.gyro_x.len());
         for &x in &self.gyro_x {
             v.push(x as f64 / 28.57143 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `gyro_x` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_gyro_x_scaled(&mut self, v: &Vec<f64>) -> &mut HsaGyroscopeData {
+    pub fn set_gyro_x_scaled(&mut self, v: &[f64]) -> &mut HsaGyroscopeData {
+        self.gyro_x = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.gyro_x = Vec::new();
             return self;
         }
-        self.gyro_x = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 28.57143;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
@@ -94,25 +93,24 @@ impl HsaGyroscopeData {
         self
     }
 
-    /// Returns `gyro_y` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn gyro_y_scaled(&self) -> Vec<f64> {
+    /// Returns `gyro_y` in its scaled value. It returns `None` when value is valid.
+    pub fn gyro_y_scaled(&self) -> Option<Vec<f64>> {
         if self.gyro_y.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.gyro_y.len());
         for &x in &self.gyro_y {
             v.push(x as f64 / 28.57143 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `gyro_y` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_gyro_y_scaled(&mut self, v: &Vec<f64>) -> &mut HsaGyroscopeData {
+    pub fn set_gyro_y_scaled(&mut self, v: &[f64]) -> &mut HsaGyroscopeData {
+        self.gyro_y = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.gyro_y = Vec::new();
             return self;
         }
-        self.gyro_y = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 28.57143;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
@@ -124,25 +122,24 @@ impl HsaGyroscopeData {
         self
     }
 
-    /// Returns `gyro_z` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn gyro_z_scaled(&self) -> Vec<f64> {
+    /// Returns `gyro_z` in its scaled value. It returns `None` when value is valid.
+    pub fn gyro_z_scaled(&self) -> Option<Vec<f64>> {
         if self.gyro_z.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.gyro_z.len());
         for &x in &self.gyro_z {
             v.push(x as f64 / 28.57143 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `gyro_z` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_gyro_z_scaled(&mut self, v: &Vec<f64>) -> &mut HsaGyroscopeData {
+    pub fn set_gyro_z_scaled(&mut self, v: &[f64]) -> &mut HsaGyroscopeData {
+        self.gyro_z = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.gyro_z = Vec::new();
             return self;
         }
-        self.gyro_z = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 28.57143;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
@@ -44,25 +44,24 @@ impl HsaRespirationData {
         }
     }
 
-    /// Returns `respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn respiration_rate_scaled(&self) -> Vec<f64> {
+    /// Returns `respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn respiration_rate_scaled(&self) -> Option<Vec<f64>> {
         if self.respiration_rate.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.respiration_rate.len());
         for &x in &self.respiration_rate {
             v.push(x as f64 / 100.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_respiration_rate_scaled(&mut self, v: &Vec<f64>) -> &mut HsaRespirationData {
+    pub fn set_respiration_rate_scaled(&mut self, v: &[f64]) -> &mut HsaRespirationData {
+        self.respiration_rate = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.respiration_rate = Vec::new();
             return self;
         }
-        self.respiration_rate = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 100.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
@@ -44,25 +44,24 @@ impl HsaWristTemperatureData {
         }
     }
 
-    /// Returns `value` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn value_scaled(&self) -> Vec<f64> {
+    /// Returns `value` in its scaled value. It returns `None` when value is valid.
+    pub fn value_scaled(&self) -> Option<Vec<f64>> {
         if self.value.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.value.len());
         for &x in &self.value {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `value` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_value_scaled(&mut self, v: &Vec<f64>) -> &mut HsaWristTemperatureData {
+    pub fn set_value_scaled(&mut self, v: &[f64]) -> &mut HsaWristTemperatureData {
+        self.value = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.value = Vec::new();
             return self;
         }
-        self.value = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -88,22 +88,22 @@ impl Jump {
         }
     }
 
-    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_lat_degrees(&self) -> f64 {
+    /// Returns `position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_lat)
     }
 
-    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_long_degrees(&self) -> f64 {
+    /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
     }
 
-    /// Returns `speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn speed_scaled(&self) -> f64 {
+    /// Returns `speed` in its scaled value. It returns `None` when value is valid.
+    pub fn speed_scaled(&self) -> Option<f64> {
         if self.speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.speed as f64 / 1000.0 - 0.0
+        Some(self.speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -117,12 +117,12 @@ impl Jump {
         self
     }
 
-    /// Returns `enhanced_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_speed_scaled(&self) -> f64 {
+    /// Returns `enhanced_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_speed_scaled(&self) -> Option<f64> {
         if self.enhanced_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_speed as f64 / 1000.0 - 0.0
+        Some(self.enhanced_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `enhanced_speed` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -640,32 +640,32 @@ impl Lap {
         }
     }
 
-    /// Returns `start_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn start_position_lat_degrees(&self) -> f64 {
+    /// Returns `start_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn start_position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_lat)
     }
 
-    /// Returns `start_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn start_position_long_degrees(&self) -> f64 {
+    /// Returns `start_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn start_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_long)
     }
 
-    /// Returns `end_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn end_position_lat_degrees(&self) -> f64 {
+    /// Returns `end_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn end_position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_lat)
     }
 
-    /// Returns `end_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn end_position_long_degrees(&self) -> f64 {
+    /// Returns `end_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn end_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_long)
     }
 
-    /// Returns `total_elapsed_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_elapsed_time_scaled(&self) -> f64 {
+    /// Returns `total_elapsed_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_elapsed_time_scaled(&self) -> Option<f64> {
         if self.total_elapsed_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_elapsed_time as f64 / 1000.0 - 0.0
+        Some(self.total_elapsed_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -679,12 +679,12 @@ impl Lap {
         self
     }
 
-    /// Returns `total_timer_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_timer_time_scaled(&self) -> f64 {
+    /// Returns `total_timer_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_timer_time_scaled(&self) -> Option<f64> {
         if self.total_timer_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_timer_time as f64 / 1000.0 - 0.0
+        Some(self.total_timer_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -698,12 +698,12 @@ impl Lap {
         self
     }
 
-    /// Returns `total_distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_distance_scaled(&self) -> f64 {
+    /// Returns `total_distance` in its scaled value. It returns `None` when value is valid.
+    pub fn total_distance_scaled(&self) -> Option<f64> {
         if self.total_distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_distance as f64 / 100.0 - 0.0
+        Some(self.total_distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -717,12 +717,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_speed_scaled(&self) -> f64 {
+    /// Returns `avg_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_speed_scaled(&self) -> Option<f64> {
         if self.avg_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -736,12 +736,12 @@ impl Lap {
         self
     }
 
-    /// Returns `max_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_speed_scaled(&self) -> f64 {
+    /// Returns `max_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_speed_scaled(&self) -> Option<f64> {
         if self.max_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_speed as f64 / 1000.0 - 0.0
+        Some(self.max_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -755,12 +755,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_stroke_distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_stroke_distance_scaled(&self) -> f64 {
+    /// Returns `avg_stroke_distance` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_stroke_distance_scaled(&self) -> Option<f64> {
         if self.avg_stroke_distance == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_stroke_distance as f64 / 100.0 - 0.0
+        Some(self.avg_stroke_distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_stroke_distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -774,12 +774,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_altitude_scaled(&self) -> f64 {
+    /// Returns `avg_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_altitude_scaled(&self) -> Option<f64> {
         if self.avg_altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_altitude as f64 / 5.0 - 500.0
+        Some(self.avg_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -793,12 +793,12 @@ impl Lap {
         self
     }
 
-    /// Returns `max_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_altitude_scaled(&self) -> f64 {
+    /// Returns `max_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn max_altitude_scaled(&self) -> Option<f64> {
         if self.max_altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_altitude as f64 / 5.0 - 500.0
+        Some(self.max_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -812,12 +812,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_grade_scaled(&self) -> f64 {
+    /// Returns `avg_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_grade_scaled(&self) -> Option<f64> {
         if self.avg_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_grade as f64 / 100.0 - 0.0
+        Some(self.avg_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -831,12 +831,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_pos_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_pos_grade_scaled(&self) -> f64 {
+    /// Returns `avg_pos_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_pos_grade_scaled(&self) -> Option<f64> {
         if self.avg_pos_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_pos_grade as f64 / 100.0 - 0.0
+        Some(self.avg_pos_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -850,12 +850,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_neg_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_neg_grade_scaled(&self) -> f64 {
+    /// Returns `avg_neg_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_neg_grade_scaled(&self) -> Option<f64> {
         if self.avg_neg_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_neg_grade as f64 / 100.0 - 0.0
+        Some(self.avg_neg_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -869,12 +869,12 @@ impl Lap {
         self
     }
 
-    /// Returns `max_pos_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_pos_grade_scaled(&self) -> f64 {
+    /// Returns `max_pos_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn max_pos_grade_scaled(&self) -> Option<f64> {
         if self.max_pos_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_pos_grade as f64 / 100.0 - 0.0
+        Some(self.max_pos_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `max_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -888,12 +888,12 @@ impl Lap {
         self
     }
 
-    /// Returns `max_neg_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_neg_grade_scaled(&self) -> f64 {
+    /// Returns `max_neg_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn max_neg_grade_scaled(&self) -> Option<f64> {
         if self.max_neg_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_neg_grade as f64 / 100.0 - 0.0
+        Some(self.max_neg_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `max_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -907,12 +907,12 @@ impl Lap {
         self
     }
 
-    /// Returns `total_moving_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_moving_time_scaled(&self) -> f64 {
+    /// Returns `total_moving_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_moving_time_scaled(&self) -> Option<f64> {
         if self.total_moving_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_moving_time as f64 / 1000.0 - 0.0
+        Some(self.total_moving_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -926,12 +926,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_pos_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_pos_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `avg_pos_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_pos_vertical_speed_scaled(&self) -> Option<f64> {
         if self.avg_pos_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_pos_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_pos_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -945,12 +945,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_neg_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_neg_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `avg_neg_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_neg_vertical_speed_scaled(&self) -> Option<f64> {
         if self.avg_neg_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_neg_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_neg_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -964,12 +964,12 @@ impl Lap {
         self
     }
 
-    /// Returns `max_pos_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_pos_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `max_pos_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_pos_vertical_speed_scaled(&self) -> Option<f64> {
         if self.max_pos_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_pos_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.max_pos_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -983,12 +983,12 @@ impl Lap {
         self
     }
 
-    /// Returns `max_neg_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_neg_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `max_neg_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_neg_vertical_speed_scaled(&self) -> Option<f64> {
         if self.max_neg_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_neg_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.max_neg_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1002,25 +1002,24 @@ impl Lap {
         self
     }
 
-    /// Returns `time_in_hr_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_hr_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_hr_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_hr_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_hr_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_hr_zone.len());
         for &x in &self.time_in_hr_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_hr_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_hr_zone_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.time_in_hr_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_hr_zone = Vec::new();
             return self;
         }
-        self.time_in_hr_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -1032,25 +1031,24 @@ impl Lap {
         self
     }
 
-    /// Returns `time_in_speed_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_speed_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_speed_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_speed_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_speed_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_speed_zone.len());
         for &x in &self.time_in_speed_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_speed_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_speed_zone_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.time_in_speed_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_speed_zone = Vec::new();
             return self;
         }
-        self.time_in_speed_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -1062,25 +1060,24 @@ impl Lap {
         self
     }
 
-    /// Returns `time_in_cadence_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_cadence_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_cadence_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_cadence_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_cadence_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_cadence_zone.len());
         for &x in &self.time_in_cadence_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_cadence_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.time_in_cadence_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_cadence_zone = Vec::new();
             return self;
         }
-        self.time_in_cadence_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -1092,25 +1089,24 @@ impl Lap {
         self
     }
 
-    /// Returns `time_in_power_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_power_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_power_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_power_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_power_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_power_zone.len());
         for &x in &self.time_in_power_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_power_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_power_zone_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.time_in_power_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_power_zone = Vec::new();
             return self;
         }
-        self.time_in_power_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -1122,12 +1118,12 @@ impl Lap {
         self
     }
 
-    /// Returns `min_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_altitude_scaled(&self) -> f64 {
+    /// Returns `min_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn min_altitude_scaled(&self) -> Option<f64> {
         if self.min_altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.min_altitude as f64 / 5.0 - 500.0
+        Some(self.min_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1141,12 +1137,12 @@ impl Lap {
         self
     }
 
-    /// Returns `active_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn active_time_scaled(&self) -> f64 {
+    /// Returns `active_time` in its scaled value. It returns `None` when value is valid.
+    pub fn active_time_scaled(&self) -> Option<f64> {
         if self.active_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.active_time as f64 / 1000.0 - 0.0
+        Some(self.active_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1160,12 +1156,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_vertical_oscillation` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_vertical_oscillation_scaled(&self) -> f64 {
+    /// Returns `avg_vertical_oscillation` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_vertical_oscillation_scaled(&self) -> Option<f64> {
         if self.avg_vertical_oscillation == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_vertical_oscillation as f64 / 10.0 - 0.0
+        Some(self.avg_vertical_oscillation as f64 / 10.0 - 0.0)
     }
 
     /// Set `avg_vertical_oscillation` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1179,12 +1175,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_stance_time_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_stance_time_percent_scaled(&self) -> f64 {
+    /// Returns `avg_stance_time_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_stance_time_percent_scaled(&self) -> Option<f64> {
         if self.avg_stance_time_percent == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_stance_time_percent as f64 / 100.0 - 0.0
+        Some(self.avg_stance_time_percent as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_stance_time_percent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1198,12 +1194,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_stance_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_stance_time_scaled(&self) -> f64 {
+    /// Returns `avg_stance_time` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_stance_time_scaled(&self) -> Option<f64> {
         if self.avg_stance_time == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_stance_time as f64 / 10.0 - 0.0
+        Some(self.avg_stance_time as f64 / 10.0 - 0.0)
     }
 
     /// Set `avg_stance_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1217,12 +1213,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_fractional_cadence` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_fractional_cadence_scaled(&self) -> f64 {
+    /// Returns `avg_fractional_cadence` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_fractional_cadence_scaled(&self) -> Option<f64> {
         if self.avg_fractional_cadence == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_fractional_cadence as f64 / 128.0 - 0.0
+        Some(self.avg_fractional_cadence as f64 / 128.0 - 0.0)
     }
 
     /// Set `avg_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1236,12 +1232,12 @@ impl Lap {
         self
     }
 
-    /// Returns `max_fractional_cadence` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_fractional_cadence_scaled(&self) -> f64 {
+    /// Returns `max_fractional_cadence` in its scaled value. It returns `None` when value is valid.
+    pub fn max_fractional_cadence_scaled(&self) -> Option<f64> {
         if self.max_fractional_cadence == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_fractional_cadence as f64 / 128.0 - 0.0
+        Some(self.max_fractional_cadence as f64 / 128.0 - 0.0)
     }
 
     /// Set `max_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1255,12 +1251,12 @@ impl Lap {
         self
     }
 
-    /// Returns `total_fractional_cycles` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_fractional_cycles_scaled(&self) -> f64 {
+    /// Returns `total_fractional_cycles` in its scaled value. It returns `None` when value is valid.
+    pub fn total_fractional_cycles_scaled(&self) -> Option<f64> {
         if self.total_fractional_cycles == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_fractional_cycles as f64 / 128.0 - 0.0
+        Some(self.total_fractional_cycles as f64 / 128.0 - 0.0)
     }
 
     /// Set `total_fractional_cycles` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1274,25 +1270,24 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_total_hemoglobin_conc` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_total_hemoglobin_conc_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_total_hemoglobin_conc.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_total_hemoglobin_conc.len());
         for &x in &self.avg_total_hemoglobin_conc {
             v.push(x as f64 / 100.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_total_hemoglobin_conc_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_avg_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.avg_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_total_hemoglobin_conc = Vec::new();
             return self;
         }
-        self.avg_total_hemoglobin_conc = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 100.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1304,25 +1299,24 @@ impl Lap {
         self
     }
 
-    /// Returns `min_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
+    /// Returns `min_total_hemoglobin_conc` in its scaled value. It returns `None` when value is valid.
+    pub fn min_total_hemoglobin_conc_scaled(&self) -> Option<Vec<f64>> {
         if self.min_total_hemoglobin_conc.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.min_total_hemoglobin_conc.len());
         for &x in &self.min_total_hemoglobin_conc {
             v.push(x as f64 / 100.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `min_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_total_hemoglobin_conc_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_min_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.min_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.min_total_hemoglobin_conc = Vec::new();
             return self;
         }
-        self.min_total_hemoglobin_conc = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 100.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1334,25 +1328,24 @@ impl Lap {
         self
     }
 
-    /// Returns `max_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
+    /// Returns `max_total_hemoglobin_conc` in its scaled value. It returns `None` when value is valid.
+    pub fn max_total_hemoglobin_conc_scaled(&self) -> Option<Vec<f64>> {
         if self.max_total_hemoglobin_conc.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.max_total_hemoglobin_conc.len());
         for &x in &self.max_total_hemoglobin_conc {
             v.push(x as f64 / 100.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `max_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_total_hemoglobin_conc_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_max_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.max_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.max_total_hemoglobin_conc = Vec::new();
             return self;
         }
-        self.max_total_hemoglobin_conc = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 100.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1364,25 +1357,24 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_saturated_hemoglobin_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_saturated_hemoglobin_percent_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_saturated_hemoglobin_percent.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_saturated_hemoglobin_percent.len());
         for &x in &self.avg_saturated_hemoglobin_percent {
             v.push(x as f64 / 10.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_saturated_hemoglobin_percent_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_avg_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.avg_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_saturated_hemoglobin_percent = Vec::new();
             return self;
         }
-        self.avg_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 10.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1394,25 +1386,24 @@ impl Lap {
         self
     }
 
-    /// Returns `min_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
+    /// Returns `min_saturated_hemoglobin_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn min_saturated_hemoglobin_percent_scaled(&self) -> Option<Vec<f64>> {
         if self.min_saturated_hemoglobin_percent.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.min_saturated_hemoglobin_percent.len());
         for &x in &self.min_saturated_hemoglobin_percent {
             v.push(x as f64 / 10.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `min_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_saturated_hemoglobin_percent_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_min_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.min_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.min_saturated_hemoglobin_percent = Vec::new();
             return self;
         }
-        self.min_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 10.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1424,25 +1415,24 @@ impl Lap {
         self
     }
 
-    /// Returns `max_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
+    /// Returns `max_saturated_hemoglobin_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn max_saturated_hemoglobin_percent_scaled(&self) -> Option<Vec<f64>> {
         if self.max_saturated_hemoglobin_percent.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.max_saturated_hemoglobin_percent.len());
         for &x in &self.max_saturated_hemoglobin_percent {
             v.push(x as f64 / 10.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `max_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_saturated_hemoglobin_percent_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_max_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.max_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.max_saturated_hemoglobin_percent = Vec::new();
             return self;
         }
-        self.max_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 10.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1454,12 +1444,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_left_torque_effectiveness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_torque_effectiveness_scaled(&self) -> f64 {
+    /// Returns `avg_left_torque_effectiveness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_torque_effectiveness_scaled(&self) -> Option<f64> {
         if self.avg_left_torque_effectiveness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_left_torque_effectiveness as f64 / 2.0 - 0.0
+        Some(self.avg_left_torque_effectiveness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_left_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1473,12 +1463,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_right_torque_effectiveness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_torque_effectiveness_scaled(&self) -> f64 {
+    /// Returns `avg_right_torque_effectiveness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_torque_effectiveness_scaled(&self) -> Option<f64> {
         if self.avg_right_torque_effectiveness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_right_torque_effectiveness as f64 / 2.0 - 0.0
+        Some(self.avg_right_torque_effectiveness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_right_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1492,12 +1482,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_left_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `avg_left_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.avg_left_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_left_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.avg_left_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_left_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1511,12 +1501,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_right_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `avg_right_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.avg_right_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_right_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.avg_right_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_right_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1530,12 +1520,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_combined_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_combined_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `avg_combined_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_combined_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.avg_combined_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_combined_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.avg_combined_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_combined_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1549,12 +1539,12 @@ impl Lap {
         self
     }
 
-    /// Returns `time_standing` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_standing_scaled(&self) -> f64 {
+    /// Returns `time_standing` in its scaled value. It returns `None` when value is valid.
+    pub fn time_standing_scaled(&self) -> Option<f64> {
         if self.time_standing == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.time_standing as f64 / 1000.0 - 0.0
+        Some(self.time_standing as f64 / 1000.0 - 0.0)
     }
 
     /// Set `time_standing` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1568,25 +1558,24 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_left_power_phase` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_power_phase_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_left_power_phase` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_power_phase_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_left_power_phase.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase.len());
         for &x in &self.avg_left_power_phase {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_left_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_avg_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.avg_left_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_left_power_phase = Vec::new();
             return self;
         }
-        self.avg_left_power_phase = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1598,25 +1587,24 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_left_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_power_phase_peak_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_left_power_phase_peak` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_power_phase_peak_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_left_power_phase_peak.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase_peak.len());
         for &x in &self.avg_left_power_phase_peak {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_left_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.avg_left_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_left_power_phase_peak = Vec::new();
             return self;
         }
-        self.avg_left_power_phase_peak = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1628,25 +1616,24 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_right_power_phase` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_power_phase_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_right_power_phase` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_power_phase_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_right_power_phase.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase.len());
         for &x in &self.avg_right_power_phase {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_right_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_avg_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.avg_right_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_right_power_phase = Vec::new();
             return self;
         }
-        self.avg_right_power_phase = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1658,25 +1645,24 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_right_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_power_phase_peak_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_right_power_phase_peak` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_power_phase_peak_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_right_power_phase_peak.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase_peak.len());
         for &x in &self.avg_right_power_phase_peak {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_right_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &Vec<f64>) -> &mut Lap {
+    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Lap {
+        self.avg_right_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_right_power_phase_peak = Vec::new();
             return self;
         }
-        self.avg_right_power_phase_peak = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1688,12 +1674,12 @@ impl Lap {
         self
     }
 
-    /// Returns `enhanced_avg_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_avg_speed_scaled(&self) -> f64 {
+    /// Returns `enhanced_avg_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_avg_speed_scaled(&self) -> Option<f64> {
         if self.enhanced_avg_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_avg_speed as f64 / 1000.0 - 0.0
+        Some(self.enhanced_avg_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `enhanced_avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1707,12 +1693,12 @@ impl Lap {
         self
     }
 
-    /// Returns `enhanced_max_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_max_speed_scaled(&self) -> f64 {
+    /// Returns `enhanced_max_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_max_speed_scaled(&self) -> Option<f64> {
         if self.enhanced_max_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_max_speed as f64 / 1000.0 - 0.0
+        Some(self.enhanced_max_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `enhanced_max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1726,12 +1712,12 @@ impl Lap {
         self
     }
 
-    /// Returns `enhanced_avg_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_avg_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_avg_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_avg_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_avg_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_avg_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_avg_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1745,12 +1731,12 @@ impl Lap {
         self
     }
 
-    /// Returns `enhanced_min_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_min_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_min_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_min_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_min_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_min_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_min_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1764,12 +1750,12 @@ impl Lap {
         self
     }
 
-    /// Returns `enhanced_max_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_max_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_max_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_max_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_max_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_max_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_max_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1783,12 +1769,12 @@ impl Lap {
         self
     }
 
-    /// Returns `lev_battery_consumption` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn lev_battery_consumption_scaled(&self) -> f64 {
+    /// Returns `lev_battery_consumption` in its scaled value. It returns `None` when value is valid.
+    pub fn lev_battery_consumption_scaled(&self) -> Option<f64> {
         if self.lev_battery_consumption == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.lev_battery_consumption as f64 / 2.0 - 0.0
+        Some(self.lev_battery_consumption as f64 / 2.0 - 0.0)
     }
 
     /// Set `lev_battery_consumption` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1802,12 +1788,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_vertical_ratio` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_vertical_ratio_scaled(&self) -> f64 {
+    /// Returns `avg_vertical_ratio` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_vertical_ratio_scaled(&self) -> Option<f64> {
         if self.avg_vertical_ratio == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_vertical_ratio as f64 / 100.0 - 0.0
+        Some(self.avg_vertical_ratio as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_vertical_ratio` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1821,12 +1807,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_stance_time_balance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_stance_time_balance_scaled(&self) -> f64 {
+    /// Returns `avg_stance_time_balance` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_stance_time_balance_scaled(&self) -> Option<f64> {
         if self.avg_stance_time_balance == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_stance_time_balance as f64 / 100.0 - 0.0
+        Some(self.avg_stance_time_balance as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_stance_time_balance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1840,12 +1826,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_step_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_step_length_scaled(&self) -> f64 {
+    /// Returns `avg_step_length` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_step_length_scaled(&self) -> Option<f64> {
         if self.avg_step_length == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_step_length as f64 / 10.0 - 0.0
+        Some(self.avg_step_length as f64 / 10.0 - 0.0)
     }
 
     /// Set `avg_step_length` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1859,12 +1845,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_vam` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_vam_scaled(&self) -> f64 {
+    /// Returns `avg_vam` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_vam_scaled(&self) -> Option<f64> {
         if self.avg_vam == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_vam as f64 / 1000.0 - 0.0
+        Some(self.avg_vam as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_vam` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1878,12 +1864,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_depth_scaled(&self) -> f64 {
+    /// Returns `avg_depth` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_depth_scaled(&self) -> Option<f64> {
         if self.avg_depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_depth as f64 / 1000.0 - 0.0
+        Some(self.avg_depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1897,12 +1883,12 @@ impl Lap {
         self
     }
 
-    /// Returns `max_depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_depth_scaled(&self) -> f64 {
+    /// Returns `max_depth` in its scaled value. It returns `None` when value is valid.
+    pub fn max_depth_scaled(&self) -> Option<f64> {
         if self.max_depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_depth as f64 / 1000.0 - 0.0
+        Some(self.max_depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1916,12 +1902,12 @@ impl Lap {
         self
     }
 
-    /// Returns `enhanced_avg_respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_avg_respiration_rate_scaled(&self) -> f64 {
+    /// Returns `enhanced_avg_respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_avg_respiration_rate_scaled(&self) -> Option<f64> {
         if self.enhanced_avg_respiration_rate == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_avg_respiration_rate as f64 / 100.0 - 0.0
+        Some(self.enhanced_avg_respiration_rate as f64 / 100.0 - 0.0)
     }
 
     /// Set `enhanced_avg_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1935,12 +1921,12 @@ impl Lap {
         self
     }
 
-    /// Returns `enhanced_max_respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_max_respiration_rate_scaled(&self) -> f64 {
+    /// Returns `enhanced_max_respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_max_respiration_rate_scaled(&self) -> Option<f64> {
         if self.enhanced_max_respiration_rate == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_max_respiration_rate as f64 / 100.0 - 0.0
+        Some(self.enhanced_max_respiration_rate as f64 / 100.0 - 0.0)
     }
 
     /// Set `enhanced_max_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1954,12 +1940,12 @@ impl Lap {
         self
     }
 
-    /// Returns `total_fractional_ascent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_fractional_ascent_scaled(&self) -> f64 {
+    /// Returns `total_fractional_ascent` in its scaled value. It returns `None` when value is valid.
+    pub fn total_fractional_ascent_scaled(&self) -> Option<f64> {
         if self.total_fractional_ascent == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_fractional_ascent as f64 / 100.0 - 0.0
+        Some(self.total_fractional_ascent as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_fractional_ascent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1973,12 +1959,12 @@ impl Lap {
         self
     }
 
-    /// Returns `total_fractional_descent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_fractional_descent_scaled(&self) -> f64 {
+    /// Returns `total_fractional_descent` in its scaled value. It returns `None` when value is valid.
+    pub fn total_fractional_descent_scaled(&self) -> Option<f64> {
         if self.total_fractional_descent == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_fractional_descent as f64 / 100.0 - 0.0
+        Some(self.total_fractional_descent as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_fractional_descent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1992,12 +1978,12 @@ impl Lap {
         self
     }
 
-    /// Returns `avg_core_temperature` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_core_temperature_scaled(&self) -> f64 {
+    /// Returns `avg_core_temperature` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_core_temperature_scaled(&self) -> Option<f64> {
         if self.avg_core_temperature == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_core_temperature as f64 / 100.0 - 0.0
+        Some(self.avg_core_temperature as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2011,12 +1997,12 @@ impl Lap {
         self
     }
 
-    /// Returns `min_core_temperature` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_core_temperature_scaled(&self) -> f64 {
+    /// Returns `min_core_temperature` in its scaled value. It returns `None` when value is valid.
+    pub fn min_core_temperature_scaled(&self) -> Option<f64> {
         if self.min_core_temperature == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.min_core_temperature as f64 / 100.0 - 0.0
+        Some(self.min_core_temperature as f64 / 100.0 - 0.0)
     }
 
     /// Set `min_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2030,12 +2016,12 @@ impl Lap {
         self
     }
 
-    /// Returns `max_core_temperature` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_core_temperature_scaled(&self) -> f64 {
+    /// Returns `max_core_temperature` in its scaled value. It returns `None` when value is valid.
+    pub fn max_core_temperature_scaled(&self) -> Option<f64> {
         if self.max_core_temperature == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_core_temperature as f64 / 100.0 - 0.0
+        Some(self.max_core_temperature as f64 / 100.0 - 0.0)
     }
 
     /// Set `max_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/length.rs
+++ b/rustyfit/src/profile/mesgdef/length.rs
@@ -137,12 +137,12 @@ impl Length {
         }
     }
 
-    /// Returns `total_elapsed_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_elapsed_time_scaled(&self) -> f64 {
+    /// Returns `total_elapsed_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_elapsed_time_scaled(&self) -> Option<f64> {
         if self.total_elapsed_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_elapsed_time as f64 / 1000.0 - 0.0
+        Some(self.total_elapsed_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -156,12 +156,12 @@ impl Length {
         self
     }
 
-    /// Returns `total_timer_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_timer_time_scaled(&self) -> f64 {
+    /// Returns `total_timer_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_timer_time_scaled(&self) -> Option<f64> {
         if self.total_timer_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_timer_time as f64 / 1000.0 - 0.0
+        Some(self.total_timer_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -175,12 +175,12 @@ impl Length {
         self
     }
 
-    /// Returns `avg_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_speed_scaled(&self) -> f64 {
+    /// Returns `avg_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_speed_scaled(&self) -> Option<f64> {
         if self.avg_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -194,12 +194,12 @@ impl Length {
         self
     }
 
-    /// Returns `enhanced_avg_respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_avg_respiration_rate_scaled(&self) -> f64 {
+    /// Returns `enhanced_avg_respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_avg_respiration_rate_scaled(&self) -> Option<f64> {
         if self.enhanced_avg_respiration_rate == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_avg_respiration_rate as f64 / 100.0 - 0.0
+        Some(self.enhanced_avg_respiration_rate as f64 / 100.0 - 0.0)
     }
 
     /// Set `enhanced_avg_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -213,12 +213,12 @@ impl Length {
         self
     }
 
-    /// Returns `enhanced_max_respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_max_respiration_rate_scaled(&self) -> f64 {
+    /// Returns `enhanced_max_respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_max_respiration_rate_scaled(&self) -> Option<f64> {
         if self.enhanced_max_respiration_rate == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_max_respiration_rate as f64 / 100.0 - 0.0
+        Some(self.enhanced_max_respiration_rate as f64 / 100.0 - 0.0)
     }
 
     /// Set `enhanced_max_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/max_met_data.rs
+++ b/rustyfit/src/profile/mesgdef/max_met_data.rs
@@ -66,12 +66,12 @@ impl MaxMetData {
         }
     }
 
-    /// Returns `vo2_max` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn vo2_max_scaled(&self) -> f64 {
+    /// Returns `vo2_max` in its scaled value. It returns `None` when value is valid.
+    pub fn vo2_max_scaled(&self) -> Option<f64> {
         if self.vo2_max == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.vo2_max as f64 / 10.0 - 0.0
+        Some(self.vo2_max as f64 / 10.0 - 0.0)
     }
 
     /// Set `vo2_max` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/met_zone.rs
+++ b/rustyfit/src/profile/mesgdef/met_zone.rs
@@ -47,12 +47,12 @@ impl MetZone {
         }
     }
 
-    /// Returns `calories` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn calories_scaled(&self) -> f64 {
+    /// Returns `calories` in its scaled value. It returns `None` when value is valid.
+    pub fn calories_scaled(&self) -> Option<f64> {
         if self.calories == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.calories as f64 / 10.0 - 0.0
+        Some(self.calories as f64 / 10.0 - 0.0)
     }
 
     /// Set `calories` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -66,12 +66,12 @@ impl MetZone {
         self
     }
 
-    /// Returns `fat_calories` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn fat_calories_scaled(&self) -> f64 {
+    /// Returns `fat_calories` in its scaled value. It returns `None` when value is valid.
+    pub fn fat_calories_scaled(&self) -> Option<f64> {
         if self.fat_calories == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.fat_calories as f64 / 10.0 - 0.0
+        Some(self.fat_calories as f64 / 10.0 - 0.0)
     }
 
     /// Set `fat_calories` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/monitoring.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring.rs
@@ -180,12 +180,12 @@ impl Monitoring {
         }
     }
 
-    /// Returns `distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn distance_scaled(&self) -> f64 {
+    /// Returns `distance` in its scaled value. It returns `None` when value is valid.
+    pub fn distance_scaled(&self) -> Option<f64> {
         if self.distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.distance as f64 / 100.0 - 0.0
+        Some(self.distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -199,12 +199,12 @@ impl Monitoring {
         self
     }
 
-    /// Returns `cycles` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn cycles_scaled(&self) -> f64 {
+    /// Returns `cycles` in its scaled value. It returns `None` when value is valid.
+    pub fn cycles_scaled(&self) -> Option<f64> {
         if self.cycles == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.cycles as f64 / 2.0 - 0.0
+        Some(self.cycles as f64 / 2.0 - 0.0)
     }
 
     /// Set `cycles` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -218,12 +218,12 @@ impl Monitoring {
         self
     }
 
-    /// Returns `active_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn active_time_scaled(&self) -> f64 {
+    /// Returns `active_time` in its scaled value. It returns `None` when value is valid.
+    pub fn active_time_scaled(&self) -> Option<f64> {
         if self.active_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.active_time as f64 / 1000.0 - 0.0
+        Some(self.active_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -237,12 +237,12 @@ impl Monitoring {
         self
     }
 
-    /// Returns `temperature` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn temperature_scaled(&self) -> f64 {
+    /// Returns `temperature` in its scaled value. It returns `None` when value is valid.
+    pub fn temperature_scaled(&self) -> Option<f64> {
         if self.temperature == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.temperature as f64 / 100.0 - 0.0
+        Some(self.temperature as f64 / 100.0 - 0.0)
     }
 
     /// Set `temperature` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -256,12 +256,12 @@ impl Monitoring {
         self
     }
 
-    /// Returns `temperature_min` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn temperature_min_scaled(&self) -> f64 {
+    /// Returns `temperature_min` in its scaled value. It returns `None` when value is valid.
+    pub fn temperature_min_scaled(&self) -> Option<f64> {
         if self.temperature_min == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.temperature_min as f64 / 100.0 - 0.0
+        Some(self.temperature_min as f64 / 100.0 - 0.0)
     }
 
     /// Set `temperature_min` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -275,12 +275,12 @@ impl Monitoring {
         self
     }
 
-    /// Returns `temperature_max` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn temperature_max_scaled(&self) -> f64 {
+    /// Returns `temperature_max` in its scaled value. It returns `None` when value is valid.
+    pub fn temperature_max_scaled(&self) -> Option<f64> {
         if self.temperature_max == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.temperature_max as f64 / 100.0 - 0.0
+        Some(self.temperature_max as f64 / 100.0 - 0.0)
     }
 
     /// Set `temperature_max` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -294,12 +294,12 @@ impl Monitoring {
         self
     }
 
-    /// Returns `intensity` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn intensity_scaled(&self) -> f64 {
+    /// Returns `intensity` in its scaled value. It returns `None` when value is valid.
+    pub fn intensity_scaled(&self) -> Option<f64> {
         if self.intensity == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.intensity as f64 / 10.0 - 0.0
+        Some(self.intensity as f64 / 10.0 - 0.0)
     }
 
     /// Set `intensity` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -313,12 +313,12 @@ impl Monitoring {
         self
     }
 
-    /// Returns `ascent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn ascent_scaled(&self) -> f64 {
+    /// Returns `ascent` in its scaled value. It returns `None` when value is valid.
+    pub fn ascent_scaled(&self) -> Option<f64> {
         if self.ascent == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.ascent as f64 / 1000.0 - 0.0
+        Some(self.ascent as f64 / 1000.0 - 0.0)
     }
 
     /// Set `ascent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -332,12 +332,12 @@ impl Monitoring {
         self
     }
 
-    /// Returns `descent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn descent_scaled(&self) -> f64 {
+    /// Returns `descent` in its scaled value. It returns `None` when value is valid.
+    pub fn descent_scaled(&self) -> Option<f64> {
         if self.descent == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.descent as f64 / 1000.0 - 0.0
+        Some(self.descent as f64 / 1000.0 - 0.0)
     }
 
     /// Set `descent` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/monitoring_info.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_info.rs
@@ -58,25 +58,24 @@ impl MonitoringInfo {
         }
     }
 
-    /// Returns `cycles_to_distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn cycles_to_distance_scaled(&self) -> Vec<f64> {
+    /// Returns `cycles_to_distance` in its scaled value. It returns `None` when value is valid.
+    pub fn cycles_to_distance_scaled(&self) -> Option<Vec<f64>> {
         if self.cycles_to_distance.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.cycles_to_distance.len());
         for &x in &self.cycles_to_distance {
             v.push(x as f64 / 5000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `cycles_to_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_cycles_to_distance_scaled(&mut self, v: &Vec<f64>) -> &mut MonitoringInfo {
+    pub fn set_cycles_to_distance_scaled(&mut self, v: &[f64]) -> &mut MonitoringInfo {
+        self.cycles_to_distance = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.cycles_to_distance = Vec::new();
             return self;
         }
-        self.cycles_to_distance = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 5000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -88,25 +87,24 @@ impl MonitoringInfo {
         self
     }
 
-    /// Returns `cycles_to_calories` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn cycles_to_calories_scaled(&self) -> Vec<f64> {
+    /// Returns `cycles_to_calories` in its scaled value. It returns `None` when value is valid.
+    pub fn cycles_to_calories_scaled(&self) -> Option<Vec<f64>> {
         if self.cycles_to_calories.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.cycles_to_calories.len());
         for &x in &self.cycles_to_calories {
             v.push(x as f64 / 5000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `cycles_to_calories` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_cycles_to_calories_scaled(&mut self, v: &Vec<f64>) -> &mut MonitoringInfo {
+    pub fn set_cycles_to_calories_scaled(&mut self, v: &[f64]) -> &mut MonitoringInfo {
+        self.cycles_to_calories = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.cycles_to_calories = Vec::new();
             return self;
         }
-        self.cycles_to_calories = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 5000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -454,22 +454,22 @@ impl Record {
         }
     }
 
-    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_lat_degrees(&self) -> f64 {
+    /// Returns `position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_lat)
     }
 
-    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_long_degrees(&self) -> f64 {
+    /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
     }
 
-    /// Returns `altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn altitude_scaled(&self) -> f64 {
+    /// Returns `altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn altitude_scaled(&self) -> Option<f64> {
         if self.altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.altitude as f64 / 5.0 - 500.0
+        Some(self.altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -483,12 +483,12 @@ impl Record {
         self
     }
 
-    /// Returns `distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn distance_scaled(&self) -> f64 {
+    /// Returns `distance` in its scaled value. It returns `None` when value is valid.
+    pub fn distance_scaled(&self) -> Option<f64> {
         if self.distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.distance as f64 / 100.0 - 0.0
+        Some(self.distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -502,12 +502,12 @@ impl Record {
         self
     }
 
-    /// Returns `speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn speed_scaled(&self) -> f64 {
+    /// Returns `speed` in its scaled value. It returns `None` when value is valid.
+    pub fn speed_scaled(&self) -> Option<f64> {
         if self.speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.speed as f64 / 1000.0 - 0.0
+        Some(self.speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -521,12 +521,12 @@ impl Record {
         self
     }
 
-    /// Returns `grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn grade_scaled(&self) -> f64 {
+    /// Returns `grade` in its scaled value. It returns `None` when value is valid.
+    pub fn grade_scaled(&self) -> Option<f64> {
         if self.grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.grade as f64 / 100.0 - 0.0
+        Some(self.grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -540,12 +540,12 @@ impl Record {
         self
     }
 
-    /// Returns `time_from_course` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_from_course_scaled(&self) -> f64 {
+    /// Returns `time_from_course` in its scaled value. It returns `None` when value is valid.
+    pub fn time_from_course_scaled(&self) -> Option<f64> {
         if self.time_from_course == i32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.time_from_course as f64 / 1000.0 - 0.0
+        Some(self.time_from_course as f64 / 1000.0 - 0.0)
     }
 
     /// Set `time_from_course` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -559,12 +559,12 @@ impl Record {
         self
     }
 
-    /// Returns `cycle_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn cycle_length_scaled(&self) -> f64 {
+    /// Returns `cycle_length` in its scaled value. It returns `None` when value is valid.
+    pub fn cycle_length_scaled(&self) -> Option<f64> {
         if self.cycle_length == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.cycle_length as f64 / 100.0 - 0.0
+        Some(self.cycle_length as f64 / 100.0 - 0.0)
     }
 
     /// Set `cycle_length` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -578,25 +578,24 @@ impl Record {
         self
     }
 
-    /// Returns `speed_1s` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn speed_1s_scaled(&self) -> Vec<f64> {
+    /// Returns `speed_1s` in its scaled value. It returns `None` when value is valid.
+    pub fn speed_1s_scaled(&self) -> Option<Vec<f64>> {
         if self.speed_1s.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.speed_1s.len());
         for &x in &self.speed_1s {
             v.push(x as f64 / 16.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `speed_1s` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_speed_1s_scaled(&mut self, v: &Vec<f64>) -> &mut Record {
+    pub fn set_speed_1s_scaled(&mut self, v: &[f64]) -> &mut Record {
+        self.speed_1s = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.speed_1s = Vec::new();
             return self;
         }
-        self.speed_1s = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 16.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -608,12 +607,12 @@ impl Record {
         self
     }
 
-    /// Returns `vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn vertical_speed_scaled(&self) -> f64 {
+    /// Returns `vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn vertical_speed_scaled(&self) -> Option<f64> {
         if self.vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -627,12 +626,12 @@ impl Record {
         self
     }
 
-    /// Returns `vertical_oscillation` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn vertical_oscillation_scaled(&self) -> f64 {
+    /// Returns `vertical_oscillation` in its scaled value. It returns `None` when value is valid.
+    pub fn vertical_oscillation_scaled(&self) -> Option<f64> {
         if self.vertical_oscillation == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.vertical_oscillation as f64 / 10.0 - 0.0
+        Some(self.vertical_oscillation as f64 / 10.0 - 0.0)
     }
 
     /// Set `vertical_oscillation` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -646,12 +645,12 @@ impl Record {
         self
     }
 
-    /// Returns `stance_time_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn stance_time_percent_scaled(&self) -> f64 {
+    /// Returns `stance_time_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn stance_time_percent_scaled(&self) -> Option<f64> {
         if self.stance_time_percent == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.stance_time_percent as f64 / 100.0 - 0.0
+        Some(self.stance_time_percent as f64 / 100.0 - 0.0)
     }
 
     /// Set `stance_time_percent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -665,12 +664,12 @@ impl Record {
         self
     }
 
-    /// Returns `stance_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn stance_time_scaled(&self) -> f64 {
+    /// Returns `stance_time` in its scaled value. It returns `None` when value is valid.
+    pub fn stance_time_scaled(&self) -> Option<f64> {
         if self.stance_time == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.stance_time as f64 / 10.0 - 0.0
+        Some(self.stance_time as f64 / 10.0 - 0.0)
     }
 
     /// Set `stance_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -684,12 +683,12 @@ impl Record {
         self
     }
 
-    /// Returns `left_torque_effectiveness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn left_torque_effectiveness_scaled(&self) -> f64 {
+    /// Returns `left_torque_effectiveness` in its scaled value. It returns `None` when value is valid.
+    pub fn left_torque_effectiveness_scaled(&self) -> Option<f64> {
         if self.left_torque_effectiveness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.left_torque_effectiveness as f64 / 2.0 - 0.0
+        Some(self.left_torque_effectiveness as f64 / 2.0 - 0.0)
     }
 
     /// Set `left_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -703,12 +702,12 @@ impl Record {
         self
     }
 
-    /// Returns `right_torque_effectiveness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn right_torque_effectiveness_scaled(&self) -> f64 {
+    /// Returns `right_torque_effectiveness` in its scaled value. It returns `None` when value is valid.
+    pub fn right_torque_effectiveness_scaled(&self) -> Option<f64> {
         if self.right_torque_effectiveness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.right_torque_effectiveness as f64 / 2.0 - 0.0
+        Some(self.right_torque_effectiveness as f64 / 2.0 - 0.0)
     }
 
     /// Set `right_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -722,12 +721,12 @@ impl Record {
         self
     }
 
-    /// Returns `left_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn left_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `left_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn left_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.left_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.left_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.left_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `left_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -741,12 +740,12 @@ impl Record {
         self
     }
 
-    /// Returns `right_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn right_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `right_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn right_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.right_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.right_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.right_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `right_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -760,12 +759,12 @@ impl Record {
         self
     }
 
-    /// Returns `combined_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn combined_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `combined_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn combined_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.combined_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.combined_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.combined_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `combined_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -779,12 +778,12 @@ impl Record {
         self
     }
 
-    /// Returns `time128` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time128_scaled(&self) -> f64 {
+    /// Returns `time128` in its scaled value. It returns `None` when value is valid.
+    pub fn time128_scaled(&self) -> Option<f64> {
         if self.time128 == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.time128 as f64 / 128.0 - 0.0
+        Some(self.time128 as f64 / 128.0 - 0.0)
     }
 
     /// Set `time128` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -798,12 +797,12 @@ impl Record {
         self
     }
 
-    /// Returns `ball_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn ball_speed_scaled(&self) -> f64 {
+    /// Returns `ball_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn ball_speed_scaled(&self) -> Option<f64> {
         if self.ball_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.ball_speed as f64 / 100.0 - 0.0
+        Some(self.ball_speed as f64 / 100.0 - 0.0)
     }
 
     /// Set `ball_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -817,12 +816,12 @@ impl Record {
         self
     }
 
-    /// Returns `cadence256` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn cadence256_scaled(&self) -> f64 {
+    /// Returns `cadence256` in its scaled value. It returns `None` when value is valid.
+    pub fn cadence256_scaled(&self) -> Option<f64> {
         if self.cadence256 == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.cadence256 as f64 / 256.0 - 0.0
+        Some(self.cadence256 as f64 / 256.0 - 0.0)
     }
 
     /// Set `cadence256` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -836,12 +835,12 @@ impl Record {
         self
     }
 
-    /// Returns `fractional_cadence` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn fractional_cadence_scaled(&self) -> f64 {
+    /// Returns `fractional_cadence` in its scaled value. It returns `None` when value is valid.
+    pub fn fractional_cadence_scaled(&self) -> Option<f64> {
         if self.fractional_cadence == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.fractional_cadence as f64 / 128.0 - 0.0
+        Some(self.fractional_cadence as f64 / 128.0 - 0.0)
     }
 
     /// Set `fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -855,12 +854,12 @@ impl Record {
         self
     }
 
-    /// Returns `total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_hemoglobin_conc_scaled(&self) -> f64 {
+    /// Returns `total_hemoglobin_conc` in its scaled value. It returns `None` when value is valid.
+    pub fn total_hemoglobin_conc_scaled(&self) -> Option<f64> {
         if self.total_hemoglobin_conc == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_hemoglobin_conc as f64 / 100.0 - 0.0
+        Some(self.total_hemoglobin_conc as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -874,12 +873,12 @@ impl Record {
         self
     }
 
-    /// Returns `total_hemoglobin_conc_min` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_hemoglobin_conc_min_scaled(&self) -> f64 {
+    /// Returns `total_hemoglobin_conc_min` in its scaled value. It returns `None` when value is valid.
+    pub fn total_hemoglobin_conc_min_scaled(&self) -> Option<f64> {
         if self.total_hemoglobin_conc_min == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_hemoglobin_conc_min as f64 / 100.0 - 0.0
+        Some(self.total_hemoglobin_conc_min as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_hemoglobin_conc_min` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -893,12 +892,12 @@ impl Record {
         self
     }
 
-    /// Returns `total_hemoglobin_conc_max` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_hemoglobin_conc_max_scaled(&self) -> f64 {
+    /// Returns `total_hemoglobin_conc_max` in its scaled value. It returns `None` when value is valid.
+    pub fn total_hemoglobin_conc_max_scaled(&self) -> Option<f64> {
         if self.total_hemoglobin_conc_max == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_hemoglobin_conc_max as f64 / 100.0 - 0.0
+        Some(self.total_hemoglobin_conc_max as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_hemoglobin_conc_max` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -912,12 +911,12 @@ impl Record {
         self
     }
 
-    /// Returns `saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn saturated_hemoglobin_percent_scaled(&self) -> f64 {
+    /// Returns `saturated_hemoglobin_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn saturated_hemoglobin_percent_scaled(&self) -> Option<f64> {
         if self.saturated_hemoglobin_percent == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.saturated_hemoglobin_percent as f64 / 10.0 - 0.0
+        Some(self.saturated_hemoglobin_percent as f64 / 10.0 - 0.0)
     }
 
     /// Set `saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -931,12 +930,12 @@ impl Record {
         self
     }
 
-    /// Returns `saturated_hemoglobin_percent_min` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn saturated_hemoglobin_percent_min_scaled(&self) -> f64 {
+    /// Returns `saturated_hemoglobin_percent_min` in its scaled value. It returns `None` when value is valid.
+    pub fn saturated_hemoglobin_percent_min_scaled(&self) -> Option<f64> {
         if self.saturated_hemoglobin_percent_min == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.saturated_hemoglobin_percent_min as f64 / 10.0 - 0.0
+        Some(self.saturated_hemoglobin_percent_min as f64 / 10.0 - 0.0)
     }
 
     /// Set `saturated_hemoglobin_percent_min` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -950,12 +949,12 @@ impl Record {
         self
     }
 
-    /// Returns `saturated_hemoglobin_percent_max` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn saturated_hemoglobin_percent_max_scaled(&self) -> f64 {
+    /// Returns `saturated_hemoglobin_percent_max` in its scaled value. It returns `None` when value is valid.
+    pub fn saturated_hemoglobin_percent_max_scaled(&self) -> Option<f64> {
         if self.saturated_hemoglobin_percent_max == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.saturated_hemoglobin_percent_max as f64 / 10.0 - 0.0
+        Some(self.saturated_hemoglobin_percent_max as f64 / 10.0 - 0.0)
     }
 
     /// Set `saturated_hemoglobin_percent_max` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -969,25 +968,24 @@ impl Record {
         self
     }
 
-    /// Returns `left_power_phase` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn left_power_phase_scaled(&self) -> Vec<f64> {
+    /// Returns `left_power_phase` in its scaled value. It returns `None` when value is valid.
+    pub fn left_power_phase_scaled(&self) -> Option<Vec<f64>> {
         if self.left_power_phase.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.left_power_phase.len());
         for &x in &self.left_power_phase {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `left_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_left_power_phase_scaled(&mut self, v: &Vec<f64>) -> &mut Record {
+    pub fn set_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Record {
+        self.left_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.left_power_phase = Vec::new();
             return self;
         }
-        self.left_power_phase = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -999,25 +997,24 @@ impl Record {
         self
     }
 
-    /// Returns `left_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn left_power_phase_peak_scaled(&self) -> Vec<f64> {
+    /// Returns `left_power_phase_peak` in its scaled value. It returns `None` when value is valid.
+    pub fn left_power_phase_peak_scaled(&self) -> Option<Vec<f64>> {
         if self.left_power_phase_peak.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.left_power_phase_peak.len());
         for &x in &self.left_power_phase_peak {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `left_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_left_power_phase_peak_scaled(&mut self, v: &Vec<f64>) -> &mut Record {
+    pub fn set_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Record {
+        self.left_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.left_power_phase_peak = Vec::new();
             return self;
         }
-        self.left_power_phase_peak = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1029,25 +1026,24 @@ impl Record {
         self
     }
 
-    /// Returns `right_power_phase` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn right_power_phase_scaled(&self) -> Vec<f64> {
+    /// Returns `right_power_phase` in its scaled value. It returns `None` when value is valid.
+    pub fn right_power_phase_scaled(&self) -> Option<Vec<f64>> {
         if self.right_power_phase.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.right_power_phase.len());
         for &x in &self.right_power_phase {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `right_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_right_power_phase_scaled(&mut self, v: &Vec<f64>) -> &mut Record {
+    pub fn set_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Record {
+        self.right_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.right_power_phase = Vec::new();
             return self;
         }
-        self.right_power_phase = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1059,25 +1055,24 @@ impl Record {
         self
     }
 
-    /// Returns `right_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn right_power_phase_peak_scaled(&self) -> Vec<f64> {
+    /// Returns `right_power_phase_peak` in its scaled value. It returns `None` when value is valid.
+    pub fn right_power_phase_peak_scaled(&self) -> Option<Vec<f64>> {
         if self.right_power_phase_peak.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.right_power_phase_peak.len());
         for &x in &self.right_power_phase_peak {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `right_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_right_power_phase_peak_scaled(&mut self, v: &Vec<f64>) -> &mut Record {
+    pub fn set_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Record {
+        self.right_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.right_power_phase_peak = Vec::new();
             return self;
         }
-        self.right_power_phase_peak = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1089,12 +1084,12 @@ impl Record {
         self
     }
 
-    /// Returns `enhanced_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_speed_scaled(&self) -> f64 {
+    /// Returns `enhanced_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_speed_scaled(&self) -> Option<f64> {
         if self.enhanced_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_speed as f64 / 1000.0 - 0.0
+        Some(self.enhanced_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `enhanced_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1108,12 +1103,12 @@ impl Record {
         self
     }
 
-    /// Returns `enhanced_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1127,12 +1122,12 @@ impl Record {
         self
     }
 
-    /// Returns `battery_soc` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn battery_soc_scaled(&self) -> f64 {
+    /// Returns `battery_soc` in its scaled value. It returns `None` when value is valid.
+    pub fn battery_soc_scaled(&self) -> Option<f64> {
         if self.battery_soc == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.battery_soc as f64 / 2.0 - 0.0
+        Some(self.battery_soc as f64 / 2.0 - 0.0)
     }
 
     /// Set `battery_soc` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1146,12 +1141,12 @@ impl Record {
         self
     }
 
-    /// Returns `vertical_ratio` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn vertical_ratio_scaled(&self) -> f64 {
+    /// Returns `vertical_ratio` in its scaled value. It returns `None` when value is valid.
+    pub fn vertical_ratio_scaled(&self) -> Option<f64> {
         if self.vertical_ratio == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.vertical_ratio as f64 / 100.0 - 0.0
+        Some(self.vertical_ratio as f64 / 100.0 - 0.0)
     }
 
     /// Set `vertical_ratio` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1165,12 +1160,12 @@ impl Record {
         self
     }
 
-    /// Returns `stance_time_balance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn stance_time_balance_scaled(&self) -> f64 {
+    /// Returns `stance_time_balance` in its scaled value. It returns `None` when value is valid.
+    pub fn stance_time_balance_scaled(&self) -> Option<f64> {
         if self.stance_time_balance == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.stance_time_balance as f64 / 100.0 - 0.0
+        Some(self.stance_time_balance as f64 / 100.0 - 0.0)
     }
 
     /// Set `stance_time_balance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1184,12 +1179,12 @@ impl Record {
         self
     }
 
-    /// Returns `step_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn step_length_scaled(&self) -> f64 {
+    /// Returns `step_length` in its scaled value. It returns `None` when value is valid.
+    pub fn step_length_scaled(&self) -> Option<f64> {
         if self.step_length == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.step_length as f64 / 10.0 - 0.0
+        Some(self.step_length as f64 / 10.0 - 0.0)
     }
 
     /// Set `step_length` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1203,12 +1198,12 @@ impl Record {
         self
     }
 
-    /// Returns `cycle_length16` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn cycle_length16_scaled(&self) -> f64 {
+    /// Returns `cycle_length16` in its scaled value. It returns `None` when value is valid.
+    pub fn cycle_length16_scaled(&self) -> Option<f64> {
         if self.cycle_length16 == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.cycle_length16 as f64 / 100.0 - 0.0
+        Some(self.cycle_length16 as f64 / 100.0 - 0.0)
     }
 
     /// Set `cycle_length16` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1222,12 +1217,12 @@ impl Record {
         self
     }
 
-    /// Returns `depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn depth_scaled(&self) -> f64 {
+    /// Returns `depth` in its scaled value. It returns `None` when value is valid.
+    pub fn depth_scaled(&self) -> Option<f64> {
         if self.depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.depth as f64 / 1000.0 - 0.0
+        Some(self.depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1241,12 +1236,12 @@ impl Record {
         self
     }
 
-    /// Returns `next_stop_depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn next_stop_depth_scaled(&self) -> f64 {
+    /// Returns `next_stop_depth` in its scaled value. It returns `None` when value is valid.
+    pub fn next_stop_depth_scaled(&self) -> Option<f64> {
         if self.next_stop_depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.next_stop_depth as f64 / 1000.0 - 0.0
+        Some(self.next_stop_depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `next_stop_depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1260,12 +1255,12 @@ impl Record {
         self
     }
 
-    /// Returns `enhanced_respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_respiration_rate_scaled(&self) -> f64 {
+    /// Returns `enhanced_respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_respiration_rate_scaled(&self) -> Option<f64> {
         if self.enhanced_respiration_rate == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_respiration_rate as f64 / 100.0 - 0.0
+        Some(self.enhanced_respiration_rate as f64 / 100.0 - 0.0)
     }
 
     /// Set `enhanced_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1279,12 +1274,12 @@ impl Record {
         self
     }
 
-    /// Returns `current_stress` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn current_stress_scaled(&self) -> f64 {
+    /// Returns `current_stress` in its scaled value. It returns `None` when value is valid.
+    pub fn current_stress_scaled(&self) -> Option<f64> {
         if self.current_stress == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.current_stress as f64 / 100.0 - 0.0
+        Some(self.current_stress as f64 / 100.0 - 0.0)
     }
 
     /// Set `current_stress` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1298,12 +1293,12 @@ impl Record {
         self
     }
 
-    /// Returns `pressure_sac` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn pressure_sac_scaled(&self) -> f64 {
+    /// Returns `pressure_sac` in its scaled value. It returns `None` when value is valid.
+    pub fn pressure_sac_scaled(&self) -> Option<f64> {
         if self.pressure_sac == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.pressure_sac as f64 / 100.0 - 0.0
+        Some(self.pressure_sac as f64 / 100.0 - 0.0)
     }
 
     /// Set `pressure_sac` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1317,12 +1312,12 @@ impl Record {
         self
     }
 
-    /// Returns `volume_sac` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn volume_sac_scaled(&self) -> f64 {
+    /// Returns `volume_sac` in its scaled value. It returns `None` when value is valid.
+    pub fn volume_sac_scaled(&self) -> Option<f64> {
         if self.volume_sac == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.volume_sac as f64 / 100.0 - 0.0
+        Some(self.volume_sac as f64 / 100.0 - 0.0)
     }
 
     /// Set `volume_sac` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1336,12 +1331,12 @@ impl Record {
         self
     }
 
-    /// Returns `rmv` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn rmv_scaled(&self) -> f64 {
+    /// Returns `rmv` in its scaled value. It returns `None` when value is valid.
+    pub fn rmv_scaled(&self) -> Option<f64> {
         if self.rmv == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.rmv as f64 / 100.0 - 0.0
+        Some(self.rmv as f64 / 100.0 - 0.0)
     }
 
     /// Set `rmv` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1355,12 +1350,12 @@ impl Record {
         self
     }
 
-    /// Returns `ascent_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn ascent_rate_scaled(&self) -> f64 {
+    /// Returns `ascent_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn ascent_rate_scaled(&self) -> Option<f64> {
         if self.ascent_rate == i32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.ascent_rate as f64 / 1000.0 - 0.0
+        Some(self.ascent_rate as f64 / 1000.0 - 0.0)
     }
 
     /// Set `ascent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1374,12 +1369,12 @@ impl Record {
         self
     }
 
-    /// Returns `po2` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn po2_scaled(&self) -> f64 {
+    /// Returns `po2` in its scaled value. It returns `None` when value is valid.
+    pub fn po2_scaled(&self) -> Option<f64> {
         if self.po2 == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.po2 as f64 / 100.0 - 0.0
+        Some(self.po2 as f64 / 100.0 - 0.0)
     }
 
     /// Set `po2` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1393,12 +1388,12 @@ impl Record {
         self
     }
 
-    /// Returns `core_temperature` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn core_temperature_scaled(&self) -> f64 {
+    /// Returns `core_temperature` in its scaled value. It returns `None` when value is valid.
+    pub fn core_temperature_scaled(&self) -> Option<f64> {
         if self.core_temperature == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.core_temperature as f64 / 100.0 - 0.0
+        Some(self.core_temperature as f64 / 100.0 - 0.0)
     }
 
     /// Set `core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/respiration_rate.rs
+++ b/rustyfit/src/profile/mesgdef/respiration_rate.rs
@@ -38,12 +38,12 @@ impl RespirationRate {
         }
     }
 
-    /// Returns `respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn respiration_rate_scaled(&self) -> f64 {
+    /// Returns `respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn respiration_rate_scaled(&self) -> Option<f64> {
         if self.respiration_rate == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.respiration_rate as f64 / 100.0 - 0.0
+        Some(self.respiration_rate as f64 / 100.0 - 0.0)
     }
 
     /// Set `respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/sdm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/sdm_profile.rs
@@ -67,12 +67,12 @@ impl SdmProfile {
         }
     }
 
-    /// Returns `sdm_cal_factor` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn sdm_cal_factor_scaled(&self) -> f64 {
+    /// Returns `sdm_cal_factor` in its scaled value. It returns `None` when value is valid.
+    pub fn sdm_cal_factor_scaled(&self) -> Option<f64> {
         if self.sdm_cal_factor == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.sdm_cal_factor as f64 / 10.0 - 0.0
+        Some(self.sdm_cal_factor as f64 / 10.0 - 0.0)
     }
 
     /// Set `sdm_cal_factor` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -86,12 +86,12 @@ impl SdmProfile {
         self
     }
 
-    /// Returns `odometer` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn odometer_scaled(&self) -> f64 {
+    /// Returns `odometer` in its scaled value. It returns `None` when value is valid.
+    pub fn odometer_scaled(&self) -> Option<f64> {
         if self.odometer == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.odometer as f64 / 100.0 - 0.0
+        Some(self.odometer as f64 / 100.0 - 0.0)
     }
 
     /// Set `odometer` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -500,52 +500,52 @@ impl SegmentLap {
         }
     }
 
-    /// Returns `start_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn start_position_lat_degrees(&self) -> f64 {
+    /// Returns `start_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn start_position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_lat)
     }
 
-    /// Returns `start_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn start_position_long_degrees(&self) -> f64 {
+    /// Returns `start_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn start_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_long)
     }
 
-    /// Returns `end_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn end_position_lat_degrees(&self) -> f64 {
+    /// Returns `end_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn end_position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_lat)
     }
 
-    /// Returns `end_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn end_position_long_degrees(&self) -> f64 {
+    /// Returns `end_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn end_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_long)
     }
 
-    /// Returns `nec_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn nec_lat_degrees(&self) -> f64 {
+    /// Returns `nec_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn nec_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.nec_lat)
     }
 
-    /// Returns `nec_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn nec_long_degrees(&self) -> f64 {
+    /// Returns `nec_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn nec_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.nec_long)
     }
 
-    /// Returns `swc_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn swc_lat_degrees(&self) -> f64 {
+    /// Returns `swc_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn swc_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.swc_lat)
     }
 
-    /// Returns `swc_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn swc_long_degrees(&self) -> f64 {
+    /// Returns `swc_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn swc_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.swc_long)
     }
 
-    /// Returns `total_elapsed_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_elapsed_time_scaled(&self) -> f64 {
+    /// Returns `total_elapsed_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_elapsed_time_scaled(&self) -> Option<f64> {
         if self.total_elapsed_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_elapsed_time as f64 / 1000.0 - 0.0
+        Some(self.total_elapsed_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -559,12 +559,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `total_timer_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_timer_time_scaled(&self) -> f64 {
+    /// Returns `total_timer_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_timer_time_scaled(&self) -> Option<f64> {
         if self.total_timer_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_timer_time as f64 / 1000.0 - 0.0
+        Some(self.total_timer_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -578,12 +578,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `total_distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_distance_scaled(&self) -> f64 {
+    /// Returns `total_distance` in its scaled value. It returns `None` when value is valid.
+    pub fn total_distance_scaled(&self) -> Option<f64> {
         if self.total_distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_distance as f64 / 100.0 - 0.0
+        Some(self.total_distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -597,12 +597,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_speed_scaled(&self) -> f64 {
+    /// Returns `avg_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_speed_scaled(&self) -> Option<f64> {
         if self.avg_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -616,12 +616,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `max_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_speed_scaled(&self) -> f64 {
+    /// Returns `max_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_speed_scaled(&self) -> Option<f64> {
         if self.max_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_speed as f64 / 1000.0 - 0.0
+        Some(self.max_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -635,12 +635,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_altitude_scaled(&self) -> f64 {
+    /// Returns `avg_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_altitude_scaled(&self) -> Option<f64> {
         if self.avg_altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_altitude as f64 / 5.0 - 500.0
+        Some(self.avg_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -654,12 +654,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `max_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_altitude_scaled(&self) -> f64 {
+    /// Returns `max_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn max_altitude_scaled(&self) -> Option<f64> {
         if self.max_altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_altitude as f64 / 5.0 - 500.0
+        Some(self.max_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -673,12 +673,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_grade_scaled(&self) -> f64 {
+    /// Returns `avg_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_grade_scaled(&self) -> Option<f64> {
         if self.avg_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_grade as f64 / 100.0 - 0.0
+        Some(self.avg_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -692,12 +692,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_pos_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_pos_grade_scaled(&self) -> f64 {
+    /// Returns `avg_pos_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_pos_grade_scaled(&self) -> Option<f64> {
         if self.avg_pos_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_pos_grade as f64 / 100.0 - 0.0
+        Some(self.avg_pos_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -711,12 +711,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_neg_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_neg_grade_scaled(&self) -> f64 {
+    /// Returns `avg_neg_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_neg_grade_scaled(&self) -> Option<f64> {
         if self.avg_neg_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_neg_grade as f64 / 100.0 - 0.0
+        Some(self.avg_neg_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -730,12 +730,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `max_pos_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_pos_grade_scaled(&self) -> f64 {
+    /// Returns `max_pos_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn max_pos_grade_scaled(&self) -> Option<f64> {
         if self.max_pos_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_pos_grade as f64 / 100.0 - 0.0
+        Some(self.max_pos_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `max_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -749,12 +749,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `max_neg_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_neg_grade_scaled(&self) -> f64 {
+    /// Returns `max_neg_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn max_neg_grade_scaled(&self) -> Option<f64> {
         if self.max_neg_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_neg_grade as f64 / 100.0 - 0.0
+        Some(self.max_neg_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `max_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -768,12 +768,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `total_moving_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_moving_time_scaled(&self) -> f64 {
+    /// Returns `total_moving_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_moving_time_scaled(&self) -> Option<f64> {
         if self.total_moving_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_moving_time as f64 / 1000.0 - 0.0
+        Some(self.total_moving_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -787,12 +787,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_pos_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_pos_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `avg_pos_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_pos_vertical_speed_scaled(&self) -> Option<f64> {
         if self.avg_pos_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_pos_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_pos_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -806,12 +806,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_neg_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_neg_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `avg_neg_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_neg_vertical_speed_scaled(&self) -> Option<f64> {
         if self.avg_neg_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_neg_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_neg_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -825,12 +825,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `max_pos_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_pos_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `max_pos_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_pos_vertical_speed_scaled(&self) -> Option<f64> {
         if self.max_pos_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_pos_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.max_pos_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -844,12 +844,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `max_neg_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_neg_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `max_neg_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_neg_vertical_speed_scaled(&self) -> Option<f64> {
         if self.max_neg_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_neg_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.max_neg_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -863,25 +863,24 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `time_in_hr_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_hr_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_hr_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_hr_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_hr_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_hr_zone.len());
         for &x in &self.time_in_hr_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_hr_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_hr_zone_scaled(&mut self, v: &Vec<f64>) -> &mut SegmentLap {
+    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+        self.time_in_hr_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_hr_zone = Vec::new();
             return self;
         }
-        self.time_in_hr_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -893,25 +892,24 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `time_in_speed_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_speed_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_speed_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_speed_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_speed_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_speed_zone.len());
         for &x in &self.time_in_speed_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_speed_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_speed_zone_scaled(&mut self, v: &Vec<f64>) -> &mut SegmentLap {
+    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+        self.time_in_speed_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_speed_zone = Vec::new();
             return self;
         }
-        self.time_in_speed_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -923,25 +921,24 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `time_in_cadence_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_cadence_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_cadence_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_cadence_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_cadence_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_cadence_zone.len());
         for &x in &self.time_in_cadence_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_cadence_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &Vec<f64>) -> &mut SegmentLap {
+    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+        self.time_in_cadence_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_cadence_zone = Vec::new();
             return self;
         }
-        self.time_in_cadence_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -953,25 +950,24 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `time_in_power_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_power_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_power_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_power_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_power_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_power_zone.len());
         for &x in &self.time_in_power_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_power_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_power_zone_scaled(&mut self, v: &Vec<f64>) -> &mut SegmentLap {
+    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+        self.time_in_power_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_power_zone = Vec::new();
             return self;
         }
-        self.time_in_power_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -983,12 +979,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `min_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_altitude_scaled(&self) -> f64 {
+    /// Returns `min_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn min_altitude_scaled(&self) -> Option<f64> {
         if self.min_altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.min_altitude as f64 / 5.0 - 500.0
+        Some(self.min_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1002,12 +998,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `active_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn active_time_scaled(&self) -> f64 {
+    /// Returns `active_time` in its scaled value. It returns `None` when value is valid.
+    pub fn active_time_scaled(&self) -> Option<f64> {
         if self.active_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.active_time as f64 / 1000.0 - 0.0
+        Some(self.active_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1021,12 +1017,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_left_torque_effectiveness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_torque_effectiveness_scaled(&self) -> f64 {
+    /// Returns `avg_left_torque_effectiveness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_torque_effectiveness_scaled(&self) -> Option<f64> {
         if self.avg_left_torque_effectiveness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_left_torque_effectiveness as f64 / 2.0 - 0.0
+        Some(self.avg_left_torque_effectiveness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_left_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1040,12 +1036,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_right_torque_effectiveness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_torque_effectiveness_scaled(&self) -> f64 {
+    /// Returns `avg_right_torque_effectiveness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_torque_effectiveness_scaled(&self) -> Option<f64> {
         if self.avg_right_torque_effectiveness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_right_torque_effectiveness as f64 / 2.0 - 0.0
+        Some(self.avg_right_torque_effectiveness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_right_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1059,12 +1055,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_left_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `avg_left_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.avg_left_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_left_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.avg_left_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_left_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1078,12 +1074,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_right_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `avg_right_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.avg_right_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_right_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.avg_right_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_right_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1097,12 +1093,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_combined_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_combined_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `avg_combined_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_combined_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.avg_combined_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_combined_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.avg_combined_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_combined_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1116,12 +1112,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_fractional_cadence` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_fractional_cadence_scaled(&self) -> f64 {
+    /// Returns `avg_fractional_cadence` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_fractional_cadence_scaled(&self) -> Option<f64> {
         if self.avg_fractional_cadence == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_fractional_cadence as f64 / 128.0 - 0.0
+        Some(self.avg_fractional_cadence as f64 / 128.0 - 0.0)
     }
 
     /// Set `avg_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1135,12 +1131,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `max_fractional_cadence` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_fractional_cadence_scaled(&self) -> f64 {
+    /// Returns `max_fractional_cadence` in its scaled value. It returns `None` when value is valid.
+    pub fn max_fractional_cadence_scaled(&self) -> Option<f64> {
         if self.max_fractional_cadence == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_fractional_cadence as f64 / 128.0 - 0.0
+        Some(self.max_fractional_cadence as f64 / 128.0 - 0.0)
     }
 
     /// Set `max_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1154,12 +1150,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `total_fractional_cycles` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_fractional_cycles_scaled(&self) -> f64 {
+    /// Returns `total_fractional_cycles` in its scaled value. It returns `None` when value is valid.
+    pub fn total_fractional_cycles_scaled(&self) -> Option<f64> {
         if self.total_fractional_cycles == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_fractional_cycles as f64 / 128.0 - 0.0
+        Some(self.total_fractional_cycles as f64 / 128.0 - 0.0)
     }
 
     /// Set `total_fractional_cycles` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1173,12 +1169,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `time_standing` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_standing_scaled(&self) -> f64 {
+    /// Returns `time_standing` in its scaled value. It returns `None` when value is valid.
+    pub fn time_standing_scaled(&self) -> Option<f64> {
         if self.time_standing == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.time_standing as f64 / 1000.0 - 0.0
+        Some(self.time_standing as f64 / 1000.0 - 0.0)
     }
 
     /// Set `time_standing` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1192,25 +1188,24 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_left_power_phase` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_power_phase_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_left_power_phase` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_power_phase_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_left_power_phase.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase.len());
         for &x in &self.avg_left_power_phase {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_left_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_scaled(&mut self, v: &Vec<f64>) -> &mut SegmentLap {
+    pub fn set_avg_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+        self.avg_left_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_left_power_phase = Vec::new();
             return self;
         }
-        self.avg_left_power_phase = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1222,25 +1217,24 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_left_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_power_phase_peak_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_left_power_phase_peak` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_power_phase_peak_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_left_power_phase_peak.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase_peak.len());
         for &x in &self.avg_left_power_phase_peak {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_left_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &Vec<f64>) -> &mut SegmentLap {
+    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+        self.avg_left_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_left_power_phase_peak = Vec::new();
             return self;
         }
-        self.avg_left_power_phase_peak = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1252,25 +1246,24 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_right_power_phase` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_power_phase_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_right_power_phase` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_power_phase_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_right_power_phase.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase.len());
         for &x in &self.avg_right_power_phase {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_right_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_scaled(&mut self, v: &Vec<f64>) -> &mut SegmentLap {
+    pub fn set_avg_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+        self.avg_right_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_right_power_phase = Vec::new();
             return self;
         }
-        self.avg_right_power_phase = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1282,25 +1275,24 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `avg_right_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_power_phase_peak_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_right_power_phase_peak` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_power_phase_peak_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_right_power_phase_peak.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase_peak.len());
         for &x in &self.avg_right_power_phase_peak {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_right_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &Vec<f64>) -> &mut SegmentLap {
+    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+        self.avg_right_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_right_power_phase_peak = Vec::new();
             return self;
         }
-        self.avg_right_power_phase_peak = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1312,12 +1304,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `total_fractional_ascent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_fractional_ascent_scaled(&self) -> f64 {
+    /// Returns `total_fractional_ascent` in its scaled value. It returns `None` when value is valid.
+    pub fn total_fractional_ascent_scaled(&self) -> Option<f64> {
         if self.total_fractional_ascent == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_fractional_ascent as f64 / 100.0 - 0.0
+        Some(self.total_fractional_ascent as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_fractional_ascent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1331,12 +1323,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `total_fractional_descent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_fractional_descent_scaled(&self) -> f64 {
+    /// Returns `total_fractional_descent` in its scaled value. It returns `None` when value is valid.
+    pub fn total_fractional_descent_scaled(&self) -> Option<f64> {
         if self.total_fractional_descent == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_fractional_descent as f64 / 100.0 - 0.0
+        Some(self.total_fractional_descent as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_fractional_descent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1350,12 +1342,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `enhanced_avg_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_avg_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_avg_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_avg_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_avg_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_avg_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_avg_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1369,12 +1361,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `enhanced_max_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_max_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_max_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_max_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_max_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_max_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_max_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1388,12 +1380,12 @@ impl SegmentLap {
         self
     }
 
-    /// Returns `enhanced_min_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_min_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_min_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_min_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_min_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_min_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_min_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
+++ b/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
@@ -65,12 +65,12 @@ impl SegmentLeaderboardEntry {
         }
     }
 
-    /// Returns `segment_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn segment_time_scaled(&self) -> f64 {
+    /// Returns `segment_time` in its scaled value. It returns `None` when value is valid.
+    pub fn segment_time_scaled(&self) -> Option<f64> {
         if self.segment_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.segment_time as f64 / 1000.0 - 0.0
+        Some(self.segment_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `segment_time` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/segment_point.rs
+++ b/rustyfit/src/profile/mesgdef/segment_point.rs
@@ -73,22 +73,22 @@ impl SegmentPoint {
         }
     }
 
-    /// Returns `position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_lat_degrees(&self) -> f64 {
+    /// Returns `position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_lat)
     }
 
-    /// Returns `position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn position_long_degrees(&self) -> f64 {
+    /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
     }
 
-    /// Returns `distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn distance_scaled(&self) -> f64 {
+    /// Returns `distance` in its scaled value. It returns `None` when value is valid.
+    pub fn distance_scaled(&self) -> Option<f64> {
         if self.distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.distance as f64 / 100.0 - 0.0
+        Some(self.distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -102,12 +102,12 @@ impl SegmentPoint {
         self
     }
 
-    /// Returns `altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn altitude_scaled(&self) -> f64 {
+    /// Returns `altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn altitude_scaled(&self) -> Option<f64> {
         if self.altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.altitude as f64 / 5.0 - 500.0
+        Some(self.altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -121,25 +121,24 @@ impl SegmentPoint {
         self
     }
 
-    /// Returns `leader_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn leader_time_scaled(&self) -> Vec<f64> {
+    /// Returns `leader_time` in its scaled value. It returns `None` when value is valid.
+    pub fn leader_time_scaled(&self) -> Option<Vec<f64>> {
         if self.leader_time.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.leader_time.len());
         for &x in &self.leader_time {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `leader_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_leader_time_scaled(&mut self, v: &Vec<f64>) -> &mut SegmentPoint {
+    pub fn set_leader_time_scaled(&mut self, v: &[f64]) -> &mut SegmentPoint {
+        self.leader_time = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.leader_time = Vec::new();
             return self;
         }
-        self.leader_time = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -151,12 +150,12 @@ impl SegmentPoint {
         self
     }
 
-    /// Returns `enhanced_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_altitude` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -814,52 +814,52 @@ impl Session {
         }
     }
 
-    /// Returns `start_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn start_position_lat_degrees(&self) -> f64 {
+    /// Returns `start_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn start_position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_lat)
     }
 
-    /// Returns `start_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn start_position_long_degrees(&self) -> f64 {
+    /// Returns `start_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn start_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_long)
     }
 
-    /// Returns `nec_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn nec_lat_degrees(&self) -> f64 {
+    /// Returns `nec_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn nec_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.nec_lat)
     }
 
-    /// Returns `nec_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn nec_long_degrees(&self) -> f64 {
+    /// Returns `nec_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn nec_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.nec_long)
     }
 
-    /// Returns `swc_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn swc_lat_degrees(&self) -> f64 {
+    /// Returns `swc_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn swc_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.swc_lat)
     }
 
-    /// Returns `swc_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn swc_long_degrees(&self) -> f64 {
+    /// Returns `swc_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn swc_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.swc_long)
     }
 
-    /// Returns `end_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn end_position_lat_degrees(&self) -> f64 {
+    /// Returns `end_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn end_position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_lat)
     }
 
-    /// Returns `end_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn end_position_long_degrees(&self) -> f64 {
+    /// Returns `end_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn end_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_long)
     }
 
-    /// Returns `total_elapsed_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_elapsed_time_scaled(&self) -> f64 {
+    /// Returns `total_elapsed_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_elapsed_time_scaled(&self) -> Option<f64> {
         if self.total_elapsed_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_elapsed_time as f64 / 1000.0 - 0.0
+        Some(self.total_elapsed_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -873,12 +873,12 @@ impl Session {
         self
     }
 
-    /// Returns `total_timer_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_timer_time_scaled(&self) -> f64 {
+    /// Returns `total_timer_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_timer_time_scaled(&self) -> Option<f64> {
         if self.total_timer_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_timer_time as f64 / 1000.0 - 0.0
+        Some(self.total_timer_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -892,12 +892,12 @@ impl Session {
         self
     }
 
-    /// Returns `total_distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_distance_scaled(&self) -> f64 {
+    /// Returns `total_distance` in its scaled value. It returns `None` when value is valid.
+    pub fn total_distance_scaled(&self) -> Option<f64> {
         if self.total_distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_distance as f64 / 100.0 - 0.0
+        Some(self.total_distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -911,12 +911,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_speed_scaled(&self) -> f64 {
+    /// Returns `avg_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_speed_scaled(&self) -> Option<f64> {
         if self.avg_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -930,12 +930,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_speed_scaled(&self) -> f64 {
+    /// Returns `max_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_speed_scaled(&self) -> Option<f64> {
         if self.max_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_speed as f64 / 1000.0 - 0.0
+        Some(self.max_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -949,12 +949,12 @@ impl Session {
         self
     }
 
-    /// Returns `total_training_effect` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_training_effect_scaled(&self) -> f64 {
+    /// Returns `total_training_effect` in its scaled value. It returns `None` when value is valid.
+    pub fn total_training_effect_scaled(&self) -> Option<f64> {
         if self.total_training_effect == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_training_effect as f64 / 10.0 - 0.0
+        Some(self.total_training_effect as f64 / 10.0 - 0.0)
     }
 
     /// Set `total_training_effect` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -968,12 +968,12 @@ impl Session {
         self
     }
 
-    /// Returns `training_stress_score` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn training_stress_score_scaled(&self) -> f64 {
+    /// Returns `training_stress_score` in its scaled value. It returns `None` when value is valid.
+    pub fn training_stress_score_scaled(&self) -> Option<f64> {
         if self.training_stress_score == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.training_stress_score as f64 / 10.0 - 0.0
+        Some(self.training_stress_score as f64 / 10.0 - 0.0)
     }
 
     /// Set `training_stress_score` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -987,12 +987,12 @@ impl Session {
         self
     }
 
-    /// Returns `intensity_factor` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn intensity_factor_scaled(&self) -> f64 {
+    /// Returns `intensity_factor` in its scaled value. It returns `None` when value is valid.
+    pub fn intensity_factor_scaled(&self) -> Option<f64> {
         if self.intensity_factor == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.intensity_factor as f64 / 1000.0 - 0.0
+        Some(self.intensity_factor as f64 / 1000.0 - 0.0)
     }
 
     /// Set `intensity_factor` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1006,12 +1006,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_stroke_count` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_stroke_count_scaled(&self) -> f64 {
+    /// Returns `avg_stroke_count` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_stroke_count_scaled(&self) -> Option<f64> {
         if self.avg_stroke_count == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_stroke_count as f64 / 10.0 - 0.0
+        Some(self.avg_stroke_count as f64 / 10.0 - 0.0)
     }
 
     /// Set `avg_stroke_count` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1025,12 +1025,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_stroke_distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_stroke_distance_scaled(&self) -> f64 {
+    /// Returns `avg_stroke_distance` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_stroke_distance_scaled(&self) -> Option<f64> {
         if self.avg_stroke_distance == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_stroke_distance as f64 / 100.0 - 0.0
+        Some(self.avg_stroke_distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_stroke_distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1044,12 +1044,12 @@ impl Session {
         self
     }
 
-    /// Returns `pool_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn pool_length_scaled(&self) -> f64 {
+    /// Returns `pool_length` in its scaled value. It returns `None` when value is valid.
+    pub fn pool_length_scaled(&self) -> Option<f64> {
         if self.pool_length == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.pool_length as f64 / 100.0 - 0.0
+        Some(self.pool_length as f64 / 100.0 - 0.0)
     }
 
     /// Set `pool_length` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1063,12 +1063,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_altitude_scaled(&self) -> f64 {
+    /// Returns `avg_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_altitude_scaled(&self) -> Option<f64> {
         if self.avg_altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_altitude as f64 / 5.0 - 500.0
+        Some(self.avg_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1082,12 +1082,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_altitude_scaled(&self) -> f64 {
+    /// Returns `max_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn max_altitude_scaled(&self) -> Option<f64> {
         if self.max_altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_altitude as f64 / 5.0 - 500.0
+        Some(self.max_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1101,12 +1101,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_grade_scaled(&self) -> f64 {
+    /// Returns `avg_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_grade_scaled(&self) -> Option<f64> {
         if self.avg_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_grade as f64 / 100.0 - 0.0
+        Some(self.avg_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1120,12 +1120,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_pos_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_pos_grade_scaled(&self) -> f64 {
+    /// Returns `avg_pos_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_pos_grade_scaled(&self) -> Option<f64> {
         if self.avg_pos_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_pos_grade as f64 / 100.0 - 0.0
+        Some(self.avg_pos_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1139,12 +1139,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_neg_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_neg_grade_scaled(&self) -> f64 {
+    /// Returns `avg_neg_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_neg_grade_scaled(&self) -> Option<f64> {
         if self.avg_neg_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_neg_grade as f64 / 100.0 - 0.0
+        Some(self.avg_neg_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1158,12 +1158,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_pos_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_pos_grade_scaled(&self) -> f64 {
+    /// Returns `max_pos_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn max_pos_grade_scaled(&self) -> Option<f64> {
         if self.max_pos_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_pos_grade as f64 / 100.0 - 0.0
+        Some(self.max_pos_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `max_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1177,12 +1177,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_neg_grade` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_neg_grade_scaled(&self) -> f64 {
+    /// Returns `max_neg_grade` in its scaled value. It returns `None` when value is valid.
+    pub fn max_neg_grade_scaled(&self) -> Option<f64> {
         if self.max_neg_grade == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_neg_grade as f64 / 100.0 - 0.0
+        Some(self.max_neg_grade as f64 / 100.0 - 0.0)
     }
 
     /// Set `max_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1196,12 +1196,12 @@ impl Session {
         self
     }
 
-    /// Returns `total_moving_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_moving_time_scaled(&self) -> f64 {
+    /// Returns `total_moving_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_moving_time_scaled(&self) -> Option<f64> {
         if self.total_moving_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_moving_time as f64 / 1000.0 - 0.0
+        Some(self.total_moving_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1215,12 +1215,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_pos_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_pos_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `avg_pos_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_pos_vertical_speed_scaled(&self) -> Option<f64> {
         if self.avg_pos_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_pos_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_pos_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1234,12 +1234,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_neg_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_neg_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `avg_neg_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_neg_vertical_speed_scaled(&self) -> Option<f64> {
         if self.avg_neg_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_neg_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_neg_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1253,12 +1253,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_pos_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_pos_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `max_pos_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_pos_vertical_speed_scaled(&self) -> Option<f64> {
         if self.max_pos_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_pos_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.max_pos_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1272,12 +1272,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_neg_vertical_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_neg_vertical_speed_scaled(&self) -> f64 {
+    /// Returns `max_neg_vertical_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_neg_vertical_speed_scaled(&self) -> Option<f64> {
         if self.max_neg_vertical_speed == i16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_neg_vertical_speed as f64 / 1000.0 - 0.0
+        Some(self.max_neg_vertical_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1291,25 +1291,24 @@ impl Session {
         self
     }
 
-    /// Returns `time_in_hr_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_hr_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_hr_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_hr_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_hr_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_hr_zone.len());
         for &x in &self.time_in_hr_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_hr_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_hr_zone_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.time_in_hr_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_hr_zone = Vec::new();
             return self;
         }
-        self.time_in_hr_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -1321,25 +1320,24 @@ impl Session {
         self
     }
 
-    /// Returns `time_in_speed_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_speed_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_speed_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_speed_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_speed_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_speed_zone.len());
         for &x in &self.time_in_speed_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_speed_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_speed_zone_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.time_in_speed_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_speed_zone = Vec::new();
             return self;
         }
-        self.time_in_speed_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -1351,25 +1349,24 @@ impl Session {
         self
     }
 
-    /// Returns `time_in_cadence_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_cadence_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_cadence_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_cadence_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_cadence_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_cadence_zone.len());
         for &x in &self.time_in_cadence_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_cadence_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.time_in_cadence_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_cadence_zone = Vec::new();
             return self;
         }
-        self.time_in_cadence_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -1381,25 +1378,24 @@ impl Session {
         self
     }
 
-    /// Returns `time_in_power_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_power_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_power_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_power_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_power_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_power_zone.len());
         for &x in &self.time_in_power_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_power_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_power_zone_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.time_in_power_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_power_zone = Vec::new();
             return self;
         }
-        self.time_in_power_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -1411,12 +1407,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_lap_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_lap_time_scaled(&self) -> f64 {
+    /// Returns `avg_lap_time` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_lap_time_scaled(&self) -> Option<f64> {
         if self.avg_lap_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_lap_time as f64 / 1000.0 - 0.0
+        Some(self.avg_lap_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_lap_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1430,12 +1426,12 @@ impl Session {
         self
     }
 
-    /// Returns `min_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_altitude_scaled(&self) -> f64 {
+    /// Returns `min_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn min_altitude_scaled(&self) -> Option<f64> {
         if self.min_altitude == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.min_altitude as f64 / 5.0 - 500.0
+        Some(self.min_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1449,12 +1445,12 @@ impl Session {
         self
     }
 
-    /// Returns `active_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn active_time_scaled(&self) -> f64 {
+    /// Returns `active_time` in its scaled value. It returns `None` when value is valid.
+    pub fn active_time_scaled(&self) -> Option<f64> {
         if self.active_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.active_time as f64 / 1000.0 - 0.0
+        Some(self.active_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1468,12 +1464,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_ball_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_ball_speed_scaled(&self) -> f64 {
+    /// Returns `max_ball_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_ball_speed_scaled(&self) -> Option<f64> {
         if self.max_ball_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_ball_speed as f64 / 100.0 - 0.0
+        Some(self.max_ball_speed as f64 / 100.0 - 0.0)
     }
 
     /// Set `max_ball_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1487,12 +1483,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_ball_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_ball_speed_scaled(&self) -> f64 {
+    /// Returns `avg_ball_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_ball_speed_scaled(&self) -> Option<f64> {
         if self.avg_ball_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_ball_speed as f64 / 100.0 - 0.0
+        Some(self.avg_ball_speed as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_ball_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1506,12 +1502,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_vertical_oscillation` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_vertical_oscillation_scaled(&self) -> f64 {
+    /// Returns `avg_vertical_oscillation` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_vertical_oscillation_scaled(&self) -> Option<f64> {
         if self.avg_vertical_oscillation == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_vertical_oscillation as f64 / 10.0 - 0.0
+        Some(self.avg_vertical_oscillation as f64 / 10.0 - 0.0)
     }
 
     /// Set `avg_vertical_oscillation` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1525,12 +1521,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_stance_time_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_stance_time_percent_scaled(&self) -> f64 {
+    /// Returns `avg_stance_time_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_stance_time_percent_scaled(&self) -> Option<f64> {
         if self.avg_stance_time_percent == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_stance_time_percent as f64 / 100.0 - 0.0
+        Some(self.avg_stance_time_percent as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_stance_time_percent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1544,12 +1540,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_stance_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_stance_time_scaled(&self) -> f64 {
+    /// Returns `avg_stance_time` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_stance_time_scaled(&self) -> Option<f64> {
         if self.avg_stance_time == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_stance_time as f64 / 10.0 - 0.0
+        Some(self.avg_stance_time as f64 / 10.0 - 0.0)
     }
 
     /// Set `avg_stance_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1563,12 +1559,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_fractional_cadence` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_fractional_cadence_scaled(&self) -> f64 {
+    /// Returns `avg_fractional_cadence` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_fractional_cadence_scaled(&self) -> Option<f64> {
         if self.avg_fractional_cadence == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_fractional_cadence as f64 / 128.0 - 0.0
+        Some(self.avg_fractional_cadence as f64 / 128.0 - 0.0)
     }
 
     /// Set `avg_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1582,12 +1578,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_fractional_cadence` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_fractional_cadence_scaled(&self) -> f64 {
+    /// Returns `max_fractional_cadence` in its scaled value. It returns `None` when value is valid.
+    pub fn max_fractional_cadence_scaled(&self) -> Option<f64> {
         if self.max_fractional_cadence == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_fractional_cadence as f64 / 128.0 - 0.0
+        Some(self.max_fractional_cadence as f64 / 128.0 - 0.0)
     }
 
     /// Set `max_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1601,12 +1597,12 @@ impl Session {
         self
     }
 
-    /// Returns `total_fractional_cycles` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_fractional_cycles_scaled(&self) -> f64 {
+    /// Returns `total_fractional_cycles` in its scaled value. It returns `None` when value is valid.
+    pub fn total_fractional_cycles_scaled(&self) -> Option<f64> {
         if self.total_fractional_cycles == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_fractional_cycles as f64 / 128.0 - 0.0
+        Some(self.total_fractional_cycles as f64 / 128.0 - 0.0)
     }
 
     /// Set `total_fractional_cycles` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1620,25 +1616,24 @@ impl Session {
         self
     }
 
-    /// Returns `avg_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_total_hemoglobin_conc` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_total_hemoglobin_conc_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_total_hemoglobin_conc.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_total_hemoglobin_conc.len());
         for &x in &self.avg_total_hemoglobin_conc {
             v.push(x as f64 / 100.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_total_hemoglobin_conc_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_avg_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.avg_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_total_hemoglobin_conc = Vec::new();
             return self;
         }
-        self.avg_total_hemoglobin_conc = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 100.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1650,25 +1645,24 @@ impl Session {
         self
     }
 
-    /// Returns `min_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
+    /// Returns `min_total_hemoglobin_conc` in its scaled value. It returns `None` when value is valid.
+    pub fn min_total_hemoglobin_conc_scaled(&self) -> Option<Vec<f64>> {
         if self.min_total_hemoglobin_conc.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.min_total_hemoglobin_conc.len());
         for &x in &self.min_total_hemoglobin_conc {
             v.push(x as f64 / 100.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `min_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_total_hemoglobin_conc_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_min_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.min_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.min_total_hemoglobin_conc = Vec::new();
             return self;
         }
-        self.min_total_hemoglobin_conc = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 100.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1680,25 +1674,24 @@ impl Session {
         self
     }
 
-    /// Returns `max_total_hemoglobin_conc` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_total_hemoglobin_conc_scaled(&self) -> Vec<f64> {
+    /// Returns `max_total_hemoglobin_conc` in its scaled value. It returns `None` when value is valid.
+    pub fn max_total_hemoglobin_conc_scaled(&self) -> Option<Vec<f64>> {
         if self.max_total_hemoglobin_conc.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.max_total_hemoglobin_conc.len());
         for &x in &self.max_total_hemoglobin_conc {
             v.push(x as f64 / 100.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `max_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_total_hemoglobin_conc_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_max_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.max_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.max_total_hemoglobin_conc = Vec::new();
             return self;
         }
-        self.max_total_hemoglobin_conc = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 100.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1710,25 +1703,24 @@ impl Session {
         self
     }
 
-    /// Returns `avg_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_saturated_hemoglobin_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_saturated_hemoglobin_percent_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_saturated_hemoglobin_percent.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_saturated_hemoglobin_percent.len());
         for &x in &self.avg_saturated_hemoglobin_percent {
             v.push(x as f64 / 10.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_saturated_hemoglobin_percent_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_avg_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.avg_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_saturated_hemoglobin_percent = Vec::new();
             return self;
         }
-        self.avg_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 10.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1740,25 +1732,24 @@ impl Session {
         self
     }
 
-    /// Returns `min_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
+    /// Returns `min_saturated_hemoglobin_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn min_saturated_hemoglobin_percent_scaled(&self) -> Option<Vec<f64>> {
         if self.min_saturated_hemoglobin_percent.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.min_saturated_hemoglobin_percent.len());
         for &x in &self.min_saturated_hemoglobin_percent {
             v.push(x as f64 / 10.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `min_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_saturated_hemoglobin_percent_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_min_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.min_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.min_saturated_hemoglobin_percent = Vec::new();
             return self;
         }
-        self.min_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 10.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1770,25 +1761,24 @@ impl Session {
         self
     }
 
-    /// Returns `max_saturated_hemoglobin_percent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_saturated_hemoglobin_percent_scaled(&self) -> Vec<f64> {
+    /// Returns `max_saturated_hemoglobin_percent` in its scaled value. It returns `None` when value is valid.
+    pub fn max_saturated_hemoglobin_percent_scaled(&self) -> Option<Vec<f64>> {
         if self.max_saturated_hemoglobin_percent.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.max_saturated_hemoglobin_percent.len());
         for &x in &self.max_saturated_hemoglobin_percent {
             v.push(x as f64 / 10.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `max_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_saturated_hemoglobin_percent_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_max_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.max_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.max_saturated_hemoglobin_percent = Vec::new();
             return self;
         }
-        self.max_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 10.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
@@ -1800,12 +1790,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_left_torque_effectiveness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_torque_effectiveness_scaled(&self) -> f64 {
+    /// Returns `avg_left_torque_effectiveness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_torque_effectiveness_scaled(&self) -> Option<f64> {
         if self.avg_left_torque_effectiveness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_left_torque_effectiveness as f64 / 2.0 - 0.0
+        Some(self.avg_left_torque_effectiveness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_left_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1819,12 +1809,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_right_torque_effectiveness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_torque_effectiveness_scaled(&self) -> f64 {
+    /// Returns `avg_right_torque_effectiveness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_torque_effectiveness_scaled(&self) -> Option<f64> {
         if self.avg_right_torque_effectiveness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_right_torque_effectiveness as f64 / 2.0 - 0.0
+        Some(self.avg_right_torque_effectiveness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_right_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1838,12 +1828,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_left_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `avg_left_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.avg_left_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_left_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.avg_left_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_left_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1857,12 +1847,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_right_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `avg_right_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.avg_right_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_right_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.avg_right_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_right_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1876,12 +1866,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_combined_pedal_smoothness` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_combined_pedal_smoothness_scaled(&self) -> f64 {
+    /// Returns `avg_combined_pedal_smoothness` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_combined_pedal_smoothness_scaled(&self) -> Option<f64> {
         if self.avg_combined_pedal_smoothness == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_combined_pedal_smoothness as f64 / 2.0 - 0.0
+        Some(self.avg_combined_pedal_smoothness as f64 / 2.0 - 0.0)
     }
 
     /// Set `avg_combined_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1895,12 +1885,12 @@ impl Session {
         self
     }
 
-    /// Returns `time_standing` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_standing_scaled(&self) -> f64 {
+    /// Returns `time_standing` in its scaled value. It returns `None` when value is valid.
+    pub fn time_standing_scaled(&self) -> Option<f64> {
         if self.time_standing == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.time_standing as f64 / 1000.0 - 0.0
+        Some(self.time_standing as f64 / 1000.0 - 0.0)
     }
 
     /// Set `time_standing` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -1914,25 +1904,24 @@ impl Session {
         self
     }
 
-    /// Returns `avg_left_power_phase` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_power_phase_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_left_power_phase` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_power_phase_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_left_power_phase.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase.len());
         for &x in &self.avg_left_power_phase {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_left_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_avg_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.avg_left_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_left_power_phase = Vec::new();
             return self;
         }
-        self.avg_left_power_phase = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1944,25 +1933,24 @@ impl Session {
         self
     }
 
-    /// Returns `avg_left_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_left_power_phase_peak_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_left_power_phase_peak` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_left_power_phase_peak_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_left_power_phase_peak.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_left_power_phase_peak.len());
         for &x in &self.avg_left_power_phase_peak {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_left_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.avg_left_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_left_power_phase_peak = Vec::new();
             return self;
         }
-        self.avg_left_power_phase_peak = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -1974,25 +1962,24 @@ impl Session {
         self
     }
 
-    /// Returns `avg_right_power_phase` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_power_phase_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_right_power_phase` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_power_phase_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_right_power_phase.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase.len());
         for &x in &self.avg_right_power_phase {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_right_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_avg_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.avg_right_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_right_power_phase = Vec::new();
             return self;
         }
-        self.avg_right_power_phase = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -2004,25 +1991,24 @@ impl Session {
         self
     }
 
-    /// Returns `avg_right_power_phase_peak` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_right_power_phase_peak_scaled(&self) -> Vec<f64> {
+    /// Returns `avg_right_power_phase_peak` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_right_power_phase_peak_scaled(&self) -> Option<Vec<f64>> {
         if self.avg_right_power_phase_peak.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.avg_right_power_phase_peak.len());
         for &x in &self.avg_right_power_phase_peak {
             v.push(x as f64 / 0.7111111 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `avg_right_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &Vec<f64>) -> &mut Session {
+    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Session {
+        self.avg_right_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.avg_right_power_phase_peak = Vec::new();
             return self;
         }
-        self.avg_right_power_phase_peak = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 0.7111111;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
@@ -2034,12 +2020,12 @@ impl Session {
         self
     }
 
-    /// Returns `enhanced_avg_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_avg_speed_scaled(&self) -> f64 {
+    /// Returns `enhanced_avg_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_avg_speed_scaled(&self) -> Option<f64> {
         if self.enhanced_avg_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_avg_speed as f64 / 1000.0 - 0.0
+        Some(self.enhanced_avg_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `enhanced_avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2053,12 +2039,12 @@ impl Session {
         self
     }
 
-    /// Returns `enhanced_max_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_max_speed_scaled(&self) -> f64 {
+    /// Returns `enhanced_max_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_max_speed_scaled(&self) -> Option<f64> {
         if self.enhanced_max_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_max_speed as f64 / 1000.0 - 0.0
+        Some(self.enhanced_max_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `enhanced_max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2072,12 +2058,12 @@ impl Session {
         self
     }
 
-    /// Returns `enhanced_avg_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_avg_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_avg_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_avg_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_avg_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_avg_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_avg_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2091,12 +2077,12 @@ impl Session {
         self
     }
 
-    /// Returns `enhanced_min_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_min_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_min_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_min_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_min_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_min_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_min_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2110,12 +2096,12 @@ impl Session {
         self
     }
 
-    /// Returns `enhanced_max_altitude` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_max_altitude_scaled(&self) -> f64 {
+    /// Returns `enhanced_max_altitude` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_max_altitude_scaled(&self) -> Option<f64> {
         if self.enhanced_max_altitude == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_max_altitude as f64 / 5.0 - 500.0
+        Some(self.enhanced_max_altitude as f64 / 5.0 - 500.0)
     }
 
     /// Set `enhanced_max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2129,12 +2115,12 @@ impl Session {
         self
     }
 
-    /// Returns `lev_battery_consumption` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn lev_battery_consumption_scaled(&self) -> f64 {
+    /// Returns `lev_battery_consumption` in its scaled value. It returns `None` when value is valid.
+    pub fn lev_battery_consumption_scaled(&self) -> Option<f64> {
         if self.lev_battery_consumption == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.lev_battery_consumption as f64 / 2.0 - 0.0
+        Some(self.lev_battery_consumption as f64 / 2.0 - 0.0)
     }
 
     /// Set `lev_battery_consumption` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2148,12 +2134,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_vertical_ratio` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_vertical_ratio_scaled(&self) -> f64 {
+    /// Returns `avg_vertical_ratio` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_vertical_ratio_scaled(&self) -> Option<f64> {
         if self.avg_vertical_ratio == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_vertical_ratio as f64 / 100.0 - 0.0
+        Some(self.avg_vertical_ratio as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_vertical_ratio` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2167,12 +2153,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_stance_time_balance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_stance_time_balance_scaled(&self) -> f64 {
+    /// Returns `avg_stance_time_balance` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_stance_time_balance_scaled(&self) -> Option<f64> {
         if self.avg_stance_time_balance == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_stance_time_balance as f64 / 100.0 - 0.0
+        Some(self.avg_stance_time_balance as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_stance_time_balance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2186,12 +2172,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_step_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_step_length_scaled(&self) -> f64 {
+    /// Returns `avg_step_length` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_step_length_scaled(&self) -> Option<f64> {
         if self.avg_step_length == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_step_length as f64 / 10.0 - 0.0
+        Some(self.avg_step_length as f64 / 10.0 - 0.0)
     }
 
     /// Set `avg_step_length` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2205,12 +2191,12 @@ impl Session {
         self
     }
 
-    /// Returns `total_anaerobic_training_effect` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_anaerobic_training_effect_scaled(&self) -> f64 {
+    /// Returns `total_anaerobic_training_effect` in its scaled value. It returns `None` when value is valid.
+    pub fn total_anaerobic_training_effect_scaled(&self) -> Option<f64> {
         if self.total_anaerobic_training_effect == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_anaerobic_training_effect as f64 / 10.0 - 0.0
+        Some(self.total_anaerobic_training_effect as f64 / 10.0 - 0.0)
     }
 
     /// Set `total_anaerobic_training_effect` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2224,12 +2210,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_vam` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_vam_scaled(&self) -> f64 {
+    /// Returns `avg_vam` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_vam_scaled(&self) -> Option<f64> {
         if self.avg_vam == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_vam as f64 / 1000.0 - 0.0
+        Some(self.avg_vam as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_vam` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2243,12 +2229,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_depth_scaled(&self) -> f64 {
+    /// Returns `avg_depth` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_depth_scaled(&self) -> Option<f64> {
         if self.avg_depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_depth as f64 / 1000.0 - 0.0
+        Some(self.avg_depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2262,12 +2248,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_depth` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_depth_scaled(&self) -> f64 {
+    /// Returns `max_depth` in its scaled value. It returns `None` when value is valid.
+    pub fn max_depth_scaled(&self) -> Option<f64> {
         if self.max_depth == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_depth as f64 / 1000.0 - 0.0
+        Some(self.max_depth as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_depth` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2281,12 +2267,12 @@ impl Session {
         self
     }
 
-    /// Returns `training_load_peak` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn training_load_peak_scaled(&self) -> f64 {
+    /// Returns `training_load_peak` in its scaled value. It returns `None` when value is valid.
+    pub fn training_load_peak_scaled(&self) -> Option<f64> {
         if self.training_load_peak == i32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.training_load_peak as f64 / 65536.0 - 0.0
+        Some(self.training_load_peak as f64 / 65536.0 - 0.0)
     }
 
     /// Set `training_load_peak` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2300,12 +2286,12 @@ impl Session {
         self
     }
 
-    /// Returns `enhanced_avg_respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_avg_respiration_rate_scaled(&self) -> f64 {
+    /// Returns `enhanced_avg_respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_avg_respiration_rate_scaled(&self) -> Option<f64> {
         if self.enhanced_avg_respiration_rate == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_avg_respiration_rate as f64 / 100.0 - 0.0
+        Some(self.enhanced_avg_respiration_rate as f64 / 100.0 - 0.0)
     }
 
     /// Set `enhanced_avg_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2319,12 +2305,12 @@ impl Session {
         self
     }
 
-    /// Returns `enhanced_max_respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_max_respiration_rate_scaled(&self) -> f64 {
+    /// Returns `enhanced_max_respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_max_respiration_rate_scaled(&self) -> Option<f64> {
         if self.enhanced_max_respiration_rate == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_max_respiration_rate as f64 / 100.0 - 0.0
+        Some(self.enhanced_max_respiration_rate as f64 / 100.0 - 0.0)
     }
 
     /// Set `enhanced_max_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2338,12 +2324,12 @@ impl Session {
         self
     }
 
-    /// Returns `enhanced_min_respiration_rate` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn enhanced_min_respiration_rate_scaled(&self) -> f64 {
+    /// Returns `enhanced_min_respiration_rate` in its scaled value. It returns `None` when value is valid.
+    pub fn enhanced_min_respiration_rate_scaled(&self) -> Option<f64> {
         if self.enhanced_min_respiration_rate == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.enhanced_min_respiration_rate as f64 / 100.0 - 0.0
+        Some(self.enhanced_min_respiration_rate as f64 / 100.0 - 0.0)
     }
 
     /// Set `enhanced_min_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2357,12 +2343,12 @@ impl Session {
         self
     }
 
-    /// Returns `total_fractional_ascent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_fractional_ascent_scaled(&self) -> f64 {
+    /// Returns `total_fractional_ascent` in its scaled value. It returns `None` when value is valid.
+    pub fn total_fractional_ascent_scaled(&self) -> Option<f64> {
         if self.total_fractional_ascent == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_fractional_ascent as f64 / 100.0 - 0.0
+        Some(self.total_fractional_ascent as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_fractional_ascent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2376,12 +2362,12 @@ impl Session {
         self
     }
 
-    /// Returns `total_fractional_descent` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_fractional_descent_scaled(&self) -> f64 {
+    /// Returns `total_fractional_descent` in its scaled value. It returns `None` when value is valid.
+    pub fn total_fractional_descent_scaled(&self) -> Option<f64> {
         if self.total_fractional_descent == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_fractional_descent as f64 / 100.0 - 0.0
+        Some(self.total_fractional_descent as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_fractional_descent` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2395,12 +2381,12 @@ impl Session {
         self
     }
 
-    /// Returns `avg_core_temperature` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_core_temperature_scaled(&self) -> f64 {
+    /// Returns `avg_core_temperature` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_core_temperature_scaled(&self) -> Option<f64> {
         if self.avg_core_temperature == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_core_temperature as f64 / 100.0 - 0.0
+        Some(self.avg_core_temperature as f64 / 100.0 - 0.0)
     }
 
     /// Set `avg_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2414,12 +2400,12 @@ impl Session {
         self
     }
 
-    /// Returns `min_core_temperature` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn min_core_temperature_scaled(&self) -> f64 {
+    /// Returns `min_core_temperature` in its scaled value. It returns `None` when value is valid.
+    pub fn min_core_temperature_scaled(&self) -> Option<f64> {
         if self.min_core_temperature == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.min_core_temperature as f64 / 100.0 - 0.0
+        Some(self.min_core_temperature as f64 / 100.0 - 0.0)
     }
 
     /// Set `min_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -2433,12 +2419,12 @@ impl Session {
         self
     }
 
-    /// Returns `max_core_temperature` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_core_temperature_scaled(&self) -> f64 {
+    /// Returns `max_core_temperature` in its scaled value. It returns `None` when value is valid.
+    pub fn max_core_temperature_scaled(&self) -> Option<f64> {
         if self.max_core_temperature == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_core_temperature as f64 / 100.0 - 0.0
+        Some(self.max_core_temperature as f64 / 100.0 - 0.0)
     }
 
     /// Set `max_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/set.rs
+++ b/rustyfit/src/profile/mesgdef/set.rs
@@ -79,12 +79,12 @@ impl Set {
         }
     }
 
-    /// Returns `duration` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn duration_scaled(&self) -> f64 {
+    /// Returns `duration` in its scaled value. It returns `None` when value is valid.
+    pub fn duration_scaled(&self) -> Option<f64> {
         if self.duration == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.duration as f64 / 1000.0 - 0.0
+        Some(self.duration as f64 / 1000.0 - 0.0)
     }
 
     /// Set `duration` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -98,12 +98,12 @@ impl Set {
         self
     }
 
-    /// Returns `weight` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn weight_scaled(&self) -> f64 {
+    /// Returns `weight` in its scaled value. It returns `None` when value is valid.
+    pub fn weight_scaled(&self) -> Option<f64> {
         if self.weight == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.weight as f64 / 16.0 - 0.0
+        Some(self.weight as f64 / 16.0 - 0.0)
     }
 
     /// Set `weight` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/sleep_assessment.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_assessment.rs
@@ -99,12 +99,12 @@ impl SleepAssessment {
         }
     }
 
-    /// Returns `average_stress_during_sleep` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn average_stress_during_sleep_scaled(&self) -> f64 {
+    /// Returns `average_stress_during_sleep` in its scaled value. It returns `None` when value is valid.
+    pub fn average_stress_during_sleep_scaled(&self) -> Option<f64> {
         if self.average_stress_during_sleep == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.average_stress_during_sleep as f64 / 100.0 - 0.0
+        Some(self.average_stress_during_sleep as f64 / 100.0 - 0.0)
     }
 
     /// Set `average_stress_during_sleep` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/software.rs
+++ b/rustyfit/src/profile/mesgdef/software.rs
@@ -44,12 +44,12 @@ impl Software {
         }
     }
 
-    /// Returns `version` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn version_scaled(&self) -> f64 {
+    /// Returns `version` in its scaled value. It returns `None` when value is valid.
+    pub fn version_scaled(&self) -> Option<f64> {
         if self.version == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.version as f64 / 100.0 - 0.0
+        Some(self.version as f64 / 100.0 - 0.0)
     }
 
     /// Set `version` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/speed_zone.rs
+++ b/rustyfit/src/profile/mesgdef/speed_zone.rs
@@ -44,12 +44,12 @@ impl SpeedZone {
         }
     }
 
-    /// Returns `high_value` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn high_value_scaled(&self) -> f64 {
+    /// Returns `high_value` in its scaled value. It returns `None` when value is valid.
+    pub fn high_value_scaled(&self) -> Option<f64> {
         if self.high_value == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.high_value as f64 / 1000.0 - 0.0
+        Some(self.high_value as f64 / 1000.0 - 0.0)
     }
 
     /// Set `high_value` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/split.rs
+++ b/rustyfit/src/profile/mesgdef/split.rs
@@ -126,32 +126,32 @@ impl Split {
         }
     }
 
-    /// Returns `start_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn start_position_lat_degrees(&self) -> f64 {
+    /// Returns `start_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn start_position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_lat)
     }
 
-    /// Returns `start_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn start_position_long_degrees(&self) -> f64 {
+    /// Returns `start_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn start_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_long)
     }
 
-    /// Returns `end_position_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn end_position_lat_degrees(&self) -> f64 {
+    /// Returns `end_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn end_position_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_lat)
     }
 
-    /// Returns `end_position_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn end_position_long_degrees(&self) -> f64 {
+    /// Returns `end_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn end_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_long)
     }
 
-    /// Returns `total_elapsed_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_elapsed_time_scaled(&self) -> f64 {
+    /// Returns `total_elapsed_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_elapsed_time_scaled(&self) -> Option<f64> {
         if self.total_elapsed_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_elapsed_time as f64 / 1000.0 - 0.0
+        Some(self.total_elapsed_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -165,12 +165,12 @@ impl Split {
         self
     }
 
-    /// Returns `total_timer_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_timer_time_scaled(&self) -> f64 {
+    /// Returns `total_timer_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_timer_time_scaled(&self) -> Option<f64> {
         if self.total_timer_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_timer_time as f64 / 1000.0 - 0.0
+        Some(self.total_timer_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -184,12 +184,12 @@ impl Split {
         self
     }
 
-    /// Returns `total_distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_distance_scaled(&self) -> f64 {
+    /// Returns `total_distance` in its scaled value. It returns `None` when value is valid.
+    pub fn total_distance_scaled(&self) -> Option<f64> {
         if self.total_distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_distance as f64 / 100.0 - 0.0
+        Some(self.total_distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -203,12 +203,12 @@ impl Split {
         self
     }
 
-    /// Returns `avg_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_speed_scaled(&self) -> f64 {
+    /// Returns `avg_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_speed_scaled(&self) -> Option<f64> {
         if self.avg_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -222,12 +222,12 @@ impl Split {
         self
     }
 
-    /// Returns `max_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_speed_scaled(&self) -> f64 {
+    /// Returns `max_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_speed_scaled(&self) -> Option<f64> {
         if self.max_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_speed as f64 / 1000.0 - 0.0
+        Some(self.max_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -241,12 +241,12 @@ impl Split {
         self
     }
 
-    /// Returns `avg_vert_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_vert_speed_scaled(&self) -> f64 {
+    /// Returns `avg_vert_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_vert_speed_scaled(&self) -> Option<f64> {
         if self.avg_vert_speed == i32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_vert_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_vert_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_vert_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -260,12 +260,12 @@ impl Split {
         self
     }
 
-    /// Returns `start_elevation` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn start_elevation_scaled(&self) -> f64 {
+    /// Returns `start_elevation` in its scaled value. It returns `None` when value is valid.
+    pub fn start_elevation_scaled(&self) -> Option<f64> {
         if self.start_elevation == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.start_elevation as f64 / 5.0 - 500.0
+        Some(self.start_elevation as f64 / 5.0 - 500.0)
     }
 
     /// Set `start_elevation` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -279,12 +279,12 @@ impl Split {
         self
     }
 
-    /// Returns `active_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn active_time_scaled(&self) -> f64 {
+    /// Returns `active_time` in its scaled value. It returns `None` when value is valid.
+    pub fn active_time_scaled(&self) -> Option<f64> {
         if self.active_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.active_time as f64 / 1000.0 - 0.0
+        Some(self.active_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -298,12 +298,12 @@ impl Split {
         self
     }
 
-    /// Returns `total_moving_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_moving_time_scaled(&self) -> f64 {
+    /// Returns `total_moving_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_moving_time_scaled(&self) -> Option<f64> {
         if self.total_moving_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_moving_time as f64 / 1000.0 - 0.0
+        Some(self.total_moving_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/split_summary.rs
+++ b/rustyfit/src/profile/mesgdef/split_summary.rs
@@ -101,12 +101,12 @@ impl SplitSummary {
         }
     }
 
-    /// Returns `total_timer_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_timer_time_scaled(&self) -> f64 {
+    /// Returns `total_timer_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_timer_time_scaled(&self) -> Option<f64> {
         if self.total_timer_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_timer_time as f64 / 1000.0 - 0.0
+        Some(self.total_timer_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -120,12 +120,12 @@ impl SplitSummary {
         self
     }
 
-    /// Returns `total_distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_distance_scaled(&self) -> f64 {
+    /// Returns `total_distance` in its scaled value. It returns `None` when value is valid.
+    pub fn total_distance_scaled(&self) -> Option<f64> {
         if self.total_distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_distance as f64 / 100.0 - 0.0
+        Some(self.total_distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -139,12 +139,12 @@ impl SplitSummary {
         self
     }
 
-    /// Returns `avg_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_speed_scaled(&self) -> f64 {
+    /// Returns `avg_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_speed_scaled(&self) -> Option<f64> {
         if self.avg_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -158,12 +158,12 @@ impl SplitSummary {
         self
     }
 
-    /// Returns `max_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn max_speed_scaled(&self) -> f64 {
+    /// Returns `max_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn max_speed_scaled(&self) -> Option<f64> {
         if self.max_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.max_speed as f64 / 1000.0 - 0.0
+        Some(self.max_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -177,12 +177,12 @@ impl SplitSummary {
         self
     }
 
-    /// Returns `avg_vert_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn avg_vert_speed_scaled(&self) -> f64 {
+    /// Returns `avg_vert_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn avg_vert_speed_scaled(&self) -> Option<f64> {
         if self.avg_vert_speed == i32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.avg_vert_speed as f64 / 1000.0 - 0.0
+        Some(self.avg_vert_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `avg_vert_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -196,12 +196,12 @@ impl SplitSummary {
         self
     }
 
-    /// Returns `active_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn active_time_scaled(&self) -> f64 {
+    /// Returns `active_time` in its scaled value. It returns `None` when value is valid.
+    pub fn active_time_scaled(&self) -> Option<f64> {
         if self.active_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.active_time as f64 / 1000.0 - 0.0
+        Some(self.active_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -215,12 +215,12 @@ impl SplitSummary {
         self
     }
 
-    /// Returns `total_moving_time` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn total_moving_time_scaled(&self) -> f64 {
+    /// Returns `total_moving_time` in its scaled value. It returns `None` when value is valid.
+    pub fn total_moving_time_scaled(&self) -> Option<f64> {
         if self.total_moving_time == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.total_moving_time as f64 / 1000.0 - 0.0
+        Some(self.total_moving_time as f64 / 1000.0 - 0.0)
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/tank_summary.rs
+++ b/rustyfit/src/profile/mesgdef/tank_summary.rs
@@ -54,12 +54,12 @@ impl TankSummary {
         }
     }
 
-    /// Returns `start_pressure` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn start_pressure_scaled(&self) -> f64 {
+    /// Returns `start_pressure` in its scaled value. It returns `None` when value is valid.
+    pub fn start_pressure_scaled(&self) -> Option<f64> {
         if self.start_pressure == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.start_pressure as f64 / 100.0 - 0.0
+        Some(self.start_pressure as f64 / 100.0 - 0.0)
     }
 
     /// Set `start_pressure` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -73,12 +73,12 @@ impl TankSummary {
         self
     }
 
-    /// Returns `end_pressure` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn end_pressure_scaled(&self) -> f64 {
+    /// Returns `end_pressure` in its scaled value. It returns `None` when value is valid.
+    pub fn end_pressure_scaled(&self) -> Option<f64> {
         if self.end_pressure == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.end_pressure as f64 / 100.0 - 0.0
+        Some(self.end_pressure as f64 / 100.0 - 0.0)
     }
 
     /// Set `end_pressure` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -92,12 +92,12 @@ impl TankSummary {
         self
     }
 
-    /// Returns `volume_used` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn volume_used_scaled(&self) -> f64 {
+    /// Returns `volume_used` in its scaled value. It returns `None` when value is valid.
+    pub fn volume_used_scaled(&self) -> Option<f64> {
         if self.volume_used == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.volume_used as f64 / 100.0 - 0.0
+        Some(self.volume_used as f64 / 100.0 - 0.0)
     }
 
     /// Set `volume_used` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/tank_update.rs
+++ b/rustyfit/src/profile/mesgdef/tank_update.rs
@@ -44,12 +44,12 @@ impl TankUpdate {
         }
     }
 
-    /// Returns `pressure` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn pressure_scaled(&self) -> f64 {
+    /// Returns `pressure` in its scaled value. It returns `None` when value is valid.
+    pub fn pressure_scaled(&self) -> Option<f64> {
         if self.pressure == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.pressure as f64 / 100.0 - 0.0
+        Some(self.pressure as f64 / 100.0 - 0.0)
     }
 
     /// Set `pressure` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
@@ -64,8 +64,11 @@ impl ThreeDSensorCalibration {
         }
     }
 
-    /// Returns `orientation_matrix` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn orientation_matrix_scaled(&self) -> [f64; 9] {
+    /// Returns `orientation_matrix` in its scaled value. It returns `None` when value is valid.
+    pub fn orientation_matrix_scaled(&self) -> Option<[f64; 9]> {
+        if self.orientation_matrix == [i32::MAX; 9] {
+            return None;
+        }
         let mut v = [f64::from_bits(u64::MAX); 9];
         for (i, &x) in self.orientation_matrix.iter().enumerate() {
             if x == i32::MAX {
@@ -73,7 +76,7 @@ impl ThreeDSensorCalibration {
             }
             v[i] = x as f64 / 65535.0 - 0.0;
         }
-        v
+        Some(v)
     }
 
     /// Set `orientation_matrix` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/time_in_zone.rs
+++ b/rustyfit/src/profile/mesgdef/time_in_zone.rs
@@ -106,25 +106,24 @@ impl TimeInZone {
         }
     }
 
-    /// Returns `time_in_hr_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_hr_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_hr_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_hr_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_hr_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_hr_zone.len());
         for &x in &self.time_in_hr_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_hr_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_hr_zone_scaled(&mut self, v: &Vec<f64>) -> &mut TimeInZone {
+    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+        self.time_in_hr_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_hr_zone = Vec::new();
             return self;
         }
-        self.time_in_hr_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -136,25 +135,24 @@ impl TimeInZone {
         self
     }
 
-    /// Returns `time_in_speed_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_speed_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_speed_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_speed_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_speed_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_speed_zone.len());
         for &x in &self.time_in_speed_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_speed_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_speed_zone_scaled(&mut self, v: &Vec<f64>) -> &mut TimeInZone {
+    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+        self.time_in_speed_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_speed_zone = Vec::new();
             return self;
         }
-        self.time_in_speed_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -166,25 +164,24 @@ impl TimeInZone {
         self
     }
 
-    /// Returns `time_in_cadence_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_cadence_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_cadence_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_cadence_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_cadence_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_cadence_zone.len());
         for &x in &self.time_in_cadence_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_cadence_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &Vec<f64>) -> &mut TimeInZone {
+    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+        self.time_in_cadence_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_cadence_zone = Vec::new();
             return self;
         }
-        self.time_in_cadence_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -196,25 +193,24 @@ impl TimeInZone {
         self
     }
 
-    /// Returns `time_in_power_zone` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn time_in_power_zone_scaled(&self) -> Vec<f64> {
+    /// Returns `time_in_power_zone` in its scaled value. It returns `None` when value is valid.
+    pub fn time_in_power_zone_scaled(&self) -> Option<Vec<f64>> {
         if self.time_in_power_zone.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.time_in_power_zone.len());
         for &x in &self.time_in_power_zone {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `time_in_power_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_power_zone_scaled(&mut self, v: &Vec<f64>) -> &mut TimeInZone {
+    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+        self.time_in_power_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.time_in_power_zone = Vec::new();
             return self;
         }
-        self.time_in_power_zone = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
@@ -226,25 +222,24 @@ impl TimeInZone {
         self
     }
 
-    /// Returns `speed_zone_high_boundary` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn speed_zone_high_boundary_scaled(&self) -> Vec<f64> {
+    /// Returns `speed_zone_high_boundary` in its scaled value. It returns `None` when value is valid.
+    pub fn speed_zone_high_boundary_scaled(&self) -> Option<Vec<f64>> {
         if self.speed_zone_high_boundary.is_empty() {
-            return Vec::new();
+            return None;
         }
         let mut v = Vec::with_capacity(self.speed_zone_high_boundary.len());
         for &x in &self.speed_zone_high_boundary {
             v.push(x as f64 / 1000.0 - 0.0)
         }
-        v
+        Some(v)
     }
 
     /// Set `speed_zone_high_boundary` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_speed_zone_high_boundary_scaled(&mut self, v: &Vec<f64>) -> &mut TimeInZone {
+    pub fn set_speed_zone_high_boundary_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+        self.speed_zone_high_boundary = Vec::with_capacity(v.len());
         if v.is_empty() {
-            self.speed_zone_high_boundary = Vec::new();
             return self;
         }
-        self.speed_zone_high_boundary = Vec::with_capacity(v.len());
         for &x in v {
             let unscaled = (x + 0.0) * 1000.0;
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {

--- a/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
+++ b/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
@@ -64,12 +64,12 @@ impl TimestampCorrelation {
         }
     }
 
-    /// Returns `fractional_timestamp` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn fractional_timestamp_scaled(&self) -> f64 {
+    /// Returns `fractional_timestamp` in its scaled value. It returns `None` when value is valid.
+    pub fn fractional_timestamp_scaled(&self) -> Option<f64> {
         if self.fractional_timestamp == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.fractional_timestamp as f64 / 32768.0 - 0.0
+        Some(self.fractional_timestamp as f64 / 32768.0 - 0.0)
     }
 
     /// Set `fractional_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -83,12 +83,12 @@ impl TimestampCorrelation {
         self
     }
 
-    /// Returns `fractional_system_timestamp` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn fractional_system_timestamp_scaled(&self) -> f64 {
+    /// Returns `fractional_system_timestamp` in its scaled value. It returns `None` when value is valid.
+    pub fn fractional_system_timestamp_scaled(&self) -> Option<f64> {
         if self.fractional_system_timestamp == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.fractional_system_timestamp as f64 / 32768.0 - 0.0
+        Some(self.fractional_system_timestamp as f64 / 32768.0 - 0.0)
     }
 
     /// Set `fractional_system_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/training_settings.rs
+++ b/rustyfit/src/profile/mesgdef/training_settings.rs
@@ -49,12 +49,12 @@ impl TrainingSettings {
         }
     }
 
-    /// Returns `target_distance` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn target_distance_scaled(&self) -> f64 {
+    /// Returns `target_distance` in its scaled value. It returns `None` when value is valid.
+    pub fn target_distance_scaled(&self) -> Option<f64> {
         if self.target_distance == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.target_distance as f64 / 100.0 - 0.0
+        Some(self.target_distance as f64 / 100.0 - 0.0)
     }
 
     /// Set `target_distance` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -68,12 +68,12 @@ impl TrainingSettings {
         self
     }
 
-    /// Returns `target_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn target_speed_scaled(&self) -> f64 {
+    /// Returns `target_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn target_speed_scaled(&self) -> Option<f64> {
         if self.target_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.target_speed as f64 / 1000.0 - 0.0
+        Some(self.target_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `target_speed` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -87,12 +87,12 @@ impl TrainingSettings {
         self
     }
 
-    /// Returns `precise_target_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn precise_target_speed_scaled(&self) -> f64 {
+    /// Returns `precise_target_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn precise_target_speed_scaled(&self) -> Option<f64> {
         if self.precise_target_speed == u32::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.precise_target_speed as f64 / 1000000.0 - 0.0
+        Some(self.precise_target_speed as f64 / 1000000.0 - 0.0)
     }
 
     /// Set `precise_target_speed` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/user_profile.rs
+++ b/rustyfit/src/profile/mesgdef/user_profile.rs
@@ -160,12 +160,12 @@ impl UserProfile {
         }
     }
 
-    /// Returns `height` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn height_scaled(&self) -> f64 {
+    /// Returns `height` in its scaled value. It returns `None` when value is valid.
+    pub fn height_scaled(&self) -> Option<f64> {
         if self.height == u8::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.height as f64 / 100.0 - 0.0
+        Some(self.height as f64 / 100.0 - 0.0)
     }
 
     /// Set `height` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -179,12 +179,12 @@ impl UserProfile {
         self
     }
 
-    /// Returns `weight` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn weight_scaled(&self) -> f64 {
+    /// Returns `weight` in its scaled value. It returns `None` when value is valid.
+    pub fn weight_scaled(&self) -> Option<f64> {
         if self.weight == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.weight as f64 / 10.0 - 0.0
+        Some(self.weight as f64 / 10.0 - 0.0)
     }
 
     /// Set `weight` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -198,12 +198,12 @@ impl UserProfile {
         self
     }
 
-    /// Returns `user_running_step_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn user_running_step_length_scaled(&self) -> f64 {
+    /// Returns `user_running_step_length` in its scaled value. It returns `None` when value is valid.
+    pub fn user_running_step_length_scaled(&self) -> Option<f64> {
         if self.user_running_step_length == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.user_running_step_length as f64 / 1000.0 - 0.0
+        Some(self.user_running_step_length as f64 / 1000.0 - 0.0)
     }
 
     /// Set `user_running_step_length` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -217,12 +217,12 @@ impl UserProfile {
         self
     }
 
-    /// Returns `user_walking_step_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn user_walking_step_length_scaled(&self) -> f64 {
+    /// Returns `user_walking_step_length` in its scaled value. It returns `None` when value is valid.
+    pub fn user_walking_step_length_scaled(&self) -> Option<f64> {
         if self.user_walking_step_length == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.user_walking_step_length as f64 / 1000.0 - 0.0
+        Some(self.user_walking_step_length as f64 / 1000.0 - 0.0)
     }
 
     /// Set `user_walking_step_length` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -109,22 +109,22 @@ impl WeatherConditions {
         }
     }
 
-    /// Returns `observed_location_lat` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn observed_location_lat_degrees(&self) -> f64 {
+    /// Returns `observed_location_lat` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn observed_location_lat_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.observed_location_lat)
     }
 
-    /// Returns `observed_location_long` in degrees instead of semicircles. It returns invalid f64 when value is valid.
-    pub fn observed_location_long_degrees(&self) -> f64 {
+    /// Returns `observed_location_long` in degrees instead of semicircles. It returns `None` when value is valid.
+    pub fn observed_location_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.observed_location_long)
     }
 
-    /// Returns `wind_speed` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn wind_speed_scaled(&self) -> f64 {
+    /// Returns `wind_speed` in its scaled value. It returns `None` when value is valid.
+    pub fn wind_speed_scaled(&self) -> Option<f64> {
         if self.wind_speed == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.wind_speed as f64 / 1000.0 - 0.0
+        Some(self.wind_speed as f64 / 1000.0 - 0.0)
     }
 
     /// Set `wind_speed` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/weight_scale.rs
+++ b/rustyfit/src/profile/mesgdef/weight_scale.rs
@@ -97,12 +97,12 @@ impl WeightScale {
         }
     }
 
-    /// Returns `weight` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn weight_scaled(&self) -> f64 {
+    /// Returns `weight` in its scaled value. It returns `None` when value is valid.
+    pub fn weight_scaled(&self) -> Option<f64> {
         if self.weight == typedef::Weight(u16::MAX) {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.weight.0 as f64 / 100.0 - 0.0
+        Some(self.weight.0 as f64 / 100.0 - 0.0)
     }
 
     /// Set `weight` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -116,12 +116,12 @@ impl WeightScale {
         self
     }
 
-    /// Returns `percent_fat` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn percent_fat_scaled(&self) -> f64 {
+    /// Returns `percent_fat` in its scaled value. It returns `None` when value is valid.
+    pub fn percent_fat_scaled(&self) -> Option<f64> {
         if self.percent_fat == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.percent_fat as f64 / 100.0 - 0.0
+        Some(self.percent_fat as f64 / 100.0 - 0.0)
     }
 
     /// Set `percent_fat` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -135,12 +135,12 @@ impl WeightScale {
         self
     }
 
-    /// Returns `percent_hydration` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn percent_hydration_scaled(&self) -> f64 {
+    /// Returns `percent_hydration` in its scaled value. It returns `None` when value is valid.
+    pub fn percent_hydration_scaled(&self) -> Option<f64> {
         if self.percent_hydration == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.percent_hydration as f64 / 100.0 - 0.0
+        Some(self.percent_hydration as f64 / 100.0 - 0.0)
     }
 
     /// Set `percent_hydration` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -154,12 +154,12 @@ impl WeightScale {
         self
     }
 
-    /// Returns `visceral_fat_mass` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn visceral_fat_mass_scaled(&self) -> f64 {
+    /// Returns `visceral_fat_mass` in its scaled value. It returns `None` when value is valid.
+    pub fn visceral_fat_mass_scaled(&self) -> Option<f64> {
         if self.visceral_fat_mass == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.visceral_fat_mass as f64 / 100.0 - 0.0
+        Some(self.visceral_fat_mass as f64 / 100.0 - 0.0)
     }
 
     /// Set `visceral_fat_mass` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -173,12 +173,12 @@ impl WeightScale {
         self
     }
 
-    /// Returns `bone_mass` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn bone_mass_scaled(&self) -> f64 {
+    /// Returns `bone_mass` in its scaled value. It returns `None` when value is valid.
+    pub fn bone_mass_scaled(&self) -> Option<f64> {
         if self.bone_mass == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.bone_mass as f64 / 100.0 - 0.0
+        Some(self.bone_mass as f64 / 100.0 - 0.0)
     }
 
     /// Set `bone_mass` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -192,12 +192,12 @@ impl WeightScale {
         self
     }
 
-    /// Returns `muscle_mass` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn muscle_mass_scaled(&self) -> f64 {
+    /// Returns `muscle_mass` in its scaled value. It returns `None` when value is valid.
+    pub fn muscle_mass_scaled(&self) -> Option<f64> {
         if self.muscle_mass == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.muscle_mass as f64 / 100.0 - 0.0
+        Some(self.muscle_mass as f64 / 100.0 - 0.0)
     }
 
     /// Set `muscle_mass` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -211,12 +211,12 @@ impl WeightScale {
         self
     }
 
-    /// Returns `basal_met` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn basal_met_scaled(&self) -> f64 {
+    /// Returns `basal_met` in its scaled value. It returns `None` when value is valid.
+    pub fn basal_met_scaled(&self) -> Option<f64> {
         if self.basal_met == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.basal_met as f64 / 4.0 - 0.0
+        Some(self.basal_met as f64 / 4.0 - 0.0)
     }
 
     /// Set `basal_met` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -230,12 +230,12 @@ impl WeightScale {
         self
     }
 
-    /// Returns `active_met` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn active_met_scaled(&self) -> f64 {
+    /// Returns `active_met` in its scaled value. It returns `None` when value is valid.
+    pub fn active_met_scaled(&self) -> Option<f64> {
         if self.active_met == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.active_met as f64 / 4.0 - 0.0
+        Some(self.active_met as f64 / 4.0 - 0.0)
     }
 
     /// Set `active_met` with scaled value, it will automatically be converted to its corresponding integer value.
@@ -249,12 +249,12 @@ impl WeightScale {
         self
     }
 
-    /// Returns `bmi` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn bmi_scaled(&self) -> f64 {
+    /// Returns `bmi` in its scaled value. It returns `None` when value is valid.
+    pub fn bmi_scaled(&self) -> Option<f64> {
         if self.bmi == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.bmi as f64 / 10.0 - 0.0
+        Some(self.bmi as f64 / 10.0 - 0.0)
     }
 
     /// Set `bmi` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/workout.rs
+++ b/rustyfit/src/profile/mesgdef/workout.rs
@@ -71,12 +71,12 @@ impl Workout {
         }
     }
 
-    /// Returns `pool_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn pool_length_scaled(&self) -> f64 {
+    /// Returns `pool_length` in its scaled value. It returns `None` when value is valid.
+    pub fn pool_length_scaled(&self) -> Option<f64> {
         if self.pool_length == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.pool_length as f64 / 100.0 - 0.0
+        Some(self.pool_length as f64 / 100.0 - 0.0)
     }
 
     /// Set `pool_length` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/workout_session.rs
+++ b/rustyfit/src/profile/mesgdef/workout_session.rs
@@ -58,12 +58,12 @@ impl WorkoutSession {
         }
     }
 
-    /// Returns `pool_length` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn pool_length_scaled(&self) -> f64 {
+    /// Returns `pool_length` in its scaled value. It returns `None` when value is valid.
+    pub fn pool_length_scaled(&self) -> Option<f64> {
         if self.pool_length == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.pool_length as f64 / 100.0 - 0.0
+        Some(self.pool_length as f64 / 100.0 - 0.0)
     }
 
     /// Set `pool_length` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/profile/mesgdef/workout_step.rs
+++ b/rustyfit/src/profile/mesgdef/workout_step.rs
@@ -108,12 +108,12 @@ impl WorkoutStep {
         }
     }
 
-    /// Returns `exercise_weight` in its scaled value. It returns invalid f64 when value is valid.
-    pub fn exercise_weight_scaled(&self) -> f64 {
+    /// Returns `exercise_weight` in its scaled value. It returns `None` when value is valid.
+    pub fn exercise_weight_scaled(&self) -> Option<f64> {
         if self.exercise_weight == u16::MAX {
-            return f64::from_bits(u64::MAX);
+            return None;
         }
-        self.exercise_weight as f64 / 100.0 - 0.0
+        Some(self.exercise_weight as f64 / 100.0 - 0.0)
     }
 
     /// Set `exercise_weight` with scaled value, it will automatically be converted to its corresponding integer value.

--- a/rustyfit/src/semconv.rs
+++ b/rustyfit/src/semconv.rs
@@ -1,41 +1,49 @@
 const PI_RADIANS: f64 = (1u32 << 31) as f64;
 const CONVERSION_FACTOR: f64 = 180.0 / PI_RADIANS;
 
-/// Converts semicircles to degrees. It returns f64 invalid when value is invalid.
-pub fn to_degrees(semicircles: i32) -> f64 {
+/// Converts semicircles to degrees. It returns `None` when value is invalid.
+pub fn to_degrees(semicircles: i32) -> Option<f64> {
     if semicircles == i32::MAX {
-        return f64::from_bits(u64::MAX);
+        return None;
     }
-    semicircles as f64 * CONVERSION_FACTOR
+    Some(semicircles as f64 * CONVERSION_FACTOR)
 }
 
-/// Converts degrees to semicircles. It returns i32 invalid when value is invalid.
-pub fn to_semicircles(degrees: f64) -> i32 {
+/// Converts degrees to semicircles. It returns `None` when value is invalid.
+pub fn to_semicircles(degrees: f64) -> Option<i32> {
     if degrees.is_nan() || degrees.is_infinite() {
-        return i32::MAX;
+        return None;
     }
-    (degrees / CONVERSION_FACTOR) as i32
+    Some((degrees / CONVERSION_FACTOR) as i32)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::f64;
+
     use crate::semconv;
 
     #[test]
     fn test_to_degrees() {
         let lat: i32 = 424480360;
-        assert_eq!(semconv::to_degrees(lat), 35.579532757401466);
+        assert_eq!(semconv::to_degrees(lat), Some(35.579532757401466));
 
         let long: i32 = -940295581;
-        assert_eq!(semconv::to_degrees(long), -78.81466512568295);
+        assert_eq!(semconv::to_degrees(long), Some(-78.81466512568295));
+
+        let invalid = i32::MAX;
+        assert_eq!(semconv::to_degrees(invalid), None);
     }
 
     #[test]
     fn test_to_semicircles() {
         let lat: f64 = 35.579532757401466;
-        assert_eq!(semconv::to_semicircles(lat), 424480360);
+        assert_eq!(semconv::to_semicircles(lat), Some(424480360));
 
         let long: f64 = -78.81466512568295;
-        assert_eq!(semconv::to_semicircles(long), -940295581);
+        assert_eq!(semconv::to_semicircles(long), Some(-940295581));
+
+        let invalid = f64::NAN;
+        assert_eq!(semconv::to_semicircles(invalid), None);
     }
 }


### PR DESCRIPTION
Conversion methods now return `Option<T>` instead of `T` to make users handle invalid value explicitly rather than implicitly. When returning `f64`, users might expect that it returns `non-NaN` value when it can return actually `NaN`. and `NaN` is not comparable.

This affects `semconv` and `mesgdef` module.

These methods are additional feature that this library introduces rather than from the protocol definition itself. It is common to have code like this:

```rs
let altitude: Option<f64> = if rec.enhanced_altitude != u32::MAX {
    Some(rec.enhanced_altitude_scaled())
} else if rec.altitude != u16::MAX {
    Some(rec.altitude_scaled())
} else {
    None
};
```

It's  more ergonomic to use:
```rs
let altitude: Option<f64> = rec
    .enhanced_altitude_scaled()
    .or_else(|| rec.altitude_scaled());
```

We already use this pattern on `DateTime` when converting from FIT timestamp to Unix timestamp or vice-versa, let's make it consistent.

Also include change on `set_<name>_scaled(v: &Vec<u8>)` into `set_<name>_scaled(v: &[u8])`, use slice, to make it more flexible, this can accept both vector and slice. While Array is kept as is since the value itself implements copy and small enough.
