### PR TITLE
feat: add `set_*_degrees` method and include minor chore

### DIFF
--- a/fitgen/internal/profile/mesgdef/mesgdef.tmpl
+++ b/fitgen/internal/profile/mesgdef/mesgdef.tmpl
@@ -86,6 +86,12 @@ impl {{ .Name }} {
         pub fn {{ .Name }}_degrees(&self) -> Option<f64> {
             semconv::to_degrees(self.{{ .Name }})
         }
+
+        /// Set `{{ .Name }}` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+        pub fn set_{{ .Name }}_degrees(&mut self, v: f64) -> &mut Self {
+            self.{{ .Name }} = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+            self
+        }
     {{ end }}
     {{ end }}
 

--- a/fitgen/internal/profile/mesgdef/mesgdef.tmpl
+++ b/fitgen/internal/profile/mesgdef/mesgdef.tmpl
@@ -134,7 +134,7 @@ impl {{ .Name }} {
 
         /// Set `{{ .Name }}` with scaled value, it will automatically be converted to its corresponding integer value.
         {{ if not .Array -}}
-        pub fn set_{{ .Name }}_scaled(&mut self, v: f64) -> &mut {{ $.Name }} {
+        pub fn set_{{ .Name }}_scaled(&mut self, v: f64) -> &mut Self {
             let unscaled = (v + {{ formatFloat .Offset }}) * {{ formatFloat .Scale }};
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > {{ .MaxValue }} as f64 {
                 self.{{ .Name }} = {{ .InvalidValue }};
@@ -144,7 +144,7 @@ impl {{ .Name }} {
             self
         }
         {{ else if eq .FixedArraySize 0 -}}
-        pub fn set_{{ .Name }}_scaled(&mut self, v: &[f64]) -> &mut {{ $.Name }} {
+        pub fn set_{{ .Name }}_scaled(&mut self, v: &[f64]) -> &mut Self {
             self.{{ .Name }} = Vec::with_capacity(v.len());
             if v.is_empty() {
                 return self;
@@ -160,7 +160,7 @@ impl {{ .Name }} {
             self
         }
         {{ else -}}
-        pub fn set_{{ .Name }}_scaled(&mut self, v: [f64; {{ .FixedArraySize }}]) -> &mut {{ $.Name }} {
+        pub fn set_{{ .Name }}_scaled(&mut self, v: [f64; {{ .FixedArraySize }}]) -> &mut Self {
             self.{{ .Name }} = [{{ .BaseType0Invalid }}; {{ .FixedArraySize }}];
             for (i, &x) in v.iter().enumerate() {
                 let unscaled = (x + {{ formatFloat .Offset }}) * {{ formatFloat .Scale }};

--- a/rustyfit/src/profile/mesgdef/aad_accel_features.rs
+++ b/rustyfit/src/profile/mesgdef/aad_accel_features.rs
@@ -67,7 +67,7 @@ impl AadAccelFeatures {
     }
 
     /// Set `time_above_threshold` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_above_threshold_scaled(&mut self, v: f64) -> &mut AadAccelFeatures {
+    pub fn set_time_above_threshold_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 25.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.time_above_threshold = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/activity.rs
+++ b/rustyfit/src/profile/mesgdef/activity.rs
@@ -72,7 +72,7 @@ impl Activity {
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Activity {
+    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_timer_time = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/ant_rx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_rx.rs
@@ -73,7 +73,7 @@ impl AntRx {
     }
 
     /// Set `fractional_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_fractional_timestamp_scaled(&mut self, v: f64) -> &mut AntRx {
+    pub fn set_fractional_timestamp_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 32768.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.fractional_timestamp = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/ant_tx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_tx.rs
@@ -73,7 +73,7 @@ impl AntTx {
     }
 
     /// Set `fractional_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_fractional_timestamp_scaled(&mut self, v: f64) -> &mut AntTx {
+    pub fn set_fractional_timestamp_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 32768.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.fractional_timestamp = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/aviation_attitude.rs
+++ b/rustyfit/src/profile/mesgdef/aviation_attitude.rs
@@ -100,7 +100,7 @@ impl AviationAttitude {
     }
 
     /// Set `pitch` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_pitch_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+    pub fn set_pitch_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.pitch = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -129,7 +129,7 @@ impl AviationAttitude {
     }
 
     /// Set `roll` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_roll_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+    pub fn set_roll_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.roll = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -158,7 +158,7 @@ impl AviationAttitude {
     }
 
     /// Set `accel_lateral` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_lateral_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+    pub fn set_accel_lateral_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.accel_lateral = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -187,7 +187,7 @@ impl AviationAttitude {
     }
 
     /// Set `accel_normal` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_normal_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+    pub fn set_accel_normal_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.accel_normal = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -216,7 +216,7 @@ impl AviationAttitude {
     }
 
     /// Set `turn_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_turn_rate_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+    pub fn set_turn_rate_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.turn_rate = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -245,7 +245,7 @@ impl AviationAttitude {
     }
 
     /// Set `track` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_track_scaled(&mut self, v: &[f64]) -> &mut AviationAttitude {
+    pub fn set_track_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.track = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/bike_profile.rs
+++ b/rustyfit/src/profile/mesgdef/bike_profile.rs
@@ -187,7 +187,7 @@ impl BikeProfile {
     }
 
     /// Set `odometer` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_odometer_scaled(&mut self, v: f64) -> &mut BikeProfile {
+    pub fn set_odometer_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.odometer = u32::MAX;
@@ -206,7 +206,7 @@ impl BikeProfile {
     }
 
     /// Set `custom_wheelsize` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_custom_wheelsize_scaled(&mut self, v: f64) -> &mut BikeProfile {
+    pub fn set_custom_wheelsize_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.custom_wheelsize = u16::MAX;
@@ -225,7 +225,7 @@ impl BikeProfile {
     }
 
     /// Set `auto_wheelsize` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_auto_wheelsize_scaled(&mut self, v: f64) -> &mut BikeProfile {
+    pub fn set_auto_wheelsize_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.auto_wheelsize = u16::MAX;
@@ -244,7 +244,7 @@ impl BikeProfile {
     }
 
     /// Set `bike_weight` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_bike_weight_scaled(&mut self, v: f64) -> &mut BikeProfile {
+    pub fn set_bike_weight_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.bike_weight = u16::MAX;
@@ -263,7 +263,7 @@ impl BikeProfile {
     }
 
     /// Set `power_cal_factor` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_power_cal_factor_scaled(&mut self, v: f64) -> &mut BikeProfile {
+    pub fn set_power_cal_factor_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.power_cal_factor = u16::MAX;
@@ -282,7 +282,7 @@ impl BikeProfile {
     }
 
     /// Set `crank_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_crank_length_scaled(&mut self, v: f64) -> &mut BikeProfile {
+    pub fn set_crank_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + -110.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.crank_length = u8::MAX;

--- a/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
@@ -51,7 +51,7 @@ impl ChronoShotData {
     }
 
     /// Set `shot_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_shot_speed_scaled(&mut self, v: f64) -> &mut ChronoShotData {
+    pub fn set_shot_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.shot_speed = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
@@ -75,7 +75,7 @@ impl ChronoShotSession {
     }
 
     /// Set `min_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_speed_scaled(&mut self, v: f64) -> &mut ChronoShotSession {
+    pub fn set_min_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.min_speed = u32::MAX;
@@ -94,7 +94,7 @@ impl ChronoShotSession {
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut ChronoShotSession {
+    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.max_speed = u32::MAX;
@@ -113,7 +113,7 @@ impl ChronoShotSession {
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut ChronoShotSession {
+    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.avg_speed = u32::MAX;
@@ -132,7 +132,7 @@ impl ChronoShotSession {
     }
 
     /// Set `grain_weight` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_grain_weight_scaled(&mut self, v: f64) -> &mut ChronoShotSession {
+    pub fn set_grain_weight_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.grain_weight = u32::MAX;
@@ -151,7 +151,7 @@ impl ChronoShotSession {
     }
 
     /// Set `standard_deviation` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_standard_deviation_scaled(&mut self, v: f64) -> &mut ChronoShotSession {
+    pub fn set_standard_deviation_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.standard_deviation = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/climb_pro.rs
+++ b/rustyfit/src/profile/mesgdef/climb_pro.rs
@@ -67,9 +67,21 @@ impl ClimbPro {
         semconv::to_degrees(self.position_lat)
     }
 
+    /// Set `position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
+    }
+
+    /// Set `position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     fn count_valid_fields(&self) -> usize {

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -72,9 +72,21 @@ impl CoursePoint {
         semconv::to_degrees(self.position_lat)
     }
 
+    /// Set `position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
+    }
+
+    /// Set `position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `distance` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -98,7 +98,7 @@ impl CoursePoint {
     }
 
     /// Set `distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_distance_scaled(&mut self, v: f64) -> &mut CoursePoint {
+    pub fn set_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.distance = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
@@ -59,7 +59,7 @@ impl DeviceAuxBatteryInfo {
     }
 
     /// Set `battery_voltage` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_battery_voltage_scaled(&mut self, v: f64) -> &mut DeviceAuxBatteryInfo {
+    pub fn set_battery_voltage_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 256.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.battery_voltage = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/device_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_info.rs
@@ -127,7 +127,7 @@ impl DeviceInfo {
     }
 
     /// Set `software_version` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_software_version_scaled(&mut self, v: f64) -> &mut DeviceInfo {
+    pub fn set_software_version_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.software_version = u16::MAX;
@@ -146,7 +146,7 @@ impl DeviceInfo {
     }
 
     /// Set `battery_voltage` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_battery_voltage_scaled(&mut self, v: f64) -> &mut DeviceInfo {
+    pub fn set_battery_voltage_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 256.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.battery_voltage = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/device_settings.rs
+++ b/rustyfit/src/profile/mesgdef/device_settings.rs
@@ -159,7 +159,7 @@ impl DeviceSettings {
     }
 
     /// Set `time_zone_offset` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_zone_offset_scaled(&mut self, v: &[f64]) -> &mut DeviceSettings {
+    pub fn set_time_zone_offset_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_zone_offset = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/dive_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_alarm.rs
@@ -103,7 +103,7 @@ impl DiveAlarm {
     }
 
     /// Set `depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_depth_scaled(&mut self, v: f64) -> &mut DiveAlarm {
+    pub fn set_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.depth = u32::MAX;
@@ -122,7 +122,7 @@ impl DiveAlarm {
     }
 
     /// Set `speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_speed_scaled(&mut self, v: f64) -> &mut DiveAlarm {
+    pub fn set_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i32::MAX as f64 {
             self.speed = i32::MAX;

--- a/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
@@ -103,7 +103,7 @@ impl DiveApneaAlarm {
     }
 
     /// Set `depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_depth_scaled(&mut self, v: f64) -> &mut DiveApneaAlarm {
+    pub fn set_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.depth = u32::MAX;
@@ -122,7 +122,7 @@ impl DiveApneaAlarm {
     }
 
     /// Set `speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_speed_scaled(&mut self, v: f64) -> &mut DiveApneaAlarm {
+    pub fn set_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i32::MAX as f64 {
             self.speed = i32::MAX;

--- a/rustyfit/src/profile/mesgdef/dive_settings.rs
+++ b/rustyfit/src/profile/mesgdef/dive_settings.rs
@@ -200,7 +200,7 @@ impl DiveSettings {
     }
 
     /// Set `po2_warn` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_po2_warn_scaled(&mut self, v: f64) -> &mut DiveSettings {
+    pub fn set_po2_warn_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.po2_warn = u8::MAX;
@@ -219,7 +219,7 @@ impl DiveSettings {
     }
 
     /// Set `po2_critical` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_po2_critical_scaled(&mut self, v: f64) -> &mut DiveSettings {
+    pub fn set_po2_critical_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.po2_critical = u8::MAX;
@@ -238,7 +238,7 @@ impl DiveSettings {
     }
 
     /// Set `po2_deco` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_po2_deco_scaled(&mut self, v: f64) -> &mut DiveSettings {
+    pub fn set_po2_deco_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.po2_deco = u8::MAX;
@@ -257,7 +257,7 @@ impl DiveSettings {
     }
 
     /// Set `ccr_low_setpoint` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_ccr_low_setpoint_scaled(&mut self, v: f64) -> &mut DiveSettings {
+    pub fn set_ccr_low_setpoint_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.ccr_low_setpoint = u8::MAX;
@@ -276,7 +276,7 @@ impl DiveSettings {
     }
 
     /// Set `ccr_low_setpoint_depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_ccr_low_setpoint_depth_scaled(&mut self, v: f64) -> &mut DiveSettings {
+    pub fn set_ccr_low_setpoint_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.ccr_low_setpoint_depth = u32::MAX;
@@ -295,7 +295,7 @@ impl DiveSettings {
     }
 
     /// Set `ccr_high_setpoint` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_ccr_high_setpoint_scaled(&mut self, v: f64) -> &mut DiveSettings {
+    pub fn set_ccr_high_setpoint_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.ccr_high_setpoint = u8::MAX;
@@ -314,7 +314,7 @@ impl DiveSettings {
     }
 
     /// Set `ccr_high_setpoint_depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_ccr_high_setpoint_depth_scaled(&mut self, v: f64) -> &mut DiveSettings {
+    pub fn set_ccr_high_setpoint_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.ccr_high_setpoint_depth = u32::MAX;
@@ -333,7 +333,7 @@ impl DiveSettings {
     }
 
     /// Set `last_stop_multiple` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_last_stop_multiple_scaled(&mut self, v: f64) -> &mut DiveSettings {
+    pub fn set_last_stop_multiple_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.last_stop_multiple = u8::MAX;

--- a/rustyfit/src/profile/mesgdef/dive_summary.rs
+++ b/rustyfit/src/profile/mesgdef/dive_summary.rs
@@ -150,7 +150,7 @@ impl DiveSummary {
     }
 
     /// Set `avg_depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_depth_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_avg_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.avg_depth = u32::MAX;
@@ -169,7 +169,7 @@ impl DiveSummary {
     }
 
     /// Set `max_depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_depth_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_max_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.max_depth = u32::MAX;
@@ -188,7 +188,7 @@ impl DiveSummary {
     }
 
     /// Set `bottom_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_bottom_time_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_bottom_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.bottom_time = u32::MAX;
@@ -207,7 +207,7 @@ impl DiveSummary {
     }
 
     /// Set `avg_pressure_sac` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_pressure_sac_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_avg_pressure_sac_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_pressure_sac = u16::MAX;
@@ -226,7 +226,7 @@ impl DiveSummary {
     }
 
     /// Set `avg_volume_sac` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_volume_sac_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_avg_volume_sac_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_volume_sac = u16::MAX;
@@ -245,7 +245,7 @@ impl DiveSummary {
     }
 
     /// Set `avg_rmv` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_rmv_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_avg_rmv_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_rmv = u16::MAX;
@@ -264,7 +264,7 @@ impl DiveSummary {
     }
 
     /// Set `descent_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_descent_time_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_descent_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.descent_time = u32::MAX;
@@ -283,7 +283,7 @@ impl DiveSummary {
     }
 
     /// Set `ascent_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_ascent_time_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_ascent_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.ascent_time = u32::MAX;
@@ -302,7 +302,7 @@ impl DiveSummary {
     }
 
     /// Set `avg_ascent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_ascent_rate_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_avg_ascent_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i32::MAX as f64 {
             self.avg_ascent_rate = i32::MAX;
@@ -321,7 +321,7 @@ impl DiveSummary {
     }
 
     /// Set `avg_descent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_descent_rate_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_avg_descent_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.avg_descent_rate = u32::MAX;
@@ -340,7 +340,7 @@ impl DiveSummary {
     }
 
     /// Set `max_ascent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_ascent_rate_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_max_ascent_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.max_ascent_rate = u32::MAX;
@@ -359,7 +359,7 @@ impl DiveSummary {
     }
 
     /// Set `max_descent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_descent_rate_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_max_descent_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.max_descent_rate = u32::MAX;
@@ -378,7 +378,7 @@ impl DiveSummary {
     }
 
     /// Set `hang_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_hang_time_scaled(&mut self, v: f64) -> &mut DiveSummary {
+    pub fn set_hang_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.hang_time = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/event.rs
+++ b/rustyfit/src/profile/mesgdef/event.rs
@@ -138,7 +138,7 @@ impl Event {
     }
 
     /// Set `radar_threat_avg_approach_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_radar_threat_avg_approach_speed_scaled(&mut self, v: f64) -> &mut Event {
+    pub fn set_radar_threat_avg_approach_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.radar_threat_avg_approach_speed = u8::MAX;
@@ -157,7 +157,7 @@ impl Event {
     }
 
     /// Set `radar_threat_max_approach_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_radar_threat_max_approach_speed_scaled(&mut self, v: f64) -> &mut Event {
+    pub fn set_radar_threat_max_approach_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.radar_threat_max_approach_speed = u8::MAX;

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -80,9 +80,21 @@ impl GpsMetadata {
         semconv::to_degrees(self.position_lat)
     }
 
+    /// Set `position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
+    }
+
+    /// Set `position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `enhanced_altitude` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -106,7 +106,7 @@ impl GpsMetadata {
     }
 
     /// Set `enhanced_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_altitude_scaled(&mut self, v: f64) -> &mut GpsMetadata {
+    pub fn set_enhanced_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_altitude = u32::MAX;
@@ -125,7 +125,7 @@ impl GpsMetadata {
     }
 
     /// Set `enhanced_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_speed_scaled(&mut self, v: f64) -> &mut GpsMetadata {
+    pub fn set_enhanced_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_speed = u32::MAX;
@@ -144,7 +144,7 @@ impl GpsMetadata {
     }
 
     /// Set `heading` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_heading_scaled(&mut self, v: f64) -> &mut GpsMetadata {
+    pub fn set_heading_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.heading = u16::MAX;
@@ -170,7 +170,7 @@ impl GpsMetadata {
     }
 
     /// Set `velocity` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_velocity_scaled(&mut self, v: [f64; 3]) -> &mut GpsMetadata {
+    pub fn set_velocity_scaled(&mut self, v: [f64; 3]) -> &mut Self {
         self.velocity = [i16::MAX; 3];
         for (i, &x) in v.iter().enumerate() {
             let unscaled = (x + 0.0) * 100.0;

--- a/rustyfit/src/profile/mesgdef/hr.rs
+++ b/rustyfit/src/profile/mesgdef/hr.rs
@@ -76,7 +76,7 @@ impl Hr {
     }
 
     /// Set `fractional_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_fractional_timestamp_scaled(&mut self, v: f64) -> &mut Hr {
+    pub fn set_fractional_timestamp_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 32768.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.fractional_timestamp = u16::MAX;
@@ -95,7 +95,7 @@ impl Hr {
     }
 
     /// Set `time256` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time256_scaled(&mut self, v: f64) -> &mut Hr {
+    pub fn set_time256_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 256.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.time256 = u8::MAX;
@@ -118,7 +118,7 @@ impl Hr {
     }
 
     /// Set `event_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_event_timestamp_scaled(&mut self, v: &[f64]) -> &mut Hr {
+    pub fn set_event_timestamp_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.event_timestamp = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/hrv.rs
+++ b/rustyfit/src/profile/mesgdef/hrv.rs
@@ -47,7 +47,7 @@ impl Hrv {
     }
 
     /// Set `time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_scaled(&mut self, v: &[f64]) -> &mut Hrv {
+    pub fn set_time_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
@@ -76,7 +76,7 @@ impl HrvStatusSummary {
     }
 
     /// Set `weekly_average` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_weekly_average_scaled(&mut self, v: f64) -> &mut HrvStatusSummary {
+    pub fn set_weekly_average_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.weekly_average = u16::MAX;
@@ -95,7 +95,7 @@ impl HrvStatusSummary {
     }
 
     /// Set `last_night_average` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_last_night_average_scaled(&mut self, v: f64) -> &mut HrvStatusSummary {
+    pub fn set_last_night_average_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.last_night_average = u16::MAX;
@@ -114,7 +114,7 @@ impl HrvStatusSummary {
     }
 
     /// Set `last_night_5_min_high` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_last_night_5_min_high_scaled(&mut self, v: f64) -> &mut HrvStatusSummary {
+    pub fn set_last_night_5_min_high_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.last_night_5_min_high = u16::MAX;
@@ -133,7 +133,7 @@ impl HrvStatusSummary {
     }
 
     /// Set `baseline_low_upper` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_baseline_low_upper_scaled(&mut self, v: f64) -> &mut HrvStatusSummary {
+    pub fn set_baseline_low_upper_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.baseline_low_upper = u16::MAX;
@@ -152,7 +152,7 @@ impl HrvStatusSummary {
     }
 
     /// Set `baseline_balanced_lower` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_baseline_balanced_lower_scaled(&mut self, v: f64) -> &mut HrvStatusSummary {
+    pub fn set_baseline_balanced_lower_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.baseline_balanced_lower = u16::MAX;
@@ -171,7 +171,7 @@ impl HrvStatusSummary {
     }
 
     /// Set `baseline_balanced_upper` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_baseline_balanced_upper_scaled(&mut self, v: f64) -> &mut HrvStatusSummary {
+    pub fn set_baseline_balanced_upper_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.baseline_balanced_upper = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/hrv_value.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_value.rs
@@ -47,7 +47,7 @@ impl HrvValue {
     }
 
     /// Set `value` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_value_scaled(&mut self, v: f64) -> &mut HrvValue {
+    pub fn set_value_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.value = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
@@ -77,7 +77,7 @@ impl HsaAccelerometerData {
     }
 
     /// Set `accel_x` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_x_scaled(&mut self, v: &[f64]) -> &mut HsaAccelerometerData {
+    pub fn set_accel_x_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.accel_x = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -106,7 +106,7 @@ impl HsaAccelerometerData {
     }
 
     /// Set `accel_y` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_y_scaled(&mut self, v: &[f64]) -> &mut HsaAccelerometerData {
+    pub fn set_accel_y_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.accel_y = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -135,7 +135,7 @@ impl HsaAccelerometerData {
     }
 
     /// Set `accel_z` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_accel_z_scaled(&mut self, v: &[f64]) -> &mut HsaAccelerometerData {
+    pub fn set_accel_z_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.accel_z = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
@@ -77,7 +77,7 @@ impl HsaGyroscopeData {
     }
 
     /// Set `gyro_x` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_gyro_x_scaled(&mut self, v: &[f64]) -> &mut HsaGyroscopeData {
+    pub fn set_gyro_x_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.gyro_x = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -106,7 +106,7 @@ impl HsaGyroscopeData {
     }
 
     /// Set `gyro_y` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_gyro_y_scaled(&mut self, v: &[f64]) -> &mut HsaGyroscopeData {
+    pub fn set_gyro_y_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.gyro_y = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -135,7 +135,7 @@ impl HsaGyroscopeData {
     }
 
     /// Set `gyro_z` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_gyro_z_scaled(&mut self, v: &[f64]) -> &mut HsaGyroscopeData {
+    pub fn set_gyro_z_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.gyro_z = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
@@ -57,7 +57,7 @@ impl HsaRespirationData {
     }
 
     /// Set `respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_respiration_rate_scaled(&mut self, v: &[f64]) -> &mut HsaRespirationData {
+    pub fn set_respiration_rate_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.respiration_rate = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
@@ -57,7 +57,7 @@ impl HsaWristTemperatureData {
     }
 
     /// Set `value` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_value_scaled(&mut self, v: &[f64]) -> &mut HsaWristTemperatureData {
+    pub fn set_value_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.value = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -119,7 +119,7 @@ impl Jump {
     }
 
     /// Set `speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_speed_scaled(&mut self, v: f64) -> &mut Jump {
+    pub fn set_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.speed = u16::MAX;
@@ -138,7 +138,7 @@ impl Jump {
     }
 
     /// Set `enhanced_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_speed_scaled(&mut self, v: f64) -> &mut Jump {
+    pub fn set_enhanced_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_speed = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -93,9 +93,21 @@ impl Jump {
         semconv::to_degrees(self.position_lat)
     }
 
+    /// Set `position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
+    }
+
+    /// Set `position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `speed` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -693,7 +693,7 @@ impl Lap {
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_elapsed_time = u32::MAX;
@@ -712,7 +712,7 @@ impl Lap {
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_timer_time = u32::MAX;
@@ -731,7 +731,7 @@ impl Lap {
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_distance = u32::MAX;
@@ -750,7 +750,7 @@ impl Lap {
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_speed = u16::MAX;
@@ -769,7 +769,7 @@ impl Lap {
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.max_speed = u16::MAX;
@@ -788,7 +788,7 @@ impl Lap {
     }
 
     /// Set `avg_stroke_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_stroke_distance_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_stroke_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_stroke_distance = u16::MAX;
@@ -807,7 +807,7 @@ impl Lap {
     }
 
     /// Set `avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_altitude_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_altitude = u16::MAX;
@@ -826,7 +826,7 @@ impl Lap {
     }
 
     /// Set `max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_altitude_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_max_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.max_altitude = u16::MAX;
@@ -845,7 +845,7 @@ impl Lap {
     }
 
     /// Set `avg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_grade_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_grade = i16::MAX;
@@ -864,7 +864,7 @@ impl Lap {
     }
 
     /// Set `avg_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_pos_grade_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_pos_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_pos_grade = i16::MAX;
@@ -883,7 +883,7 @@ impl Lap {
     }
 
     /// Set `avg_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_neg_grade_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_neg_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_neg_grade = i16::MAX;
@@ -902,7 +902,7 @@ impl Lap {
     }
 
     /// Set `max_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_pos_grade_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_max_pos_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_pos_grade = i16::MAX;
@@ -921,7 +921,7 @@ impl Lap {
     }
 
     /// Set `max_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_neg_grade_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_max_neg_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_neg_grade = i16::MAX;
@@ -940,7 +940,7 @@ impl Lap {
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_moving_time = u32::MAX;
@@ -959,7 +959,7 @@ impl Lap {
     }
 
     /// Set `avg_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_pos_vertical_speed = i16::MAX;
@@ -978,7 +978,7 @@ impl Lap {
     }
 
     /// Set `avg_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_neg_vertical_speed = i16::MAX;
@@ -997,7 +997,7 @@ impl Lap {
     }
 
     /// Set `max_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_max_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_pos_vertical_speed = i16::MAX;
@@ -1016,7 +1016,7 @@ impl Lap {
     }
 
     /// Set `max_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_max_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_neg_vertical_speed = i16::MAX;
@@ -1039,7 +1039,7 @@ impl Lap {
     }
 
     /// Set `time_in_hr_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_hr_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1068,7 +1068,7 @@ impl Lap {
     }
 
     /// Set `time_in_speed_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_speed_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1097,7 +1097,7 @@ impl Lap {
     }
 
     /// Set `time_in_cadence_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_cadence_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1126,7 +1126,7 @@ impl Lap {
     }
 
     /// Set `time_in_power_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_power_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1151,7 +1151,7 @@ impl Lap {
     }
 
     /// Set `min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_altitude_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_min_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.min_altitude = u16::MAX;
@@ -1170,7 +1170,7 @@ impl Lap {
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.active_time = u32::MAX;
@@ -1189,7 +1189,7 @@ impl Lap {
     }
 
     /// Set `avg_vertical_oscillation` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_vertical_oscillation_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_vertical_oscillation_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_vertical_oscillation = u16::MAX;
@@ -1208,7 +1208,7 @@ impl Lap {
     }
 
     /// Set `avg_stance_time_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_stance_time_percent_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_stance_time_percent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_stance_time_percent = u16::MAX;
@@ -1227,7 +1227,7 @@ impl Lap {
     }
 
     /// Set `avg_stance_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_stance_time_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_stance_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_stance_time = u16::MAX;
@@ -1246,7 +1246,7 @@ impl Lap {
     }
 
     /// Set `avg_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_fractional_cadence_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_fractional_cadence_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_fractional_cadence = u8::MAX;
@@ -1265,7 +1265,7 @@ impl Lap {
     }
 
     /// Set `max_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_fractional_cadence_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_max_fractional_cadence_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.max_fractional_cadence = u8::MAX;
@@ -1284,7 +1284,7 @@ impl Lap {
     }
 
     /// Set `total_fractional_cycles` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_fractional_cycles_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_total_fractional_cycles_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_fractional_cycles = u8::MAX;
@@ -1307,7 +1307,7 @@ impl Lap {
     }
 
     /// Set `avg_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_avg_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1336,7 +1336,7 @@ impl Lap {
     }
 
     /// Set `min_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_min_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.min_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1365,7 +1365,7 @@ impl Lap {
     }
 
     /// Set `max_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_max_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.max_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1394,7 +1394,7 @@ impl Lap {
     }
 
     /// Set `avg_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_avg_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1423,7 +1423,7 @@ impl Lap {
     }
 
     /// Set `min_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_min_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.min_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1452,7 +1452,7 @@ impl Lap {
     }
 
     /// Set `max_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_max_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.max_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1477,7 +1477,7 @@ impl Lap {
     }
 
     /// Set `avg_left_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_left_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_left_torque_effectiveness = u8::MAX;
@@ -1496,7 +1496,7 @@ impl Lap {
     }
 
     /// Set `avg_right_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_right_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_right_torque_effectiveness = u8::MAX;
@@ -1515,7 +1515,7 @@ impl Lap {
     }
 
     /// Set `avg_left_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_left_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_left_pedal_smoothness = u8::MAX;
@@ -1534,7 +1534,7 @@ impl Lap {
     }
 
     /// Set `avg_right_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_right_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_right_pedal_smoothness = u8::MAX;
@@ -1553,7 +1553,7 @@ impl Lap {
     }
 
     /// Set `avg_combined_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_combined_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_combined_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_combined_pedal_smoothness = u8::MAX;
@@ -1572,7 +1572,7 @@ impl Lap {
     }
 
     /// Set `time_standing` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_standing_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_time_standing_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.time_standing = u32::MAX;
@@ -1595,7 +1595,7 @@ impl Lap {
     }
 
     /// Set `avg_left_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_avg_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_left_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1624,7 +1624,7 @@ impl Lap {
     }
 
     /// Set `avg_left_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_left_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1653,7 +1653,7 @@ impl Lap {
     }
 
     /// Set `avg_right_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_avg_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_right_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1682,7 +1682,7 @@ impl Lap {
     }
 
     /// Set `avg_right_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Lap {
+    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_right_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1707,7 +1707,7 @@ impl Lap {
     }
 
     /// Set `enhanced_avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_avg_speed_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_enhanced_avg_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_avg_speed = u32::MAX;
@@ -1726,7 +1726,7 @@ impl Lap {
     }
 
     /// Set `enhanced_max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_max_speed_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_enhanced_max_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_max_speed = u32::MAX;
@@ -1745,7 +1745,7 @@ impl Lap {
     }
 
     /// Set `enhanced_avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_avg_altitude_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_enhanced_avg_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_avg_altitude = u32::MAX;
@@ -1764,7 +1764,7 @@ impl Lap {
     }
 
     /// Set `enhanced_min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_min_altitude_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_enhanced_min_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_min_altitude = u32::MAX;
@@ -1783,7 +1783,7 @@ impl Lap {
     }
 
     /// Set `enhanced_max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_max_altitude_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_enhanced_max_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_max_altitude = u32::MAX;
@@ -1802,7 +1802,7 @@ impl Lap {
     }
 
     /// Set `lev_battery_consumption` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_lev_battery_consumption_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_lev_battery_consumption_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.lev_battery_consumption = u8::MAX;
@@ -1821,7 +1821,7 @@ impl Lap {
     }
 
     /// Set `avg_vertical_ratio` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_vertical_ratio_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_vertical_ratio_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_vertical_ratio = u16::MAX;
@@ -1840,7 +1840,7 @@ impl Lap {
     }
 
     /// Set `avg_stance_time_balance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_stance_time_balance_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_stance_time_balance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_stance_time_balance = u16::MAX;
@@ -1859,7 +1859,7 @@ impl Lap {
     }
 
     /// Set `avg_step_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_step_length_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_step_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_step_length = u16::MAX;
@@ -1878,7 +1878,7 @@ impl Lap {
     }
 
     /// Set `avg_vam` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_vam_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_vam_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_vam = u16::MAX;
@@ -1897,7 +1897,7 @@ impl Lap {
     }
 
     /// Set `avg_depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_depth_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.avg_depth = u32::MAX;
@@ -1916,7 +1916,7 @@ impl Lap {
     }
 
     /// Set `max_depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_depth_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_max_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.max_depth = u32::MAX;
@@ -1935,7 +1935,7 @@ impl Lap {
     }
 
     /// Set `enhanced_avg_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_avg_respiration_rate_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_enhanced_avg_respiration_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.enhanced_avg_respiration_rate = u16::MAX;
@@ -1954,7 +1954,7 @@ impl Lap {
     }
 
     /// Set `enhanced_max_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_max_respiration_rate_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_enhanced_max_respiration_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.enhanced_max_respiration_rate = u16::MAX;
@@ -1973,7 +1973,7 @@ impl Lap {
     }
 
     /// Set `total_fractional_ascent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_fractional_ascent_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_total_fractional_ascent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_fractional_ascent = u8::MAX;
@@ -1992,7 +1992,7 @@ impl Lap {
     }
 
     /// Set `total_fractional_descent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_fractional_descent_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_total_fractional_descent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_fractional_descent = u8::MAX;
@@ -2011,7 +2011,7 @@ impl Lap {
     }
 
     /// Set `avg_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_core_temperature_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_avg_core_temperature_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_core_temperature = u16::MAX;
@@ -2030,7 +2030,7 @@ impl Lap {
     }
 
     /// Set `min_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_core_temperature_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_min_core_temperature_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.min_core_temperature = u16::MAX;
@@ -2049,7 +2049,7 @@ impl Lap {
     }
 
     /// Set `max_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_core_temperature_scaled(&mut self, v: f64) -> &mut Lap {
+    pub fn set_max_core_temperature_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.max_core_temperature = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -645,9 +645,21 @@ impl Lap {
         semconv::to_degrees(self.start_position_lat)
     }
 
+    /// Set `start_position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_start_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.start_position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `start_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn start_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_long)
+    }
+
+    /// Set `start_position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_start_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.start_position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `end_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
@@ -655,9 +667,21 @@ impl Lap {
         semconv::to_degrees(self.end_position_lat)
     }
 
+    /// Set `end_position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_end_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.end_position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `end_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn end_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_long)
+    }
+
+    /// Set `end_position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_end_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.end_position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `total_elapsed_time` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/length.rs
+++ b/rustyfit/src/profile/mesgdef/length.rs
@@ -146,7 +146,7 @@ impl Length {
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut Length {
+    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_elapsed_time = u32::MAX;
@@ -165,7 +165,7 @@ impl Length {
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Length {
+    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_timer_time = u32::MAX;
@@ -184,7 +184,7 @@ impl Length {
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Length {
+    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_speed = u16::MAX;
@@ -203,7 +203,7 @@ impl Length {
     }
 
     /// Set `enhanced_avg_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_avg_respiration_rate_scaled(&mut self, v: f64) -> &mut Length {
+    pub fn set_enhanced_avg_respiration_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.enhanced_avg_respiration_rate = u16::MAX;
@@ -222,7 +222,7 @@ impl Length {
     }
 
     /// Set `enhanced_max_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_max_respiration_rate_scaled(&mut self, v: f64) -> &mut Length {
+    pub fn set_enhanced_max_respiration_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.enhanced_max_respiration_rate = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/max_met_data.rs
+++ b/rustyfit/src/profile/mesgdef/max_met_data.rs
@@ -75,7 +75,7 @@ impl MaxMetData {
     }
 
     /// Set `vo2_max` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_vo2_max_scaled(&mut self, v: f64) -> &mut MaxMetData {
+    pub fn set_vo2_max_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.vo2_max = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/met_zone.rs
+++ b/rustyfit/src/profile/mesgdef/met_zone.rs
@@ -56,7 +56,7 @@ impl MetZone {
     }
 
     /// Set `calories` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_calories_scaled(&mut self, v: f64) -> &mut MetZone {
+    pub fn set_calories_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.calories = u16::MAX;
@@ -75,7 +75,7 @@ impl MetZone {
     }
 
     /// Set `fat_calories` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_fat_calories_scaled(&mut self, v: f64) -> &mut MetZone {
+    pub fn set_fat_calories_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.fat_calories = u8::MAX;

--- a/rustyfit/src/profile/mesgdef/monitoring.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring.rs
@@ -189,7 +189,7 @@ impl Monitoring {
     }
 
     /// Set `distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_distance_scaled(&mut self, v: f64) -> &mut Monitoring {
+    pub fn set_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.distance = u32::MAX;
@@ -208,7 +208,7 @@ impl Monitoring {
     }
 
     /// Set `cycles` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_cycles_scaled(&mut self, v: f64) -> &mut Monitoring {
+    pub fn set_cycles_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.cycles = u32::MAX;
@@ -227,7 +227,7 @@ impl Monitoring {
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Monitoring {
+    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.active_time = u32::MAX;
@@ -246,7 +246,7 @@ impl Monitoring {
     }
 
     /// Set `temperature` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_temperature_scaled(&mut self, v: f64) -> &mut Monitoring {
+    pub fn set_temperature_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.temperature = i16::MAX;
@@ -265,7 +265,7 @@ impl Monitoring {
     }
 
     /// Set `temperature_min` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_temperature_min_scaled(&mut self, v: f64) -> &mut Monitoring {
+    pub fn set_temperature_min_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.temperature_min = i16::MAX;
@@ -284,7 +284,7 @@ impl Monitoring {
     }
 
     /// Set `temperature_max` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_temperature_max_scaled(&mut self, v: f64) -> &mut Monitoring {
+    pub fn set_temperature_max_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.temperature_max = i16::MAX;
@@ -303,7 +303,7 @@ impl Monitoring {
     }
 
     /// Set `intensity` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_intensity_scaled(&mut self, v: f64) -> &mut Monitoring {
+    pub fn set_intensity_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.intensity = u8::MAX;
@@ -322,7 +322,7 @@ impl Monitoring {
     }
 
     /// Set `ascent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_ascent_scaled(&mut self, v: f64) -> &mut Monitoring {
+    pub fn set_ascent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.ascent = u32::MAX;
@@ -341,7 +341,7 @@ impl Monitoring {
     }
 
     /// Set `descent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_descent_scaled(&mut self, v: f64) -> &mut Monitoring {
+    pub fn set_descent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.descent = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/monitoring_info.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_info.rs
@@ -71,7 +71,7 @@ impl MonitoringInfo {
     }
 
     /// Set `cycles_to_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_cycles_to_distance_scaled(&mut self, v: &[f64]) -> &mut MonitoringInfo {
+    pub fn set_cycles_to_distance_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.cycles_to_distance = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -100,7 +100,7 @@ impl MonitoringInfo {
     }
 
     /// Set `cycles_to_calories` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_cycles_to_calories_scaled(&mut self, v: &[f64]) -> &mut MonitoringInfo {
+    pub fn set_cycles_to_calories_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.cycles_to_calories = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -485,7 +485,7 @@ impl Record {
     }
 
     /// Set `altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_altitude_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.altitude = u16::MAX;
@@ -504,7 +504,7 @@ impl Record {
     }
 
     /// Set `distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_distance_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.distance = u32::MAX;
@@ -523,7 +523,7 @@ impl Record {
     }
 
     /// Set `speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_speed_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.speed = u16::MAX;
@@ -542,7 +542,7 @@ impl Record {
     }
 
     /// Set `grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_grade_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.grade = i16::MAX;
@@ -561,7 +561,7 @@ impl Record {
     }
 
     /// Set `time_from_course` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_from_course_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_time_from_course_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i32::MAX as f64 {
             self.time_from_course = i32::MAX;
@@ -580,7 +580,7 @@ impl Record {
     }
 
     /// Set `cycle_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_cycle_length_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_cycle_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.cycle_length = u8::MAX;
@@ -603,7 +603,7 @@ impl Record {
     }
 
     /// Set `speed_1s` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_speed_1s_scaled(&mut self, v: &[f64]) -> &mut Record {
+    pub fn set_speed_1s_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.speed_1s = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -628,7 +628,7 @@ impl Record {
     }
 
     /// Set `vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_vertical_speed_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.vertical_speed = i16::MAX;
@@ -647,7 +647,7 @@ impl Record {
     }
 
     /// Set `vertical_oscillation` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_vertical_oscillation_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_vertical_oscillation_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.vertical_oscillation = u16::MAX;
@@ -666,7 +666,7 @@ impl Record {
     }
 
     /// Set `stance_time_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_stance_time_percent_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_stance_time_percent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.stance_time_percent = u16::MAX;
@@ -685,7 +685,7 @@ impl Record {
     }
 
     /// Set `stance_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_stance_time_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_stance_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.stance_time = u16::MAX;
@@ -704,7 +704,7 @@ impl Record {
     }
 
     /// Set `left_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_left_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_left_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.left_torque_effectiveness = u8::MAX;
@@ -723,7 +723,7 @@ impl Record {
     }
 
     /// Set `right_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_right_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_right_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.right_torque_effectiveness = u8::MAX;
@@ -742,7 +742,7 @@ impl Record {
     }
 
     /// Set `left_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_left_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_left_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.left_pedal_smoothness = u8::MAX;
@@ -761,7 +761,7 @@ impl Record {
     }
 
     /// Set `right_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_right_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_right_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.right_pedal_smoothness = u8::MAX;
@@ -780,7 +780,7 @@ impl Record {
     }
 
     /// Set `combined_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_combined_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_combined_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.combined_pedal_smoothness = u8::MAX;
@@ -799,7 +799,7 @@ impl Record {
     }
 
     /// Set `time128` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time128_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_time128_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.time128 = u8::MAX;
@@ -818,7 +818,7 @@ impl Record {
     }
 
     /// Set `ball_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_ball_speed_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_ball_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.ball_speed = u16::MAX;
@@ -837,7 +837,7 @@ impl Record {
     }
 
     /// Set `cadence256` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_cadence256_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_cadence256_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 256.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.cadence256 = u16::MAX;
@@ -856,7 +856,7 @@ impl Record {
     }
 
     /// Set `fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_fractional_cadence_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_fractional_cadence_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.fractional_cadence = u8::MAX;
@@ -875,7 +875,7 @@ impl Record {
     }
 
     /// Set `total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_hemoglobin_conc_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_total_hemoglobin_conc_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.total_hemoglobin_conc = u16::MAX;
@@ -894,7 +894,7 @@ impl Record {
     }
 
     /// Set `total_hemoglobin_conc_min` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_hemoglobin_conc_min_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_total_hemoglobin_conc_min_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.total_hemoglobin_conc_min = u16::MAX;
@@ -913,7 +913,7 @@ impl Record {
     }
 
     /// Set `total_hemoglobin_conc_max` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_hemoglobin_conc_max_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_total_hemoglobin_conc_max_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.total_hemoglobin_conc_max = u16::MAX;
@@ -932,7 +932,7 @@ impl Record {
     }
 
     /// Set `saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_saturated_hemoglobin_percent_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_saturated_hemoglobin_percent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.saturated_hemoglobin_percent = u16::MAX;
@@ -951,7 +951,7 @@ impl Record {
     }
 
     /// Set `saturated_hemoglobin_percent_min` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_saturated_hemoglobin_percent_min_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_saturated_hemoglobin_percent_min_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.saturated_hemoglobin_percent_min = u16::MAX;
@@ -970,7 +970,7 @@ impl Record {
     }
 
     /// Set `saturated_hemoglobin_percent_max` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_saturated_hemoglobin_percent_max_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_saturated_hemoglobin_percent_max_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.saturated_hemoglobin_percent_max = u16::MAX;
@@ -993,7 +993,7 @@ impl Record {
     }
 
     /// Set `left_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Record {
+    pub fn set_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.left_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1022,7 +1022,7 @@ impl Record {
     }
 
     /// Set `left_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Record {
+    pub fn set_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.left_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1051,7 +1051,7 @@ impl Record {
     }
 
     /// Set `right_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Record {
+    pub fn set_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.right_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1080,7 +1080,7 @@ impl Record {
     }
 
     /// Set `right_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Record {
+    pub fn set_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.right_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1105,7 +1105,7 @@ impl Record {
     }
 
     /// Set `enhanced_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_speed_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_enhanced_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_speed = u32::MAX;
@@ -1124,7 +1124,7 @@ impl Record {
     }
 
     /// Set `enhanced_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_altitude_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_enhanced_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_altitude = u32::MAX;
@@ -1143,7 +1143,7 @@ impl Record {
     }
 
     /// Set `battery_soc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_battery_soc_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_battery_soc_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.battery_soc = u8::MAX;
@@ -1162,7 +1162,7 @@ impl Record {
     }
 
     /// Set `vertical_ratio` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_vertical_ratio_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_vertical_ratio_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.vertical_ratio = u16::MAX;
@@ -1181,7 +1181,7 @@ impl Record {
     }
 
     /// Set `stance_time_balance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_stance_time_balance_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_stance_time_balance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.stance_time_balance = u16::MAX;
@@ -1200,7 +1200,7 @@ impl Record {
     }
 
     /// Set `step_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_step_length_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_step_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.step_length = u16::MAX;
@@ -1219,7 +1219,7 @@ impl Record {
     }
 
     /// Set `cycle_length16` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_cycle_length16_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_cycle_length16_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.cycle_length16 = u16::MAX;
@@ -1238,7 +1238,7 @@ impl Record {
     }
 
     /// Set `depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_depth_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.depth = u32::MAX;
@@ -1257,7 +1257,7 @@ impl Record {
     }
 
     /// Set `next_stop_depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_next_stop_depth_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_next_stop_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.next_stop_depth = u32::MAX;
@@ -1276,7 +1276,7 @@ impl Record {
     }
 
     /// Set `enhanced_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_respiration_rate_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_enhanced_respiration_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.enhanced_respiration_rate = u16::MAX;
@@ -1295,7 +1295,7 @@ impl Record {
     }
 
     /// Set `current_stress` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_current_stress_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_current_stress_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.current_stress = u16::MAX;
@@ -1314,7 +1314,7 @@ impl Record {
     }
 
     /// Set `pressure_sac` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_pressure_sac_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_pressure_sac_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.pressure_sac = u16::MAX;
@@ -1333,7 +1333,7 @@ impl Record {
     }
 
     /// Set `volume_sac` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_volume_sac_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_volume_sac_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.volume_sac = u16::MAX;
@@ -1352,7 +1352,7 @@ impl Record {
     }
 
     /// Set `rmv` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_rmv_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_rmv_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.rmv = u16::MAX;
@@ -1371,7 +1371,7 @@ impl Record {
     }
 
     /// Set `ascent_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_ascent_rate_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_ascent_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i32::MAX as f64 {
             self.ascent_rate = i32::MAX;
@@ -1390,7 +1390,7 @@ impl Record {
     }
 
     /// Set `po2` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_po2_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_po2_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.po2 = u8::MAX;
@@ -1409,7 +1409,7 @@ impl Record {
     }
 
     /// Set `core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_core_temperature_scaled(&mut self, v: f64) -> &mut Record {
+    pub fn set_core_temperature_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.core_temperature = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -459,9 +459,21 @@ impl Record {
         semconv::to_degrees(self.position_lat)
     }
 
+    /// Set `position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
+    }
+
+    /// Set `position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `altitude` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/respiration_rate.rs
+++ b/rustyfit/src/profile/mesgdef/respiration_rate.rs
@@ -47,7 +47,7 @@ impl RespirationRate {
     }
 
     /// Set `respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_respiration_rate_scaled(&mut self, v: f64) -> &mut RespirationRate {
+    pub fn set_respiration_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.respiration_rate = i16::MAX;

--- a/rustyfit/src/profile/mesgdef/sdm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/sdm_profile.rs
@@ -76,7 +76,7 @@ impl SdmProfile {
     }
 
     /// Set `sdm_cal_factor` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_sdm_cal_factor_scaled(&mut self, v: f64) -> &mut SdmProfile {
+    pub fn set_sdm_cal_factor_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.sdm_cal_factor = u16::MAX;
@@ -95,7 +95,7 @@ impl SdmProfile {
     }
 
     /// Set `odometer` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_odometer_scaled(&mut self, v: f64) -> &mut SdmProfile {
+    pub fn set_odometer_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.odometer = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -505,9 +505,21 @@ impl SegmentLap {
         semconv::to_degrees(self.start_position_lat)
     }
 
+    /// Set `start_position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_start_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.start_position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `start_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn start_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_long)
+    }
+
+    /// Set `start_position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_start_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.start_position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `end_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
@@ -515,9 +527,21 @@ impl SegmentLap {
         semconv::to_degrees(self.end_position_lat)
     }
 
+    /// Set `end_position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_end_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.end_position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `end_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn end_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_long)
+    }
+
+    /// Set `end_position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_end_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.end_position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `nec_lat` in degrees instead of semicircles. It returns `None` when value is valid.
@@ -525,9 +549,21 @@ impl SegmentLap {
         semconv::to_degrees(self.nec_lat)
     }
 
+    /// Set `nec_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_nec_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.nec_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `nec_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn nec_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.nec_long)
+    }
+
+    /// Set `nec_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_nec_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.nec_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `swc_lat` in degrees instead of semicircles. It returns `None` when value is valid.
@@ -535,9 +571,21 @@ impl SegmentLap {
         semconv::to_degrees(self.swc_lat)
     }
 
+    /// Set `swc_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_swc_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.swc_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `swc_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn swc_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.swc_long)
+    }
+
+    /// Set `swc_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_swc_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.swc_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `total_elapsed_time` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -597,7 +597,7 @@ impl SegmentLap {
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_elapsed_time = u32::MAX;
@@ -616,7 +616,7 @@ impl SegmentLap {
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_timer_time = u32::MAX;
@@ -635,7 +635,7 @@ impl SegmentLap {
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_distance = u32::MAX;
@@ -654,7 +654,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_speed = u16::MAX;
@@ -673,7 +673,7 @@ impl SegmentLap {
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.max_speed = u16::MAX;
@@ -692,7 +692,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_altitude_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_altitude = u16::MAX;
@@ -711,7 +711,7 @@ impl SegmentLap {
     }
 
     /// Set `max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_altitude_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_max_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.max_altitude = u16::MAX;
@@ -730,7 +730,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_grade_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_grade = i16::MAX;
@@ -749,7 +749,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_pos_grade_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_pos_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_pos_grade = i16::MAX;
@@ -768,7 +768,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_neg_grade_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_neg_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_neg_grade = i16::MAX;
@@ -787,7 +787,7 @@ impl SegmentLap {
     }
 
     /// Set `max_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_pos_grade_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_max_pos_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_pos_grade = i16::MAX;
@@ -806,7 +806,7 @@ impl SegmentLap {
     }
 
     /// Set `max_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_neg_grade_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_max_neg_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_neg_grade = i16::MAX;
@@ -825,7 +825,7 @@ impl SegmentLap {
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_moving_time = u32::MAX;
@@ -844,7 +844,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_pos_vertical_speed = i16::MAX;
@@ -863,7 +863,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_neg_vertical_speed = i16::MAX;
@@ -882,7 +882,7 @@ impl SegmentLap {
     }
 
     /// Set `max_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_max_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_pos_vertical_speed = i16::MAX;
@@ -901,7 +901,7 @@ impl SegmentLap {
     }
 
     /// Set `max_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_max_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_neg_vertical_speed = i16::MAX;
@@ -924,7 +924,7 @@ impl SegmentLap {
     }
 
     /// Set `time_in_hr_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_hr_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -953,7 +953,7 @@ impl SegmentLap {
     }
 
     /// Set `time_in_speed_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_speed_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -982,7 +982,7 @@ impl SegmentLap {
     }
 
     /// Set `time_in_cadence_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_cadence_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1011,7 +1011,7 @@ impl SegmentLap {
     }
 
     /// Set `time_in_power_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_power_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1036,7 +1036,7 @@ impl SegmentLap {
     }
 
     /// Set `min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_altitude_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_min_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.min_altitude = u16::MAX;
@@ -1055,7 +1055,7 @@ impl SegmentLap {
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.active_time = u32::MAX;
@@ -1074,7 +1074,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_left_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_torque_effectiveness_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_left_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_left_torque_effectiveness = u8::MAX;
@@ -1093,7 +1093,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_right_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_torque_effectiveness_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_right_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_right_torque_effectiveness = u8::MAX;
@@ -1112,7 +1112,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_left_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_pedal_smoothness_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_left_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_left_pedal_smoothness = u8::MAX;
@@ -1131,7 +1131,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_right_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_pedal_smoothness_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_right_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_right_pedal_smoothness = u8::MAX;
@@ -1150,7 +1150,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_combined_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_combined_pedal_smoothness_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_combined_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_combined_pedal_smoothness = u8::MAX;
@@ -1169,7 +1169,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_fractional_cadence_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_avg_fractional_cadence_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_fractional_cadence = u8::MAX;
@@ -1188,7 +1188,7 @@ impl SegmentLap {
     }
 
     /// Set `max_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_fractional_cadence_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_max_fractional_cadence_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.max_fractional_cadence = u8::MAX;
@@ -1207,7 +1207,7 @@ impl SegmentLap {
     }
 
     /// Set `total_fractional_cycles` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_fractional_cycles_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_total_fractional_cycles_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_fractional_cycles = u8::MAX;
@@ -1226,7 +1226,7 @@ impl SegmentLap {
     }
 
     /// Set `time_standing` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_standing_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_time_standing_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.time_standing = u32::MAX;
@@ -1249,7 +1249,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_left_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+    pub fn set_avg_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_left_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1278,7 +1278,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_left_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_left_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1307,7 +1307,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_right_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+    pub fn set_avg_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_right_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1336,7 +1336,7 @@ impl SegmentLap {
     }
 
     /// Set `avg_right_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut SegmentLap {
+    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_right_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1361,7 +1361,7 @@ impl SegmentLap {
     }
 
     /// Set `total_fractional_ascent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_fractional_ascent_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_total_fractional_ascent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_fractional_ascent = u8::MAX;
@@ -1380,7 +1380,7 @@ impl SegmentLap {
     }
 
     /// Set `total_fractional_descent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_fractional_descent_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_total_fractional_descent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_fractional_descent = u8::MAX;
@@ -1399,7 +1399,7 @@ impl SegmentLap {
     }
 
     /// Set `enhanced_avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_avg_altitude_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_enhanced_avg_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_avg_altitude = u32::MAX;
@@ -1418,7 +1418,7 @@ impl SegmentLap {
     }
 
     /// Set `enhanced_max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_max_altitude_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_enhanced_max_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_max_altitude = u32::MAX;
@@ -1437,7 +1437,7 @@ impl SegmentLap {
     }
 
     /// Set `enhanced_min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_min_altitude_scaled(&mut self, v: f64) -> &mut SegmentLap {
+    pub fn set_enhanced_min_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_min_altitude = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
+++ b/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
@@ -74,7 +74,7 @@ impl SegmentLeaderboardEntry {
     }
 
     /// Set `segment_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_segment_time_scaled(&mut self, v: f64) -> &mut SegmentLeaderboardEntry {
+    pub fn set_segment_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.segment_time = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/segment_point.rs
+++ b/rustyfit/src/profile/mesgdef/segment_point.rs
@@ -104,7 +104,7 @@ impl SegmentPoint {
     }
 
     /// Set `distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_distance_scaled(&mut self, v: f64) -> &mut SegmentPoint {
+    pub fn set_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.distance = u32::MAX;
@@ -123,7 +123,7 @@ impl SegmentPoint {
     }
 
     /// Set `altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_altitude_scaled(&mut self, v: f64) -> &mut SegmentPoint {
+    pub fn set_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.altitude = u16::MAX;
@@ -146,7 +146,7 @@ impl SegmentPoint {
     }
 
     /// Set `leader_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_leader_time_scaled(&mut self, v: &[f64]) -> &mut SegmentPoint {
+    pub fn set_leader_time_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.leader_time = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -171,7 +171,7 @@ impl SegmentPoint {
     }
 
     /// Set `enhanced_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_altitude_scaled(&mut self, v: f64) -> &mut SegmentPoint {
+    pub fn set_enhanced_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_altitude = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/segment_point.rs
+++ b/rustyfit/src/profile/mesgdef/segment_point.rs
@@ -78,9 +78,21 @@ impl SegmentPoint {
         semconv::to_degrees(self.position_lat)
     }
 
+    /// Set `position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.position_long)
+    }
+
+    /// Set `position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `distance` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -819,9 +819,21 @@ impl Session {
         semconv::to_degrees(self.start_position_lat)
     }
 
+    /// Set `start_position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_start_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.start_position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `start_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn start_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_long)
+    }
+
+    /// Set `start_position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_start_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.start_position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `nec_lat` in degrees instead of semicircles. It returns `None` when value is valid.
@@ -829,9 +841,21 @@ impl Session {
         semconv::to_degrees(self.nec_lat)
     }
 
+    /// Set `nec_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_nec_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.nec_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `nec_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn nec_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.nec_long)
+    }
+
+    /// Set `nec_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_nec_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.nec_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `swc_lat` in degrees instead of semicircles. It returns `None` when value is valid.
@@ -839,9 +863,21 @@ impl Session {
         semconv::to_degrees(self.swc_lat)
     }
 
+    /// Set `swc_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_swc_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.swc_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `swc_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn swc_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.swc_long)
+    }
+
+    /// Set `swc_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_swc_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.swc_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `end_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
@@ -849,9 +885,21 @@ impl Session {
         semconv::to_degrees(self.end_position_lat)
     }
 
+    /// Set `end_position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_end_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.end_position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `end_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn end_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_long)
+    }
+
+    /// Set `end_position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_end_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.end_position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `total_elapsed_time` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -911,7 +911,7 @@ impl Session {
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_elapsed_time = u32::MAX;
@@ -930,7 +930,7 @@ impl Session {
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_timer_time = u32::MAX;
@@ -949,7 +949,7 @@ impl Session {
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_distance = u32::MAX;
@@ -968,7 +968,7 @@ impl Session {
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_speed = u16::MAX;
@@ -987,7 +987,7 @@ impl Session {
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.max_speed = u16::MAX;
@@ -1006,7 +1006,7 @@ impl Session {
     }
 
     /// Set `total_training_effect` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_training_effect_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_total_training_effect_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_training_effect = u8::MAX;
@@ -1025,7 +1025,7 @@ impl Session {
     }
 
     /// Set `training_stress_score` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_training_stress_score_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_training_stress_score_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.training_stress_score = u16::MAX;
@@ -1044,7 +1044,7 @@ impl Session {
     }
 
     /// Set `intensity_factor` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_intensity_factor_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_intensity_factor_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.intensity_factor = u16::MAX;
@@ -1063,7 +1063,7 @@ impl Session {
     }
 
     /// Set `avg_stroke_count` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_stroke_count_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_stroke_count_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.avg_stroke_count = u32::MAX;
@@ -1082,7 +1082,7 @@ impl Session {
     }
 
     /// Set `avg_stroke_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_stroke_distance_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_stroke_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_stroke_distance = u16::MAX;
@@ -1101,7 +1101,7 @@ impl Session {
     }
 
     /// Set `pool_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_pool_length_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_pool_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.pool_length = u16::MAX;
@@ -1120,7 +1120,7 @@ impl Session {
     }
 
     /// Set `avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_altitude_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_altitude = u16::MAX;
@@ -1139,7 +1139,7 @@ impl Session {
     }
 
     /// Set `max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_altitude_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.max_altitude = u16::MAX;
@@ -1158,7 +1158,7 @@ impl Session {
     }
 
     /// Set `avg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_grade_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_grade = i16::MAX;
@@ -1177,7 +1177,7 @@ impl Session {
     }
 
     /// Set `avg_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_pos_grade_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_pos_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_pos_grade = i16::MAX;
@@ -1196,7 +1196,7 @@ impl Session {
     }
 
     /// Set `avg_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_neg_grade_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_neg_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_neg_grade = i16::MAX;
@@ -1215,7 +1215,7 @@ impl Session {
     }
 
     /// Set `max_pos_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_pos_grade_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_pos_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_pos_grade = i16::MAX;
@@ -1234,7 +1234,7 @@ impl Session {
     }
 
     /// Set `max_neg_grade` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_neg_grade_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_neg_grade_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_neg_grade = i16::MAX;
@@ -1253,7 +1253,7 @@ impl Session {
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_moving_time = u32::MAX;
@@ -1272,7 +1272,7 @@ impl Session {
     }
 
     /// Set `avg_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_pos_vertical_speed = i16::MAX;
@@ -1291,7 +1291,7 @@ impl Session {
     }
 
     /// Set `avg_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.avg_neg_vertical_speed = i16::MAX;
@@ -1310,7 +1310,7 @@ impl Session {
     }
 
     /// Set `max_pos_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_pos_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_pos_vertical_speed = i16::MAX;
@@ -1329,7 +1329,7 @@ impl Session {
     }
 
     /// Set `max_neg_vertical_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_neg_vertical_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
             self.max_neg_vertical_speed = i16::MAX;
@@ -1352,7 +1352,7 @@ impl Session {
     }
 
     /// Set `time_in_hr_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_hr_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1381,7 +1381,7 @@ impl Session {
     }
 
     /// Set `time_in_speed_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_speed_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1410,7 +1410,7 @@ impl Session {
     }
 
     /// Set `time_in_cadence_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_cadence_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1439,7 +1439,7 @@ impl Session {
     }
 
     /// Set `time_in_power_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_power_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1464,7 +1464,7 @@ impl Session {
     }
 
     /// Set `avg_lap_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_lap_time_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_lap_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.avg_lap_time = u32::MAX;
@@ -1483,7 +1483,7 @@ impl Session {
     }
 
     /// Set `min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_altitude_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_min_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.min_altitude = u16::MAX;
@@ -1502,7 +1502,7 @@ impl Session {
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.active_time = u32::MAX;
@@ -1521,7 +1521,7 @@ impl Session {
     }
 
     /// Set `max_ball_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_ball_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_ball_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.max_ball_speed = u16::MAX;
@@ -1540,7 +1540,7 @@ impl Session {
     }
 
     /// Set `avg_ball_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_ball_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_ball_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_ball_speed = u16::MAX;
@@ -1559,7 +1559,7 @@ impl Session {
     }
 
     /// Set `avg_vertical_oscillation` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_vertical_oscillation_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_vertical_oscillation_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_vertical_oscillation = u16::MAX;
@@ -1578,7 +1578,7 @@ impl Session {
     }
 
     /// Set `avg_stance_time_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_stance_time_percent_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_stance_time_percent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_stance_time_percent = u16::MAX;
@@ -1597,7 +1597,7 @@ impl Session {
     }
 
     /// Set `avg_stance_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_stance_time_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_stance_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_stance_time = u16::MAX;
@@ -1616,7 +1616,7 @@ impl Session {
     }
 
     /// Set `avg_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_fractional_cadence_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_fractional_cadence_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_fractional_cadence = u8::MAX;
@@ -1635,7 +1635,7 @@ impl Session {
     }
 
     /// Set `max_fractional_cadence` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_fractional_cadence_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_fractional_cadence_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.max_fractional_cadence = u8::MAX;
@@ -1654,7 +1654,7 @@ impl Session {
     }
 
     /// Set `total_fractional_cycles` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_fractional_cycles_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_total_fractional_cycles_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 128.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_fractional_cycles = u8::MAX;
@@ -1677,7 +1677,7 @@ impl Session {
     }
 
     /// Set `avg_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_avg_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1706,7 +1706,7 @@ impl Session {
     }
 
     /// Set `min_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_min_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.min_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1735,7 +1735,7 @@ impl Session {
     }
 
     /// Set `max_total_hemoglobin_conc` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_max_total_hemoglobin_conc_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.max_total_hemoglobin_conc = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1764,7 +1764,7 @@ impl Session {
     }
 
     /// Set `avg_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_avg_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1793,7 +1793,7 @@ impl Session {
     }
 
     /// Set `min_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_min_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.min_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1822,7 +1822,7 @@ impl Session {
     }
 
     /// Set `max_saturated_hemoglobin_percent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_max_saturated_hemoglobin_percent_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.max_saturated_hemoglobin_percent = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1847,7 +1847,7 @@ impl Session {
     }
 
     /// Set `avg_left_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_left_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_left_torque_effectiveness = u8::MAX;
@@ -1866,7 +1866,7 @@ impl Session {
     }
 
     /// Set `avg_right_torque_effectiveness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_right_torque_effectiveness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_right_torque_effectiveness = u8::MAX;
@@ -1885,7 +1885,7 @@ impl Session {
     }
 
     /// Set `avg_left_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_left_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_left_pedal_smoothness = u8::MAX;
@@ -1904,7 +1904,7 @@ impl Session {
     }
 
     /// Set `avg_right_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_right_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_right_pedal_smoothness = u8::MAX;
@@ -1923,7 +1923,7 @@ impl Session {
     }
 
     /// Set `avg_combined_pedal_smoothness` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_combined_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_combined_pedal_smoothness_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.avg_combined_pedal_smoothness = u8::MAX;
@@ -1942,7 +1942,7 @@ impl Session {
     }
 
     /// Set `time_standing` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_standing_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_time_standing_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.time_standing = u32::MAX;
@@ -1965,7 +1965,7 @@ impl Session {
     }
 
     /// Set `avg_left_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_avg_left_power_phase_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_left_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -1994,7 +1994,7 @@ impl Session {
     }
 
     /// Set `avg_left_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_avg_left_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_left_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -2023,7 +2023,7 @@ impl Session {
     }
 
     /// Set `avg_right_power_phase` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_avg_right_power_phase_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_right_power_phase = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -2052,7 +2052,7 @@ impl Session {
     }
 
     /// Set `avg_right_power_phase_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Session {
+    pub fn set_avg_right_power_phase_peak_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.avg_right_power_phase_peak = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -2077,7 +2077,7 @@ impl Session {
     }
 
     /// Set `enhanced_avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_avg_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_enhanced_avg_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_avg_speed = u32::MAX;
@@ -2096,7 +2096,7 @@ impl Session {
     }
 
     /// Set `enhanced_max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_max_speed_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_enhanced_max_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_max_speed = u32::MAX;
@@ -2115,7 +2115,7 @@ impl Session {
     }
 
     /// Set `enhanced_avg_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_avg_altitude_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_enhanced_avg_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_avg_altitude = u32::MAX;
@@ -2134,7 +2134,7 @@ impl Session {
     }
 
     /// Set `enhanced_min_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_min_altitude_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_enhanced_min_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_min_altitude = u32::MAX;
@@ -2153,7 +2153,7 @@ impl Session {
     }
 
     /// Set `enhanced_max_altitude` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_max_altitude_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_enhanced_max_altitude_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.enhanced_max_altitude = u32::MAX;
@@ -2172,7 +2172,7 @@ impl Session {
     }
 
     /// Set `lev_battery_consumption` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_lev_battery_consumption_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_lev_battery_consumption_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 2.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.lev_battery_consumption = u8::MAX;
@@ -2191,7 +2191,7 @@ impl Session {
     }
 
     /// Set `avg_vertical_ratio` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_vertical_ratio_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_vertical_ratio_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_vertical_ratio = u16::MAX;
@@ -2210,7 +2210,7 @@ impl Session {
     }
 
     /// Set `avg_stance_time_balance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_stance_time_balance_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_stance_time_balance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_stance_time_balance = u16::MAX;
@@ -2229,7 +2229,7 @@ impl Session {
     }
 
     /// Set `avg_step_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_step_length_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_step_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_step_length = u16::MAX;
@@ -2248,7 +2248,7 @@ impl Session {
     }
 
     /// Set `total_anaerobic_training_effect` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_anaerobic_training_effect_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_total_anaerobic_training_effect_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_anaerobic_training_effect = u8::MAX;
@@ -2267,7 +2267,7 @@ impl Session {
     }
 
     /// Set `avg_vam` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_vam_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_vam_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_vam = u16::MAX;
@@ -2286,7 +2286,7 @@ impl Session {
     }
 
     /// Set `avg_depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_depth_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.avg_depth = u32::MAX;
@@ -2305,7 +2305,7 @@ impl Session {
     }
 
     /// Set `max_depth` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_depth_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_depth_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.max_depth = u32::MAX;
@@ -2324,7 +2324,7 @@ impl Session {
     }
 
     /// Set `training_load_peak` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_training_load_peak_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_training_load_peak_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 65536.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i32::MAX as f64 {
             self.training_load_peak = i32::MAX;
@@ -2343,7 +2343,7 @@ impl Session {
     }
 
     /// Set `enhanced_avg_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_avg_respiration_rate_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_enhanced_avg_respiration_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.enhanced_avg_respiration_rate = u16::MAX;
@@ -2362,7 +2362,7 @@ impl Session {
     }
 
     /// Set `enhanced_max_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_max_respiration_rate_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_enhanced_max_respiration_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.enhanced_max_respiration_rate = u16::MAX;
@@ -2381,7 +2381,7 @@ impl Session {
     }
 
     /// Set `enhanced_min_respiration_rate` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_enhanced_min_respiration_rate_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_enhanced_min_respiration_rate_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.enhanced_min_respiration_rate = u16::MAX;
@@ -2400,7 +2400,7 @@ impl Session {
     }
 
     /// Set `total_fractional_ascent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_fractional_ascent_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_total_fractional_ascent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_fractional_ascent = u8::MAX;
@@ -2419,7 +2419,7 @@ impl Session {
     }
 
     /// Set `total_fractional_descent` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_fractional_descent_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_total_fractional_descent_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.total_fractional_descent = u8::MAX;
@@ -2438,7 +2438,7 @@ impl Session {
     }
 
     /// Set `avg_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_core_temperature_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_avg_core_temperature_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.avg_core_temperature = u16::MAX;
@@ -2457,7 +2457,7 @@ impl Session {
     }
 
     /// Set `min_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_min_core_temperature_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_min_core_temperature_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.min_core_temperature = u16::MAX;
@@ -2476,7 +2476,7 @@ impl Session {
     }
 
     /// Set `max_core_temperature` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_core_temperature_scaled(&mut self, v: f64) -> &mut Session {
+    pub fn set_max_core_temperature_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.max_core_temperature = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/set.rs
+++ b/rustyfit/src/profile/mesgdef/set.rs
@@ -88,7 +88,7 @@ impl Set {
     }
 
     /// Set `duration` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_duration_scaled(&mut self, v: f64) -> &mut Set {
+    pub fn set_duration_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.duration = u32::MAX;
@@ -107,7 +107,7 @@ impl Set {
     }
 
     /// Set `weight` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_weight_scaled(&mut self, v: f64) -> &mut Set {
+    pub fn set_weight_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 16.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.weight = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/sleep_assessment.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_assessment.rs
@@ -108,7 +108,7 @@ impl SleepAssessment {
     }
 
     /// Set `average_stress_during_sleep` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_average_stress_during_sleep_scaled(&mut self, v: f64) -> &mut SleepAssessment {
+    pub fn set_average_stress_during_sleep_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.average_stress_during_sleep = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/software.rs
+++ b/rustyfit/src/profile/mesgdef/software.rs
@@ -53,7 +53,7 @@ impl Software {
     }
 
     /// Set `version` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_version_scaled(&mut self, v: f64) -> &mut Software {
+    pub fn set_version_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.version = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/speed_zone.rs
+++ b/rustyfit/src/profile/mesgdef/speed_zone.rs
@@ -53,7 +53,7 @@ impl SpeedZone {
     }
 
     /// Set `high_value` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_high_value_scaled(&mut self, v: f64) -> &mut SpeedZone {
+    pub fn set_high_value_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.high_value = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/split.rs
+++ b/rustyfit/src/profile/mesgdef/split.rs
@@ -179,7 +179,7 @@ impl Split {
     }
 
     /// Set `total_elapsed_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut Split {
+    pub fn set_total_elapsed_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_elapsed_time = u32::MAX;
@@ -198,7 +198,7 @@ impl Split {
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Split {
+    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_timer_time = u32::MAX;
@@ -217,7 +217,7 @@ impl Split {
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut Split {
+    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_distance = u32::MAX;
@@ -236,7 +236,7 @@ impl Split {
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Split {
+    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.avg_speed = u32::MAX;
@@ -255,7 +255,7 @@ impl Split {
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut Split {
+    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.max_speed = u32::MAX;
@@ -274,7 +274,7 @@ impl Split {
     }
 
     /// Set `avg_vert_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_vert_speed_scaled(&mut self, v: f64) -> &mut Split {
+    pub fn set_avg_vert_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i32::MAX as f64 {
             self.avg_vert_speed = i32::MAX;
@@ -293,7 +293,7 @@ impl Split {
     }
 
     /// Set `start_elevation` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_start_elevation_scaled(&mut self, v: f64) -> &mut Split {
+    pub fn set_start_elevation_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 500.0) * 5.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.start_elevation = u32::MAX;
@@ -312,7 +312,7 @@ impl Split {
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Split {
+    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.active_time = u32::MAX;
@@ -331,7 +331,7 @@ impl Split {
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut Split {
+    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_moving_time = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/split.rs
+++ b/rustyfit/src/profile/mesgdef/split.rs
@@ -131,9 +131,21 @@ impl Split {
         semconv::to_degrees(self.start_position_lat)
     }
 
+    /// Set `start_position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_start_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.start_position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `start_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn start_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.start_position_long)
+    }
+
+    /// Set `start_position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_start_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.start_position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `end_position_lat` in degrees instead of semicircles. It returns `None` when value is valid.
@@ -141,9 +153,21 @@ impl Split {
         semconv::to_degrees(self.end_position_lat)
     }
 
+    /// Set `end_position_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_end_position_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.end_position_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `end_position_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn end_position_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.end_position_long)
+    }
+
+    /// Set `end_position_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_end_position_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.end_position_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `total_elapsed_time` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/split_summary.rs
+++ b/rustyfit/src/profile/mesgdef/split_summary.rs
@@ -110,7 +110,7 @@ impl SplitSummary {
     }
 
     /// Set `total_timer_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut SplitSummary {
+    pub fn set_total_timer_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_timer_time = u32::MAX;
@@ -129,7 +129,7 @@ impl SplitSummary {
     }
 
     /// Set `total_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut SplitSummary {
+    pub fn set_total_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_distance = u32::MAX;
@@ -148,7 +148,7 @@ impl SplitSummary {
     }
 
     /// Set `avg_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut SplitSummary {
+    pub fn set_avg_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.avg_speed = u32::MAX;
@@ -167,7 +167,7 @@ impl SplitSummary {
     }
 
     /// Set `max_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut SplitSummary {
+    pub fn set_max_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.max_speed = u32::MAX;
@@ -186,7 +186,7 @@ impl SplitSummary {
     }
 
     /// Set `avg_vert_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_avg_vert_speed_scaled(&mut self, v: f64) -> &mut SplitSummary {
+    pub fn set_avg_vert_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i32::MAX as f64 {
             self.avg_vert_speed = i32::MAX;
@@ -205,7 +205,7 @@ impl SplitSummary {
     }
 
     /// Set `active_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut SplitSummary {
+    pub fn set_active_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.active_time = u32::MAX;
@@ -224,7 +224,7 @@ impl SplitSummary {
     }
 
     /// Set `total_moving_time` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut SplitSummary {
+    pub fn set_total_moving_time_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.total_moving_time = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/tank_summary.rs
+++ b/rustyfit/src/profile/mesgdef/tank_summary.rs
@@ -63,7 +63,7 @@ impl TankSummary {
     }
 
     /// Set `start_pressure` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_start_pressure_scaled(&mut self, v: f64) -> &mut TankSummary {
+    pub fn set_start_pressure_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.start_pressure = u16::MAX;
@@ -82,7 +82,7 @@ impl TankSummary {
     }
 
     /// Set `end_pressure` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_end_pressure_scaled(&mut self, v: f64) -> &mut TankSummary {
+    pub fn set_end_pressure_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.end_pressure = u16::MAX;
@@ -101,7 +101,7 @@ impl TankSummary {
     }
 
     /// Set `volume_used` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_volume_used_scaled(&mut self, v: f64) -> &mut TankSummary {
+    pub fn set_volume_used_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.volume_used = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/tank_update.rs
+++ b/rustyfit/src/profile/mesgdef/tank_update.rs
@@ -53,7 +53,7 @@ impl TankUpdate {
     }
 
     /// Set `pressure` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_pressure_scaled(&mut self, v: f64) -> &mut TankUpdate {
+    pub fn set_pressure_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.pressure = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
@@ -80,7 +80,7 @@ impl ThreeDSensorCalibration {
     }
 
     /// Set `orientation_matrix` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_orientation_matrix_scaled(&mut self, v: [f64; 9]) -> &mut ThreeDSensorCalibration {
+    pub fn set_orientation_matrix_scaled(&mut self, v: [f64; 9]) -> &mut Self {
         self.orientation_matrix = [i32::MAX; 9];
         for (i, &x) in v.iter().enumerate() {
             let unscaled = (x + 0.0) * 65535.0;

--- a/rustyfit/src/profile/mesgdef/time_in_zone.rs
+++ b/rustyfit/src/profile/mesgdef/time_in_zone.rs
@@ -119,7 +119,7 @@ impl TimeInZone {
     }
 
     /// Set `time_in_hr_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+    pub fn set_time_in_hr_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_hr_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -148,7 +148,7 @@ impl TimeInZone {
     }
 
     /// Set `time_in_speed_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+    pub fn set_time_in_speed_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_speed_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -177,7 +177,7 @@ impl TimeInZone {
     }
 
     /// Set `time_in_cadence_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+    pub fn set_time_in_cadence_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_cadence_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -206,7 +206,7 @@ impl TimeInZone {
     }
 
     /// Set `time_in_power_zone` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+    pub fn set_time_in_power_zone_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.time_in_power_zone = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;
@@ -235,7 +235,7 @@ impl TimeInZone {
     }
 
     /// Set `speed_zone_high_boundary` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_speed_zone_high_boundary_scaled(&mut self, v: &[f64]) -> &mut TimeInZone {
+    pub fn set_speed_zone_high_boundary_scaled(&mut self, v: &[f64]) -> &mut Self {
         self.speed_zone_high_boundary = Vec::with_capacity(v.len());
         if v.is_empty() {
             return self;

--- a/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
+++ b/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
@@ -73,7 +73,7 @@ impl TimestampCorrelation {
     }
 
     /// Set `fractional_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_fractional_timestamp_scaled(&mut self, v: f64) -> &mut TimestampCorrelation {
+    pub fn set_fractional_timestamp_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 32768.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.fractional_timestamp = u16::MAX;
@@ -92,7 +92,7 @@ impl TimestampCorrelation {
     }
 
     /// Set `fractional_system_timestamp` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_fractional_system_timestamp_scaled(&mut self, v: f64) -> &mut TimestampCorrelation {
+    pub fn set_fractional_system_timestamp_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 32768.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.fractional_system_timestamp = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/training_settings.rs
+++ b/rustyfit/src/profile/mesgdef/training_settings.rs
@@ -58,7 +58,7 @@ impl TrainingSettings {
     }
 
     /// Set `target_distance` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_target_distance_scaled(&mut self, v: f64) -> &mut TrainingSettings {
+    pub fn set_target_distance_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.target_distance = u32::MAX;
@@ -77,7 +77,7 @@ impl TrainingSettings {
     }
 
     /// Set `target_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_target_speed_scaled(&mut self, v: f64) -> &mut TrainingSettings {
+    pub fn set_target_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.target_speed = u16::MAX;
@@ -96,7 +96,7 @@ impl TrainingSettings {
     }
 
     /// Set `precise_target_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_precise_target_speed_scaled(&mut self, v: f64) -> &mut TrainingSettings {
+    pub fn set_precise_target_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u32::MAX as f64 {
             self.precise_target_speed = u32::MAX;

--- a/rustyfit/src/profile/mesgdef/user_profile.rs
+++ b/rustyfit/src/profile/mesgdef/user_profile.rs
@@ -169,7 +169,7 @@ impl UserProfile {
     }
 
     /// Set `height` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_height_scaled(&mut self, v: f64) -> &mut UserProfile {
+    pub fn set_height_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u8::MAX as f64 {
             self.height = u8::MAX;
@@ -188,7 +188,7 @@ impl UserProfile {
     }
 
     /// Set `weight` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_weight_scaled(&mut self, v: f64) -> &mut UserProfile {
+    pub fn set_weight_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.weight = u16::MAX;
@@ -207,7 +207,7 @@ impl UserProfile {
     }
 
     /// Set `user_running_step_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_user_running_step_length_scaled(&mut self, v: f64) -> &mut UserProfile {
+    pub fn set_user_running_step_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.user_running_step_length = u16::MAX;
@@ -226,7 +226,7 @@ impl UserProfile {
     }
 
     /// Set `user_walking_step_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_user_walking_step_length_scaled(&mut self, v: f64) -> &mut UserProfile {
+    pub fn set_user_walking_step_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.user_walking_step_length = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -114,9 +114,21 @@ impl WeatherConditions {
         semconv::to_degrees(self.observed_location_lat)
     }
 
+    /// Set `observed_location_lat` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_observed_location_lat_degrees(&mut self, v: f64) -> &mut Self {
+        self.observed_location_lat = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
+    }
+
     /// Returns `observed_location_long` in degrees instead of semicircles. It returns `None` when value is valid.
     pub fn observed_location_long_degrees(&self) -> Option<f64> {
         semconv::to_degrees(self.observed_location_long)
+    }
+
+    /// Set `observed_location_long` with a value in degrees instead of semicircles, the value will be converted to semicircles.
+    pub fn set_observed_location_long_degrees(&mut self, v: f64) -> &mut Self {
+        self.observed_location_long = semconv::to_semicircles(v).unwrap_or(i32::MAX);
+        self
     }
 
     /// Returns `wind_speed` in its scaled value. It returns `None` when value is valid.

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -140,7 +140,7 @@ impl WeatherConditions {
     }
 
     /// Set `wind_speed` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_wind_speed_scaled(&mut self, v: f64) -> &mut WeatherConditions {
+    pub fn set_wind_speed_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 1000.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.wind_speed = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/weight_scale.rs
+++ b/rustyfit/src/profile/mesgdef/weight_scale.rs
@@ -106,7 +106,7 @@ impl WeightScale {
     }
 
     /// Set `weight` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_weight_scaled(&mut self, v: f64) -> &mut WeightScale {
+    pub fn set_weight_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.weight = typedef::Weight(u16::MAX);
@@ -125,7 +125,7 @@ impl WeightScale {
     }
 
     /// Set `percent_fat` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_percent_fat_scaled(&mut self, v: f64) -> &mut WeightScale {
+    pub fn set_percent_fat_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.percent_fat = u16::MAX;
@@ -144,7 +144,7 @@ impl WeightScale {
     }
 
     /// Set `percent_hydration` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_percent_hydration_scaled(&mut self, v: f64) -> &mut WeightScale {
+    pub fn set_percent_hydration_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.percent_hydration = u16::MAX;
@@ -163,7 +163,7 @@ impl WeightScale {
     }
 
     /// Set `visceral_fat_mass` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_visceral_fat_mass_scaled(&mut self, v: f64) -> &mut WeightScale {
+    pub fn set_visceral_fat_mass_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.visceral_fat_mass = u16::MAX;
@@ -182,7 +182,7 @@ impl WeightScale {
     }
 
     /// Set `bone_mass` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_bone_mass_scaled(&mut self, v: f64) -> &mut WeightScale {
+    pub fn set_bone_mass_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.bone_mass = u16::MAX;
@@ -201,7 +201,7 @@ impl WeightScale {
     }
 
     /// Set `muscle_mass` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_muscle_mass_scaled(&mut self, v: f64) -> &mut WeightScale {
+    pub fn set_muscle_mass_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.muscle_mass = u16::MAX;
@@ -220,7 +220,7 @@ impl WeightScale {
     }
 
     /// Set `basal_met` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_basal_met_scaled(&mut self, v: f64) -> &mut WeightScale {
+    pub fn set_basal_met_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 4.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.basal_met = u16::MAX;
@@ -239,7 +239,7 @@ impl WeightScale {
     }
 
     /// Set `active_met` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_active_met_scaled(&mut self, v: f64) -> &mut WeightScale {
+    pub fn set_active_met_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 4.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.active_met = u16::MAX;
@@ -258,7 +258,7 @@ impl WeightScale {
     }
 
     /// Set `bmi` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_bmi_scaled(&mut self, v: f64) -> &mut WeightScale {
+    pub fn set_bmi_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 10.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.bmi = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/workout.rs
+++ b/rustyfit/src/profile/mesgdef/workout.rs
@@ -80,7 +80,7 @@ impl Workout {
     }
 
     /// Set `pool_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_pool_length_scaled(&mut self, v: f64) -> &mut Workout {
+    pub fn set_pool_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.pool_length = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/workout_session.rs
+++ b/rustyfit/src/profile/mesgdef/workout_session.rs
@@ -67,7 +67,7 @@ impl WorkoutSession {
     }
 
     /// Set `pool_length` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_pool_length_scaled(&mut self, v: f64) -> &mut WorkoutSession {
+    pub fn set_pool_length_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.pool_length = u16::MAX;

--- a/rustyfit/src/profile/mesgdef/workout_step.rs
+++ b/rustyfit/src/profile/mesgdef/workout_step.rs
@@ -117,7 +117,7 @@ impl WorkoutStep {
     }
 
     /// Set `exercise_weight` with scaled value, it will automatically be converted to its corresponding integer value.
-    pub fn set_exercise_weight_scaled(&mut self, v: f64) -> &mut WorkoutStep {
+    pub fn set_exercise_weight_scaled(&mut self, v: f64) -> &mut Self {
         let unscaled = (v + 0.0) * 100.0;
         if unscaled.is_nan() || unscaled.is_infinite() || unscaled > u16::MAX as f64 {
             self.exercise_weight = u16::MAX;


### PR DESCRIPTION
We have both `*_scaled` and `set_*_scaled` but we only have `*_degrees`, this PR add `set_*_degrees`. Also include minor chore to return `&mut Self` instead of `&mut Record`, `&mut Session`, etc.