### PR TITLE
fix: mesgdef on handling floating-point value

### DIFF
--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -146,6 +146,11 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			field.IfSelfEqualInvalid = fmt.Sprintf("self.%s == %s", field.Name, field.InvalidValue)
 			field.IfSelfNotEqualInvalid = fmt.Sprintf("self.%s != %s", field.Name, field.InvalidValue)
 			field.IfNotEqualInvalid = fmt.Sprintf("m.%s != %s", field.Name, field.InvalidValue)
+			if field.BaseType0 == "f32" || field.BaseType0 == "f64" {
+				field.IfSelfEqualInvalid = fmt.Sprintf("self.%s.to_bits() == u%s::MAX", field.Name, field.BaseType0[1:])
+				field.IfSelfNotEqualInvalid = fmt.Sprintf("self.%s.to_bits() != u%s::MAX", field.Name, field.BaseType0[1:])
+				field.IfNotEqualInvalid = fmt.Sprintf("m.%s.to_bits() != u%s::MAX", field.Name, field.BaseType0[1:])
+			}
 			if parserField.Array == "[N]" || (field.BaseType == "STRING" && parserField.Array == "") {
 				field.IfSelfEqualInvalid = fmt.Sprintf("self.%s.is_empty()", field.Name)
 				field.IfSelfNotEqualInvalid = fmt.Sprintf("!self.%s.is_empty()", field.Name)
@@ -158,10 +163,6 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			} else {
 				field.Scale = scaleOrDefault(parserField.Scales, 0)
 				field.Offset = offsetOrDefault(parserField.Offsets, 0)
-			}
-
-			if field.FixedArraySize > 0 && (field.Scale != 1 || field.Offset != 0) {
-				field.InvalidArrayValueScaled = b.invalidArrayValueScaled(field.FixedArraySize)
 			}
 
 			field.Comment = createComment(&field, parserField.Array)
@@ -467,9 +468,14 @@ func (b *Builder) invalidValueOf(fieldType, array string, fixedArraySize byte) s
 	rustType := baseTypeToRustTypeReplacer.Replace(baseType)
 
 	var invalid string
-	if baseType == "string" {
+	switch baseType {
+	case "string":
 		invalid = "String::new()"
-	} else {
+	case "float32":
+		invalid = "f32::from_bits(u32::MAX)"
+	case "float64":
+		invalid = "f64::from_bits(u64::MAX)"
+	default:
 		if strings.HasSuffix(baseType, "z") {
 			invalid = fmt.Sprintf("%s::MIN", rustType)
 		} else {
@@ -492,18 +498,6 @@ func (b *Builder) invalidValueOf(fieldType, array string, fixedArraySize byte) s
 	}
 
 	return fmt.Sprintf("typedef::%s(%s)", strutil.ToTitle(fieldType), invalid)
-}
-
-func (b *Builder) invalidArrayValueScaled(fixedArraySize byte) string {
-	return fmt.Sprintf(`[%d]float64{
-		%s
-	}`,
-		fixedArraySize,
-		strings.Repeat(
-			"math.Float64frombits(basetype.Float64Invalid),\n",
-			int(fixedArraySize),
-		),
-	)
 }
 
 // Profile.xlsx says unless otherwise specified, scale of 1 is assumed.

--- a/rustyfit/src/profile/mesgdef/climb_pro.rs
+++ b/rustyfit/src/profile/mesgdef/climb_pro.rs
@@ -56,7 +56,7 @@ impl ClimbPro {
             climb_pro_event: typedef::ClimbProEvent(u8::MAX),
             climb_number: u16::MAX,
             climb_category: u8::MAX,
-            current_dist: f32::MAX,
+            current_dist: f32::from_bits(u32::MAX),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -91,7 +91,7 @@ impl ClimbPro {
             + (self.climb_pro_event != typedef::ClimbProEvent(u8::MAX)) as usize
             + (self.climb_number != u16::MAX) as usize
             + (self.climb_category != u8::MAX) as usize
-            + (self.current_dist != f32::MAX) as usize
+            + (self.current_dist.to_bits() != u32::MAX) as usize
     }
 }
 
@@ -184,7 +184,7 @@ impl From<ClimbPro> for Message {
                 is_expanded: false,
             });
         };
-        if m.current_dist != f32::MAX {
+        if m.current_dist.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,

--- a/rustyfit/src/profile/mesgdef/dive_settings.rs
+++ b/rustyfit/src/profile/mesgdef/dive_settings.rs
@@ -158,12 +158,12 @@ impl DiveSettings {
             gf_low: u8::MAX,
             gf_high: u8::MAX,
             water_type: typedef::WaterType(u8::MAX),
-            water_density: f32::MAX,
+            water_density: f32::from_bits(u32::MAX),
             po2_warn: u8::MAX,
             po2_critical: u8::MAX,
             po2_deco: u8::MAX,
             safety_stop_enabled: typedef::Bool(u8::MAX),
-            bottom_depth: f32::MAX,
+            bottom_depth: f32::from_bits(u32::MAX),
             bottom_time: u32::MAX,
             apnea_countdown_enabled: typedef::Bool(u8::MAX),
             apnea_countdown_time: u32::MAX,
@@ -351,12 +351,12 @@ impl DiveSettings {
             + (self.gf_low != u8::MAX) as usize
             + (self.gf_high != u8::MAX) as usize
             + (self.water_type != typedef::WaterType(u8::MAX)) as usize
-            + (self.water_density != f32::MAX) as usize
+            + (self.water_density.to_bits() != u32::MAX) as usize
             + (self.po2_warn != u8::MAX) as usize
             + (self.po2_critical != u8::MAX) as usize
             + (self.po2_deco != u8::MAX) as usize
             + (self.safety_stop_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.bottom_depth != f32::MAX) as usize
+            + (self.bottom_depth.to_bits() != u32::MAX) as usize
             + (self.bottom_time != u32::MAX) as usize
             + (self.apnea_countdown_enabled != typedef::Bool(u8::MAX)) as usize
             + (self.apnea_countdown_time != u32::MAX) as usize
@@ -517,7 +517,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.water_density != f32::MAX {
+        if m.water_density.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::FLOAT32,
@@ -557,7 +557,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.bottom_depth != f32::MAX {
+        if m.bottom_depth.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::FLOAT32,

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -73,11 +73,11 @@ impl Jump {
     pub const fn new() -> Self {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
-            distance: f32::MAX,
-            height: f32::MAX,
+            distance: f32::from_bits(u32::MAX),
+            height: f32::from_bits(u32::MAX),
             rotations: u8::MAX,
-            hang_time: f32::MAX,
-            score: f32::MAX,
+            hang_time: f32::from_bits(u32::MAX),
+            score: f32::from_bits(u32::MAX),
             position_lat: i32::MAX,
             position_long: i32::MAX,
             speed: u16::MAX,
@@ -170,11 +170,11 @@ impl Jump {
 
     fn count_valid_fields(&self) -> usize {
         (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.distance != f32::MAX) as usize
-            + (self.height != f32::MAX) as usize
+            + (self.distance.to_bits() != u32::MAX) as usize
+            + (self.height.to_bits() != u32::MAX) as usize
             + (self.rotations != u8::MAX) as usize
-            + (self.hang_time != f32::MAX) as usize
-            + (self.score != f32::MAX) as usize
+            + (self.hang_time.to_bits() != u32::MAX) as usize
+            + (self.score.to_bits() != u32::MAX) as usize
             + (self.position_lat != i32::MAX) as usize
             + (self.position_long != i32::MAX) as usize
             + (self.speed != u16::MAX) as usize
@@ -240,7 +240,7 @@ impl From<Jump> for Message {
                 is_expanded: false,
             });
         };
-        if m.distance != f32::MAX {
+        if m.distance.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FLOAT32,
@@ -248,7 +248,7 @@ impl From<Jump> for Message {
                 is_expanded: false,
             });
         };
-        if m.height != f32::MAX {
+        if m.height.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::FLOAT32,
@@ -264,7 +264,7 @@ impl From<Jump> for Message {
                 is_expanded: false,
             });
         };
-        if m.hang_time != f32::MAX {
+        if m.hang_time.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::FLOAT32,
@@ -272,7 +272,7 @@ impl From<Jump> for Message {
                 is_expanded: false,
             });
         };
-        if m.score != f32::MAX {
+        if m.score.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::FLOAT32,

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -624,11 +624,11 @@ impl Lap {
             enhanced_max_respiration_rate: u16::MAX,
             avg_respiration_rate: u8::MAX,
             max_respiration_rate: u8::MAX,
-            total_grit: f32::MAX,
-            total_flow: f32::MAX,
+            total_grit: f32::from_bits(u32::MAX),
+            total_flow: f32::from_bits(u32::MAX),
             jump_count: u16::MAX,
-            avg_grit: f32::MAX,
-            avg_flow: f32::MAX,
+            avg_grit: f32::from_bits(u32::MAX),
+            avg_flow: f32::from_bits(u32::MAX),
             total_fractional_ascent: u8::MAX,
             total_fractional_descent: u8::MAX,
             avg_core_temperature: u16::MAX,
@@ -2194,11 +2194,11 @@ impl Lap {
             + (self.enhanced_max_respiration_rate != u16::MAX) as usize
             + (self.avg_respiration_rate != u8::MAX) as usize
             + (self.max_respiration_rate != u8::MAX) as usize
-            + (self.total_grit != f32::MAX) as usize
-            + (self.total_flow != f32::MAX) as usize
+            + (self.total_grit.to_bits() != u32::MAX) as usize
+            + (self.total_flow.to_bits() != u32::MAX) as usize
             + (self.jump_count != u16::MAX) as usize
-            + (self.avg_grit != f32::MAX) as usize
-            + (self.avg_flow != f32::MAX) as usize
+            + (self.avg_grit.to_bits() != u32::MAX) as usize
+            + (self.avg_flow.to_bits() != u32::MAX) as usize
             + (self.total_fractional_ascent != u8::MAX) as usize
             + (self.total_fractional_descent != u8::MAX) as usize
             + (self.avg_core_temperature != u16::MAX) as usize
@@ -3288,7 +3288,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.total_grit != f32::MAX {
+        if m.total_grit.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 149,
                 profile_type: ProfileType::FLOAT32,
@@ -3296,7 +3296,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.total_flow != f32::MAX {
+        if m.total_flow.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 150,
                 profile_type: ProfileType::FLOAT32,
@@ -3312,7 +3312,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.avg_grit != f32::MAX {
+        if m.avg_grit.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 153,
                 profile_type: ProfileType::FLOAT32,
@@ -3320,7 +3320,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.avg_flow != f32::MAX {
+        if m.avg_flow.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 154,
                 profile_type: ProfileType::FLOAT32,

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -434,8 +434,8 @@ impl Record {
             n2_load: u16::MAX,
             respiration_rate: u8::MAX,
             enhanced_respiration_rate: u16::MAX,
-            grit: f32::MAX,
-            flow: f32::MAX,
+            grit: f32::from_bits(u32::MAX),
+            flow: f32::from_bits(u32::MAX),
             current_stress: u16::MAX,
             ebike_travel_range: u16::MAX,
             ebike_battery_level: u8::MAX,
@@ -1510,8 +1510,8 @@ impl Record {
             + (self.n2_load != u16::MAX) as usize
             + (self.respiration_rate != u8::MAX) as usize
             + (self.enhanced_respiration_rate != u16::MAX) as usize
-            + (self.grit != f32::MAX) as usize
-            + (self.flow != f32::MAX) as usize
+            + (self.grit.to_bits() != u32::MAX) as usize
+            + (self.flow.to_bits() != u32::MAX) as usize
             + (self.current_stress != u16::MAX) as usize
             + (self.ebike_travel_range != u16::MAX) as usize
             + (self.ebike_battery_level != u8::MAX) as usize
@@ -2227,7 +2227,7 @@ impl From<Record> for Message {
                 is_expanded: is_expanded(&m.state, 108),
             });
         };
-        if m.grit != f32::MAX {
+        if m.grit.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 114,
                 profile_type: ProfileType::FLOAT32,
@@ -2235,7 +2235,7 @@ impl From<Record> for Message {
                 is_expanded: false,
             });
         };
-        if m.flow != f32::MAX {
+        if m.flow.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 115,
                 profile_type: ProfileType::FLOAT32,

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -485,10 +485,10 @@ impl SegmentLap {
             avg_cadence_position: Vec::new(),
             max_cadence_position: Vec::new(),
             manufacturer: typedef::Manufacturer(u16::MAX),
-            total_grit: f32::MAX,
-            total_flow: f32::MAX,
-            avg_grit: f32::MAX,
-            avg_flow: f32::MAX,
+            total_grit: f32::from_bits(u32::MAX),
+            total_flow: f32::from_bits(u32::MAX),
+            avg_grit: f32::from_bits(u32::MAX),
+            avg_flow: f32::from_bits(u32::MAX),
             total_fractional_ascent: u8::MAX,
             total_fractional_descent: u8::MAX,
             enhanced_avg_altitude: u32::MAX,
@@ -1554,10 +1554,10 @@ impl SegmentLap {
             + (!self.avg_cadence_position.is_empty()) as usize
             + (!self.max_cadence_position.is_empty()) as usize
             + (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
-            + (self.total_grit != f32::MAX) as usize
-            + (self.total_flow != f32::MAX) as usize
-            + (self.avg_grit != f32::MAX) as usize
-            + (self.avg_flow != f32::MAX) as usize
+            + (self.total_grit.to_bits() != u32::MAX) as usize
+            + (self.total_flow.to_bits() != u32::MAX) as usize
+            + (self.avg_grit.to_bits() != u32::MAX) as usize
+            + (self.avg_flow.to_bits() != u32::MAX) as usize
             + (self.total_fractional_ascent != u8::MAX) as usize
             + (self.total_fractional_descent != u8::MAX) as usize
             + (self.enhanced_avg_altitude != u32::MAX) as usize
@@ -2389,7 +2389,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.total_grit != f32::MAX {
+        if m.total_grit.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 84,
                 profile_type: ProfileType::FLOAT32,
@@ -2397,7 +2397,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.total_flow != f32::MAX {
+        if m.total_flow.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 85,
                 profile_type: ProfileType::FLOAT32,
@@ -2405,7 +2405,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.avg_grit != f32::MAX {
+        if m.avg_grit.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 86,
                 profile_type: ProfileType::FLOAT32,
@@ -2413,7 +2413,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.avg_flow != f32::MAX {
+        if m.avg_flow.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 87,
                 profile_type: ProfileType::FLOAT32,

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -791,11 +791,11 @@ impl Session {
             enhanced_avg_respiration_rate: u16::MAX,
             enhanced_max_respiration_rate: u16::MAX,
             enhanced_min_respiration_rate: u16::MAX,
-            total_grit: f32::MAX,
-            total_flow: f32::MAX,
+            total_grit: f32::from_bits(u32::MAX),
+            total_flow: f32::from_bits(u32::MAX),
             jump_count: u16::MAX,
-            avg_grit: f32::MAX,
-            avg_flow: f32::MAX,
+            avg_grit: f32::from_bits(u32::MAX),
+            avg_flow: f32::from_bits(u32::MAX),
             workout_feel: u8::MAX,
             workout_rpe: u8::MAX,
             avg_spo2: u8::MAX,
@@ -2648,11 +2648,11 @@ impl Session {
             + (self.enhanced_avg_respiration_rate != u16::MAX) as usize
             + (self.enhanced_max_respiration_rate != u16::MAX) as usize
             + (self.enhanced_min_respiration_rate != u16::MAX) as usize
-            + (self.total_grit != f32::MAX) as usize
-            + (self.total_flow != f32::MAX) as usize
+            + (self.total_grit.to_bits() != u32::MAX) as usize
+            + (self.total_flow.to_bits() != u32::MAX) as usize
             + (self.jump_count != u16::MAX) as usize
-            + (self.avg_grit != f32::MAX) as usize
-            + (self.avg_flow != f32::MAX) as usize
+            + (self.avg_grit.to_bits() != u32::MAX) as usize
+            + (self.avg_flow.to_bits() != u32::MAX) as usize
             + (self.workout_feel != u8::MAX) as usize
             + (self.workout_rpe != u8::MAX) as usize
             + (self.avg_spo2 != u8::MAX) as usize
@@ -3999,7 +3999,7 @@ impl From<Session> for Message {
                 is_expanded: is_expanded(&m.state, 180),
             });
         };
-        if m.total_grit != f32::MAX {
+        if m.total_grit.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 181,
                 profile_type: ProfileType::FLOAT32,
@@ -4007,7 +4007,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.total_flow != f32::MAX {
+        if m.total_flow.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 182,
                 profile_type: ProfileType::FLOAT32,
@@ -4023,7 +4023,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.avg_grit != f32::MAX {
+        if m.avg_grit.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 186,
                 profile_type: ProfileType::FLOAT32,
@@ -4031,7 +4031,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.avg_flow != f32::MAX {
+        if m.avg_flow.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 187,
                 profile_type: ProfileType::FLOAT32,

--- a/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
+++ b/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
@@ -44,9 +44,9 @@ impl SkinTempOvernight {
         Self {
             timestamp: typedef::DateTime(u32::MAX),
             local_timestamp: typedef::LocalDateTime(u32::MAX),
-            average_deviation: f32::MAX,
-            average_7_day_deviation: f32::MAX,
-            nightly_value: f32::MAX,
+            average_deviation: f32::from_bits(u32::MAX),
+            average_7_day_deviation: f32::from_bits(u32::MAX),
+            nightly_value: f32::from_bits(u32::MAX),
             unknown_fields: Vec::new(),
             developer_fields: Vec::new(),
         }
@@ -55,9 +55,9 @@ impl SkinTempOvernight {
     fn count_valid_fields(&self) -> usize {
         (self.timestamp != typedef::DateTime(u32::MAX)) as usize
             + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
-            + (self.average_deviation != f32::MAX) as usize
-            + (self.average_7_day_deviation != f32::MAX) as usize
-            + (self.nightly_value != f32::MAX) as usize
+            + (self.average_deviation.to_bits() != u32::MAX) as usize
+            + (self.average_7_day_deviation.to_bits() != u32::MAX) as usize
+            + (self.nightly_value.to_bits() != u32::MAX) as usize
     }
 }
 
@@ -116,7 +116,7 @@ impl From<SkinTempOvernight> for Message {
                 is_expanded: false,
             });
         };
-        if m.average_deviation != f32::MAX {
+        if m.average_deviation.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::FLOAT32,
@@ -124,7 +124,7 @@ impl From<SkinTempOvernight> for Message {
                 is_expanded: false,
             });
         };
-        if m.average_7_day_deviation != f32::MAX {
+        if m.average_7_day_deviation.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::FLOAT32,
@@ -132,7 +132,7 @@ impl From<SkinTempOvernight> for Message {
                 is_expanded: false,
             });
         };
-        if m.nightly_value != f32::MAX {
+        if m.nightly_value.to_bits() != u32::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::FLOAT32,


### PR DESCRIPTION
Floating-point should be evaluated on its bits representation. Compare it to `f32::MAX` is wrong since it's still valid value, and if the value is `NaN`, it becomes not comparable so can not compare them.