### PR TITLE
fix: internal proto Value as_f32 as_f64 invalid

### DIFF
--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -626,7 +626,7 @@ impl Value {
         if let Value::Float32(v) = self {
             return *v;
         }
-        f32::MAX
+        f32::from_bits(u32::MAX)
     }
 
     /// Returns `f64` or its invalid value when it's not a `f64` value.
@@ -635,7 +635,7 @@ impl Value {
         if let Value::Float64(v) = self {
             return *v;
         }
-        f64::MAX
+        f64::from_bits(u64::MAX)
     }
 
     /// Returns `i64` or its invalid value when it's not an `i64` value.


### PR DESCRIPTION
`f32` and `f64` invalid value in integer form should be `u32::MAX` and `u64::MAX`. However, this "invalid path" is currently unreachable by any code in our library, and this method is not public so users can't invoke it. `mesgdef` is currently using pattern matching directly so when known field is exist, it will always contains a float value, even though the content of the value might be an invalid float value.

No release needed since not affecting anything.