### PR TITLE
refactor: typedef DateTime change new to from_unix_timestamp

### DIFF
--- a/fitgen/internal/profile/typedef/typedef.tmpl
+++ b/fitgen/internal/profile/typedef/typedef.tmpl
@@ -46,13 +46,15 @@ impl {{ .TypeName }} {
     const FIT_EPOCH_OFFSET: i64 = 631065600;
     
     /// Creates a new DateTime (relative to 31 December 1989 UTC) from Unix seconds (relative to 1 January 1970 UTC)
-    /// if the value is within a valid range. None otherwise.
-    pub fn new(unix_secs: i64) -> Option<{{ .TypeName }}> {
-    	let t = unix_secs.checked_sub(Self::FIT_EPOCH_OFFSET)?;
-    	if t >= 0 && t < u32::MAX as i64 {
-            Some({{ .TypeName }}(t as u32))
+    /// if the value is within a valid range. `{{ .TypeName }}(u32::MAX)` otherwise.
+    pub fn from_unix_timestamp(secs: i64) -> {{ .TypeName }} {
+    	if let Some(t) = secs.checked_sub(Self::FIT_EPOCH_OFFSET) 
+            && t >= 0 
+            && t < u32::MAX as i64 
+        {
+            {{ .TypeName }}(t as u32)
         } else {
-            None
+            {{ .TypeName }}(u32::MAX)
         }
     }
     

--- a/rustyfit/src/profile/typedef/date_time.rs
+++ b/rustyfit/src/profile/typedef/date_time.rs
@@ -20,13 +20,15 @@ impl DateTime {
     const FIT_EPOCH_OFFSET: i64 = 631065600;
 
     /// Creates a new DateTime (relative to 31 December 1989 UTC) from Unix seconds (relative to 1 January 1970 UTC)
-    /// if the value is within a valid range. None otherwise.
-    pub fn new(unix_secs: i64) -> Option<DateTime> {
-        let t = unix_secs.checked_sub(Self::FIT_EPOCH_OFFSET)?;
-        if t >= 0 && t < u32::MAX as i64 {
-            Some(DateTime(t as u32))
+    /// if the value is within a valid range. `DateTime(u32::MAX)` otherwise.
+    pub fn from_unix_timestamp(secs: i64) -> DateTime {
+        if let Some(t) = secs.checked_sub(Self::FIT_EPOCH_OFFSET)
+            && t >= 0
+            && t < u32::MAX as i64
+        {
+            DateTime(t as u32)
         } else {
-            None
+            DateTime(u32::MAX)
         }
     }
 

--- a/rustyfit/src/profile/typedef/local_date_time.rs
+++ b/rustyfit/src/profile/typedef/local_date_time.rs
@@ -20,13 +20,15 @@ impl LocalDateTime {
     const FIT_EPOCH_OFFSET: i64 = 631065600;
 
     /// Creates a new DateTime (relative to 31 December 1989 UTC) from Unix seconds (relative to 1 January 1970 UTC)
-    /// if the value is within a valid range. None otherwise.
-    pub fn new(unix_secs: i64) -> Option<LocalDateTime> {
-        let t = unix_secs.checked_sub(Self::FIT_EPOCH_OFFSET)?;
-        if t >= 0 && t < u32::MAX as i64 {
-            Some(LocalDateTime(t as u32))
+    /// if the value is within a valid range. `LocalDateTime(u32::MAX)` otherwise.
+    pub fn from_unix_timestamp(secs: i64) -> LocalDateTime {
+        if let Some(t) = secs.checked_sub(Self::FIT_EPOCH_OFFSET)
+            && t >= 0
+            && t < u32::MAX as i64
+        {
+            LocalDateTime(t as u32)
         } else {
-            None
+            LocalDateTime(u32::MAX)
         }
     }
 


### PR DESCRIPTION
Rename `new` to `from_unix_timestamp` for more explicit name for what it does.

`DateTime` and `LocalDateTime` are FIT Protocol types, I believe it makes more sense to return `T` instead of `Option<T>` because it's normally used for converting a value  into a FIT Protocol's value.