### PR TITLE
refactor: typedef unix timestamp now use i64

### DIFF
--- a/fitgen/internal/profile/typedef/typedef.tmpl
+++ b/fitgen/internal/profile/typedef/typedef.tmpl
@@ -43,13 +43,13 @@ impl {{ .TypeName }} {
     
     {{- if or (eq .TypeName "DateTime") (eq .TypeName "LocalDateTime") }}
     /// Offset duration in secs between UNIX_EPOCH (1 January 1970 UTC) and FIT_EPOCH (31 December 1989 UTC).
-    const FIT_EPOCH_OFFSET: u64 = 631065600;
+    const FIT_EPOCH_OFFSET: i64 = 631065600;
     
     /// Creates a new DateTime (relative to 31 December 1989 UTC) from Unix seconds (relative to 1 January 1970 UTC)
     /// if the value is within a valid range. None otherwise.
-    pub fn new(unix_secs: u64) -> Option<{{ .TypeName }}> {
+    pub fn new(unix_secs: i64) -> Option<{{ .TypeName }}> {
     	let t = unix_secs.checked_sub(Self::FIT_EPOCH_OFFSET)?;
-    	if t < u32::MAX as u64 {
+    	if t >= 0 && t < u32::MAX as i64 {
             Some({{ .TypeName }}(t as u32))
         } else {
             None
@@ -57,11 +57,11 @@ impl {{ .TypeName }} {
     }
     
     /// Returns Some(t) where t is Unix seconds (relative to 1 January 1970 UTC) if `self` is a valid {{ .TypeName }}. None otherwise.
-    pub fn checked_unix_secs(&self) -> Option<u64> {
+    pub fn checked_unix_secs(&self) -> Option<i64> {
     	if self.0 == u32::MAX {
      		None
         } else {
-            Some(self.0 as u64 + Self::FIT_EPOCH_OFFSET)
+            Some(self.0 as i64 + Self::FIT_EPOCH_OFFSET)
         }
     }
     {{ end -}}

--- a/rustyfit/src/profile/typedef/date_time.rs
+++ b/rustyfit/src/profile/typedef/date_time.rs
@@ -17,13 +17,13 @@ impl DateTime {
     pub const MIN: DateTime = DateTime(0x10000000);
 
     /// Offset duration in secs between UNIX_EPOCH (1 January 1970 UTC) and FIT_EPOCH (31 December 1989 UTC).
-    const FIT_EPOCH_OFFSET: u64 = 631065600;
+    const FIT_EPOCH_OFFSET: i64 = 631065600;
 
     /// Creates a new DateTime (relative to 31 December 1989 UTC) from Unix seconds (relative to 1 January 1970 UTC)
     /// if the value is within a valid range. None otherwise.
-    pub fn new(unix_secs: u64) -> Option<DateTime> {
+    pub fn new(unix_secs: i64) -> Option<DateTime> {
         let t = unix_secs.checked_sub(Self::FIT_EPOCH_OFFSET)?;
-        if t < u32::MAX as u64 {
+        if t >= 0 && t < u32::MAX as i64 {
             Some(DateTime(t as u32))
         } else {
             None
@@ -31,11 +31,11 @@ impl DateTime {
     }
 
     /// Returns Some(t) where t is Unix seconds (relative to 1 January 1970 UTC) if `self` is a valid DateTime. None otherwise.
-    pub fn checked_unix_secs(&self) -> Option<u64> {
+    pub fn checked_unix_secs(&self) -> Option<i64> {
         if self.0 == u32::MAX {
             None
         } else {
-            Some(self.0 as u64 + Self::FIT_EPOCH_OFFSET)
+            Some(self.0 as i64 + Self::FIT_EPOCH_OFFSET)
         }
     }
 }

--- a/rustyfit/src/profile/typedef/local_date_time.rs
+++ b/rustyfit/src/profile/typedef/local_date_time.rs
@@ -17,13 +17,13 @@ impl LocalDateTime {
     pub const MIN: LocalDateTime = LocalDateTime(0x10000000);
 
     /// Offset duration in secs between UNIX_EPOCH (1 January 1970 UTC) and FIT_EPOCH (31 December 1989 UTC).
-    const FIT_EPOCH_OFFSET: u64 = 631065600;
+    const FIT_EPOCH_OFFSET: i64 = 631065600;
 
     /// Creates a new DateTime (relative to 31 December 1989 UTC) from Unix seconds (relative to 1 January 1970 UTC)
     /// if the value is within a valid range. None otherwise.
-    pub fn new(unix_secs: u64) -> Option<LocalDateTime> {
+    pub fn new(unix_secs: i64) -> Option<LocalDateTime> {
         let t = unix_secs.checked_sub(Self::FIT_EPOCH_OFFSET)?;
-        if t < u32::MAX as u64 {
+        if t >= 0 && t < u32::MAX as i64 {
             Some(LocalDateTime(t as u32))
         } else {
             None
@@ -31,11 +31,11 @@ impl LocalDateTime {
     }
 
     /// Returns Some(t) where t is Unix seconds (relative to 1 January 1970 UTC) if `self` is a valid LocalDateTime. None otherwise.
-    pub fn checked_unix_secs(&self) -> Option<u64> {
+    pub fn checked_unix_secs(&self) -> Option<i64> {
         if self.0 == u32::MAX {
             None
         } else {
-            Some(self.0 as u64 + Self::FIT_EPOCH_OFFSET)
+            Some(self.0 as i64 + Self::FIT_EPOCH_OFFSET)
         }
     }
 }


### PR DESCRIPTION
The standard type for Unix timestamp is `i64`. Chrono also uses `i64` (https://docs.rs/chrono/latest/src/chrono/datetime/mod.rs.html#768) so using `u64` was a mistake.