### PR TITLE
chore: mesgdef simplify value comparison using inner for typedef

### DIFF
--- a/fitgen/internal/profile/mesgdef/builder.go
+++ b/fitgen/internal/profile/mesgdef/builder.go
@@ -98,10 +98,11 @@ func (b *Builder) Build() ([]generator.Data, error) {
 				Num:  parserField.Num,
 				Name: strutil.ToNonRustIdent(parserField.Name),
 				Name0: func() string {
+					name := strutil.ToNonRustIdent(parserField.Name)
 					if parserField.Type == baseType.String() {
-						return parserField.Name
+						return name
 					}
-					return fmt.Sprintf("%s.0", parserField.Name)
+					return fmt.Sprintf("%s.0", name)
 				}(),
 				NameUpperCase: strings.ToUpper(parserField.Name),
 				String:        parserField.Name,
@@ -123,7 +124,8 @@ func (b *Builder) Build() ([]generator.Data, error) {
 				Type:           b.transformType(parserField.Type, parserField.Array, fixedArraySize),
 				TypedValue:     b.transformTypedValue(parserField.Type, parserField.Array, fixedArraySize),
 				ProtoValue:     b.transformToProtoValue(strutil.ToNonRustIdent(parserField.Name), parserField.Type, parserField.Array, fixedArraySize),
-				InvalidValue:   b.invalidValueOf(parserField.Type, parserField.Array, fixedArraySize),
+				InvalidValue:   b.invalidValue(parserField.Type, parserField.Array, fixedArraySize, false),
+				InvalidValue0:  b.invalidValue(parserField.Type, parserField.Array, fixedArraySize, true),
 				Comment:        parserField.Comment,
 				Scale:          1,
 				Offset:         0,
@@ -131,8 +133,11 @@ func (b *Builder) Build() ([]generator.Data, error) {
 				FixedArraySize: fixedArraySize,
 				Units:          parserField.Units,
 			}
+
 			if field.BaseType == "STRING" {
 				imports["alloc::string::String"] = struct{}{}
+			}
+			if strings.Contains(field.TypedValue, "to_owned") {
 				imports["alloc::borrow::ToOwned"] = struct{}{}
 			}
 			if field.Units == "semicircles" {
@@ -143,13 +148,13 @@ func (b *Builder) Build() ([]generator.Data, error) {
 				field.CanExpand = true
 			}
 
-			field.IfSelfEqualInvalid = fmt.Sprintf("self.%s == %s", field.Name, field.InvalidValue)
-			field.IfSelfNotEqualInvalid = fmt.Sprintf("self.%s != %s", field.Name, field.InvalidValue)
-			field.IfNotEqualInvalid = fmt.Sprintf("m.%s != %s", field.Name, field.InvalidValue)
+			field.IfSelfEqualInvalid = fmt.Sprintf("self.%s == %s", field.Name0, field.InvalidValue0)
+			field.IfSelfNotEqualInvalid = fmt.Sprintf("self.%s != %s", field.Name0, field.InvalidValue0)
+			field.IfNotEqualInvalid = fmt.Sprintf("m.%s != %s", field.Name0, field.InvalidValue0)
 			if field.BaseType0 == "f32" || field.BaseType0 == "f64" {
-				field.IfSelfEqualInvalid = fmt.Sprintf("self.%s.to_bits() == u%s::MAX", field.Name, field.BaseType0[1:])
-				field.IfSelfNotEqualInvalid = fmt.Sprintf("self.%s.to_bits() != u%s::MAX", field.Name, field.BaseType0[1:])
-				field.IfNotEqualInvalid = fmt.Sprintf("m.%s.to_bits() != u%s::MAX", field.Name, field.BaseType0[1:])
+				field.IfSelfEqualInvalid = fmt.Sprintf("self.%s.to_bits() == u%s::MAX", field.Name0, field.BaseType0[1:])
+				field.IfSelfNotEqualInvalid = fmt.Sprintf("self.%s.to_bits() != u%s::MAX", field.Name0, field.BaseType0[1:])
+				field.IfNotEqualInvalid = fmt.Sprintf("m.%s.to_bits() != u%s::MAX", field.Name0, field.BaseType0[1:])
 			}
 			if parserField.Array == "[N]" || (field.BaseType == "STRING" && parserField.Array == "") {
 				field.IfSelfEqualInvalid = fmt.Sprintf("self.%s.is_empty()", field.Name)
@@ -477,7 +482,7 @@ func (b *Builder) transformTypedValue(fieldType, array string, fixedArraySize ui
 	}`, strings.TrimSuffix(valueEnumType, "z"), typdef)
 }
 
-func (b *Builder) invalidValueOf(fieldType, array string, fixedArraySize byte) string {
+func (b *Builder) invalidValue(fieldType, array string, fixedArraySize byte, inner bool) string {
 	baseType := b.lookup.BaseType(fieldType).String()
 	rustType := baseTypeToRustTypeReplacer.Replace(baseType)
 
@@ -507,7 +512,7 @@ func (b *Builder) invalidValueOf(fieldType, array string, fixedArraySize byte) s
 		return fmt.Sprintf("[%s; %d]", invalid, int(fixedArraySize))
 	}
 
-	if baseType == fieldType {
+	if baseType == fieldType || inner {
 		return invalid
 	}
 

--- a/fitgen/internal/profile/mesgdef/data.go
+++ b/fitgen/internal/profile/mesgdef/data.go
@@ -45,6 +45,7 @@ type Field struct {
 	IsValidValue          string
 	ComparableValue       string
 	InvalidValue          string
+	InvalidValue0         string // Invalid value but with inner value if it's typedef: typedef::File(u32::MAX) -> u32::MAX
 	Comment               string
 	Units                 string
 	Scale                 float64

--- a/fitgen/internal/profile/mesgdef/mesgdef.tmpl
+++ b/fitgen/internal/profile/mesgdef/mesgdef.tmpl
@@ -10,7 +10,9 @@
 {{ define "mesgdef" -}}
 {{ template "header" . -}}
 
-#![allow(unused, clippy::manual_range_patterns)]
+{{ if gt .MaxFieldExpandNum 1 -}}
+#![allow(clippy::manual_range_patterns)]
+{{ end }}
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -172,7 +174,7 @@ impl {{ .Name }} {
                 if unscaled.is_nan() || unscaled.is_infinite() || unscaled > {{ .MaxValue }} as f64 {
                     continue
                 }
-                self.{{ .Name }}[i] = (unscaled as {{ .BaseType0 }});
+                self.{{ .Name }}[i] = unscaled as {{ .BaseType0 }};
             }
             self
         }

--- a/rustyfit/src/profile/mesgdef/aad_accel_features.rs
+++ b/rustyfit/src/profile/mesgdef/aad_accel_features.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -80,7 +78,7 @@ impl AadAccelFeatures {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.time != u16::MAX) as usize
             + (self.energy_total != u32::MAX) as usize
             + (self.zero_cross_cnt != u16::MAX) as usize
@@ -129,7 +127,7 @@ impl From<AadAccelFeatures> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/accelerometer_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -90,7 +88,7 @@ impl AccelerometerData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (!self.sample_time_offset.is_empty()) as usize
             + (!self.accel_x.is_empty()) as usize
@@ -151,7 +149,7 @@ impl From<AccelerometerData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/activity.rs
+++ b/rustyfit/src/profile/mesgdef/activity.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -85,13 +83,13 @@ impl Activity {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.total_timer_time != u32::MAX) as usize
             + (self.num_sessions != u16::MAX) as usize
-            + (self.r#type != typedef::Activity(u8::MAX)) as usize
-            + (self.event != typedef::Event(u8::MAX)) as usize
-            + (self.event_type != typedef::EventType(u8::MAX)) as usize
-            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+            + (self.r#type.0 != u8::MAX) as usize
+            + (self.event.0 != u8::MAX) as usize
+            + (self.event_type.0 != u8::MAX) as usize
+            + (self.local_timestamp.0 != u32::MAX) as usize
             + (self.event_group != u8::MAX) as usize
     }
 }
@@ -138,7 +136,7 @@ impl From<Activity> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -162,7 +160,7 @@ impl From<Activity> for Message {
                 is_expanded: false,
             });
         };
-        if m.r#type != typedef::Activity(u8::MAX) {
+        if m.r#type.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::ACTIVITY,
@@ -170,7 +168,7 @@ impl From<Activity> for Message {
                 is_expanded: false,
             });
         };
-        if m.event != typedef::Event(u8::MAX) {
+        if m.event.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::EVENT,
@@ -178,7 +176,7 @@ impl From<Activity> for Message {
                 is_expanded: false,
             });
         };
-        if m.event_type != typedef::EventType(u8::MAX) {
+        if m.event_type.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::EVENT_TYPE,
@@ -186,7 +184,7 @@ impl From<Activity> for Message {
                 is_expanded: false,
             });
         };
-        if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
+        if m.local_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::LOCAL_DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/ant_channel_id.rs
+++ b/rustyfit/src/profile/mesgdef/ant_channel_id.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -57,7 +55,7 @@ impl AntChannelId {
             + (self.device_type != u8::MIN) as usize
             + (self.device_number != u16::MIN) as usize
             + (self.transmission_type != u8::MIN) as usize
-            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+            + (self.device_index.0 != u8::MAX) as usize
     }
 }
 
@@ -132,7 +130,7 @@ impl From<AntChannelId> for Message {
                 is_expanded: false,
             });
         };
-        if m.device_index != typedef::DeviceIndex(u8::MAX) {
+        if m.device_index.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::DEVICE_INDEX,

--- a/rustyfit/src/profile/mesgdef/ant_rx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_rx.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -106,7 +106,7 @@ impl AntRx {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.fractional_timestamp != u16::MAX) as usize
             + (self.mesg_id != u8::MAX) as usize
             + (!self.mesg_data.is_empty()) as usize
@@ -161,7 +161,7 @@ impl From<AntRx> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/ant_tx.rs
+++ b/rustyfit/src/profile/mesgdef/ant_tx.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -106,7 +106,7 @@ impl AntTx {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.fractional_timestamp != u16::MAX) as usize
             + (self.mesg_id != u8::MAX) as usize
             + (!self.mesg_data.is_empty()) as usize
@@ -161,7 +161,7 @@ impl From<AntTx> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/aviation_attitude.rs
+++ b/rustyfit/src/profile/mesgdef/aviation_attitude.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -274,7 +272,7 @@ impl AviationAttitude {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (!self.system_time.is_empty()) as usize
             + (!self.pitch.is_empty()) as usize
@@ -353,7 +351,7 @@ impl From<AviationAttitude> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/barometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/barometer_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -50,7 +48,7 @@ impl BarometerData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (!self.sample_time_offset.is_empty()) as usize
             + (!self.baro_pres.is_empty()) as usize
@@ -95,7 +93,7 @@ impl From<BarometerData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/beat_intervals.rs
+++ b/rustyfit/src/profile/mesgdef/beat_intervals.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -44,7 +42,7 @@ impl BeatIntervals {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (!self.time.is_empty()) as usize
     }
@@ -87,7 +85,7 @@ impl From<BeatIntervals> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/bike_profile.rs
+++ b/rustyfit/src/profile/mesgdef/bike_profile.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -305,10 +303,10 @@ impl BikeProfile {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (!self.name.is_empty()) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.sport.0 != u8::MAX) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
             + (self.odometer != u32::MAX) as usize
             + (self.bike_spd_ant_id != u16::MIN) as usize
             + (self.bike_cad_ant_id != u16::MIN) as usize
@@ -318,15 +316,15 @@ impl BikeProfile {
             + (self.auto_wheelsize != u16::MAX) as usize
             + (self.bike_weight != u16::MAX) as usize
             + (self.power_cal_factor != u16::MAX) as usize
-            + (self.auto_wheel_cal != typedef::Bool(u8::MAX)) as usize
-            + (self.auto_power_zero != typedef::Bool(u8::MAX)) as usize
+            + (self.auto_wheel_cal.0 != u8::MAX) as usize
+            + (self.auto_power_zero.0 != u8::MAX) as usize
             + (self.id != u8::MAX) as usize
-            + (self.spd_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.cad_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.spdcad_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.power_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.spd_enabled.0 != u8::MAX) as usize
+            + (self.cad_enabled.0 != u8::MAX) as usize
+            + (self.spdcad_enabled.0 != u8::MAX) as usize
+            + (self.power_enabled.0 != u8::MAX) as usize
             + (self.crank_length != u8::MAX) as usize
-            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.enabled.0 != u8::MAX) as usize
             + (self.bike_spd_ant_id_trans_type != u8::MIN) as usize
             + (self.bike_cad_ant_id_trans_type != u8::MIN) as usize
             + (self.bike_spdcad_ant_id_trans_type != u8::MIN) as usize
@@ -336,7 +334,7 @@ impl BikeProfile {
             + (!self.front_gear.is_empty()) as usize
             + (self.rear_gear_num != u8::MIN) as usize
             + (!self.rear_gear.is_empty()) as usize
-            + (self.shimano_di2_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.shimano_di2_enabled.0 != u8::MAX) as usize
     }
 }
 
@@ -406,7 +404,7 @@ impl From<BikeProfile> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -422,7 +420,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SPORT,
@@ -430,7 +428,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SUB_SPORT,
@@ -510,7 +508,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.auto_wheel_cal != typedef::Bool(u8::MAX) {
+        if m.auto_wheel_cal.0 != u8::MAX {
             fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::BOOL,
@@ -518,7 +516,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.auto_power_zero != typedef::Bool(u8::MAX) {
+        if m.auto_power_zero.0 != u8::MAX {
             fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::BOOL,
@@ -534,7 +532,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.spd_enabled != typedef::Bool(u8::MAX) {
+        if m.spd_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::BOOL,
@@ -542,7 +540,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.cad_enabled != typedef::Bool(u8::MAX) {
+        if m.cad_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::BOOL,
@@ -550,7 +548,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.spdcad_enabled != typedef::Bool(u8::MAX) {
+        if m.spdcad_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::BOOL,
@@ -558,7 +556,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.power_enabled != typedef::Bool(u8::MAX) {
+        if m.power_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::BOOL,
@@ -574,7 +572,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.enabled != typedef::Bool(u8::MAX) {
+        if m.enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 20,
                 profile_type: ProfileType::BOOL,
@@ -654,7 +652,7 @@ impl From<BikeProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.shimano_di2_enabled != typedef::Bool(u8::MAX) {
+        if m.shimano_di2_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 44,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/blood_pressure.rs
+++ b/rustyfit/src/profile/mesgdef/blood_pressure.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -83,7 +81,7 @@ impl BloodPressure {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.systolic_pressure != u16::MAX) as usize
             + (self.diastolic_pressure != u16::MAX) as usize
             + (self.mean_arterial_pressure != u16::MAX) as usize
@@ -91,9 +89,9 @@ impl BloodPressure {
             + (self.map_morning_values != u16::MAX) as usize
             + (self.map_evening_values != u16::MAX) as usize
             + (self.heart_rate != u8::MAX) as usize
-            + (self.heart_rate_type != typedef::HrType(u8::MAX)) as usize
-            + (self.status != typedef::BpStatus(u8::MAX)) as usize
-            + (self.user_profile_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.heart_rate_type.0 != u8::MAX) as usize
+            + (self.status.0 != u8::MAX) as usize
+            + (self.user_profile_index.0 != u16::MAX) as usize
     }
 }
 
@@ -142,7 +140,7 @@ impl From<BloodPressure> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -206,7 +204,7 @@ impl From<BloodPressure> for Message {
                 is_expanded: false,
             });
         };
-        if m.heart_rate_type != typedef::HrType(u8::MAX) {
+        if m.heart_rate_type.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::HR_TYPE,
@@ -214,7 +212,7 @@ impl From<BloodPressure> for Message {
                 is_expanded: false,
             });
         };
-        if m.status != typedef::BpStatus(u8::MAX) {
+        if m.status.0 != u8::MAX {
             fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BP_STATUS,
@@ -222,7 +220,7 @@ impl From<BloodPressure> for Message {
                 is_expanded: false,
             });
         };
-        if m.user_profile_index != typedef::MessageIndex(u16::MAX) {
+        if m.user_profile_index.0 != u16::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/cadence_zone.rs
+++ b/rustyfit/src/profile/mesgdef/cadence_zone.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -45,7 +43,7 @@ impl CadenceZone {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.high_value != u8::MAX) as usize
             + (!self.name.is_empty()) as usize
     }
@@ -88,7 +86,7 @@ impl From<CadenceZone> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/camera_event.rs
+++ b/rustyfit/src/profile/mesgdef/camera_event.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -54,11 +52,11 @@ impl CameraEvent {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
-            + (self.camera_event_type != typedef::CameraEventType(u8::MAX)) as usize
+            + (self.camera_event_type.0 != u8::MAX) as usize
             + (!self.camera_file_uuid.is_empty()) as usize
-            + (self.camera_orientation != typedef::CameraOrientationType(u8::MAX)) as usize
+            + (self.camera_orientation.0 != u8::MAX) as usize
     }
 }
 
@@ -101,7 +99,7 @@ impl From<CameraEvent> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -117,7 +115,7 @@ impl From<CameraEvent> for Message {
                 is_expanded: false,
             });
         };
-        if m.camera_event_type != typedef::CameraEventType(u8::MAX) {
+        if m.camera_event_type.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::CAMERA_EVENT_TYPE,
@@ -133,7 +131,7 @@ impl From<CameraEvent> for Message {
                 is_expanded: false,
             });
         };
-        if m.camera_orientation != typedef::CameraOrientationType(u8::MAX) {
+        if m.camera_orientation.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::CAMERA_ORIENTATION_TYPE,

--- a/rustyfit/src/profile/mesgdef/capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/capabilities.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -52,8 +50,8 @@ impl Capabilities {
     fn count_valid_fields(&self) -> usize {
         (!self.languages.is_empty()) as usize
             + (!self.sports.is_empty()) as usize
-            + (self.workouts_supported != typedef::WorkoutCapabilities(u32::MIN)) as usize
-            + (self.connectivity_supported != typedef::ConnectivityCapabilities(u32::MIN)) as usize
+            + (self.workouts_supported.0 != u32::MIN) as usize
+            + (self.connectivity_supported.0 != u32::MIN) as usize
     }
 }
 
@@ -126,7 +124,7 @@ impl From<Capabilities> for Message {
                 is_expanded: false,
             });
         };
-        if m.workouts_supported != typedef::WorkoutCapabilities(u32::MIN) {
+        if m.workouts_supported.0 != u32::MIN {
             fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::WORKOUT_CAPABILITIES,
@@ -134,7 +132,7 @@ impl From<Capabilities> for Message {
                 is_expanded: false,
             });
         };
-        if m.connectivity_supported != typedef::ConnectivityCapabilities(u32::MIN) {
+        if m.connectivity_supported.0 != u32::MIN {
             fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::CONNECTIVITY_CAPABILITIES,

--- a/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -64,7 +62,7 @@ impl ChronoShotData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.shot_speed != u32::MAX) as usize
             + (self.shot_num != u16::MAX) as usize
     }
@@ -107,7 +105,7 @@ impl From<ChronoShotData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
+++ b/rustyfit/src/profile/mesgdef/chrono_shot_session.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -172,12 +170,12 @@ impl ChronoShotSession {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.min_speed != u32::MAX) as usize
             + (self.max_speed != u32::MAX) as usize
             + (self.avg_speed != u32::MAX) as usize
             + (self.shot_count != u16::MAX) as usize
-            + (self.projectile_type != typedef::ProjectileType(u8::MAX)) as usize
+            + (self.projectile_type.0 != u8::MAX) as usize
             + (self.grain_weight != u32::MAX) as usize
             + (self.standard_deviation != u32::MAX) as usize
     }
@@ -225,7 +223,7 @@ impl From<ChronoShotSession> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -265,7 +263,7 @@ impl From<ChronoShotSession> for Message {
                 is_expanded: false,
             });
         };
-        if m.projectile_type != typedef::ProjectileType(u8::MAX) {
+        if m.projectile_type.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::PROJECTILE_TYPE,

--- a/rustyfit/src/profile/mesgdef/climb_pro.rs
+++ b/rustyfit/src/profile/mesgdef/climb_pro.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use crate::semconv;
@@ -85,10 +83,10 @@ impl ClimbPro {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.position_lat != i32::MAX) as usize
             + (self.position_long != i32::MAX) as usize
-            + (self.climb_pro_event != typedef::ClimbProEvent(u8::MAX)) as usize
+            + (self.climb_pro_event.0 != u8::MAX) as usize
             + (self.climb_number != u16::MAX) as usize
             + (self.climb_category != u8::MAX) as usize
             + (self.current_dist.to_bits() != u32::MAX) as usize
@@ -136,7 +134,7 @@ impl From<ClimbPro> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -160,7 +158,7 @@ impl From<ClimbPro> for Message {
                 is_expanded: false,
             });
         };
-        if m.climb_pro_event != typedef::ClimbProEvent(u8::MAX) {
+        if m.climb_pro_event.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::CLIMB_PRO_EVENT,

--- a/rustyfit/src/profile/mesgdef/connectivity.rs
+++ b/rustyfit/src/profile/mesgdef/connectivity.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -87,19 +85,19 @@ impl Connectivity {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.bluetooth_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.bluetooth_le_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.ant_enabled != typedef::Bool(u8::MAX)) as usize
+        (self.bluetooth_enabled.0 != u8::MAX) as usize
+            + (self.bluetooth_le_enabled.0 != u8::MAX) as usize
+            + (self.ant_enabled.0 != u8::MAX) as usize
             + (!self.name.is_empty()) as usize
-            + (self.live_tracking_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.weather_conditions_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.weather_alerts_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.auto_activity_upload_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.course_download_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.workout_download_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.gps_ephemeris_download_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.incident_detection_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.grouptrack_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.live_tracking_enabled.0 != u8::MAX) as usize
+            + (self.weather_conditions_enabled.0 != u8::MAX) as usize
+            + (self.weather_alerts_enabled.0 != u8::MAX) as usize
+            + (self.auto_activity_upload_enabled.0 != u8::MAX) as usize
+            + (self.course_download_enabled.0 != u8::MAX) as usize
+            + (self.workout_download_enabled.0 != u8::MAX) as usize
+            + (self.gps_ephemeris_download_enabled.0 != u8::MAX) as usize
+            + (self.incident_detection_enabled.0 != u8::MAX) as usize
+            + (self.grouptrack_enabled.0 != u8::MAX) as usize
     }
 }
 
@@ -150,7 +148,7 @@ impl From<Connectivity> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.bluetooth_enabled != typedef::Bool(u8::MAX) {
+        if m.bluetooth_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::BOOL,
@@ -158,7 +156,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.bluetooth_le_enabled != typedef::Bool(u8::MAX) {
+        if m.bluetooth_le_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::BOOL,
@@ -166,7 +164,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.ant_enabled != typedef::Bool(u8::MAX) {
+        if m.ant_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BOOL,
@@ -182,7 +180,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.live_tracking_enabled != typedef::Bool(u8::MAX) {
+        if m.live_tracking_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::BOOL,
@@ -190,7 +188,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.weather_conditions_enabled != typedef::Bool(u8::MAX) {
+        if m.weather_conditions_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::BOOL,
@@ -198,7 +196,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.weather_alerts_enabled != typedef::Bool(u8::MAX) {
+        if m.weather_alerts_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::BOOL,
@@ -206,7 +204,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.auto_activity_upload_enabled != typedef::Bool(u8::MAX) {
+        if m.auto_activity_upload_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::BOOL,
@@ -214,7 +212,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.course_download_enabled != typedef::Bool(u8::MAX) {
+        if m.course_download_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BOOL,
@@ -222,7 +220,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.workout_download_enabled != typedef::Bool(u8::MAX) {
+        if m.workout_download_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
@@ -230,7 +228,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.gps_ephemeris_download_enabled != typedef::Bool(u8::MAX) {
+        if m.gps_ephemeris_download_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::BOOL,
@@ -238,7 +236,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.incident_detection_enabled != typedef::Bool(u8::MAX) {
+        if m.incident_detection_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::BOOL,
@@ -246,7 +244,7 @@ impl From<Connectivity> for Message {
                 is_expanded: false,
             });
         };
-        if m.grouptrack_enabled != typedef::Bool(u8::MAX) {
+        if m.grouptrack_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/course.rs
+++ b/rustyfit/src/profile/mesgdef/course.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -49,10 +47,10 @@ impl Course {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.sport != typedef::Sport(u8::MAX)) as usize
+        (self.sport.0 != u8::MAX) as usize
             + (!self.name.is_empty()) as usize
-            + (self.capabilities != typedef::CourseCapabilities(u32::MIN)) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.capabilities.0 != u32::MIN) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
     }
 }
 
@@ -94,7 +92,7 @@ impl From<Course> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SPORT,
@@ -110,7 +108,7 @@ impl From<Course> for Message {
                 is_expanded: false,
             });
         };
-        if m.capabilities != typedef::CourseCapabilities(u32::MIN) {
+        if m.capabilities.0 != u32::MIN {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::COURSE_CAPABILITIES,
@@ -118,7 +116,7 @@ impl From<Course> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::SUB_SPORT,

--- a/rustyfit/src/profile/mesgdef/course_point.rs
+++ b/rustyfit/src/profile/mesgdef/course_point.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use crate::semconv;
@@ -111,14 +109,14 @@ impl CoursePoint {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.timestamp.0 != u32::MAX) as usize
             + (self.position_lat != i32::MAX) as usize
             + (self.position_long != i32::MAX) as usize
             + (self.distance != u32::MAX) as usize
-            + (self.r#type != typedef::CoursePoint(u8::MAX)) as usize
+            + (self.r#type.0 != u8::MAX) as usize
             + (!self.name.is_empty()) as usize
-            + (self.favorite != typedef::Bool(u8::MAX)) as usize
+            + (self.favorite.0 != u8::MAX) as usize
     }
 }
 
@@ -164,7 +162,7 @@ impl From<CoursePoint> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -172,7 +170,7 @@ impl From<CoursePoint> for Message {
                 is_expanded: false,
             });
         };
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,
@@ -204,7 +202,7 @@ impl From<CoursePoint> for Message {
                 is_expanded: false,
             });
         };
-        if m.r#type != typedef::CoursePoint(u8::MAX) {
+        if m.r#type.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::COURSE_POINT,
@@ -220,7 +218,7 @@ impl From<CoursePoint> for Message {
                 is_expanded: false,
             });
         };
-        if m.favorite != typedef::Bool(u8::MAX) {
+        if m.favorite.0 != u8::MAX {
             fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/developer_data_id.rs
+++ b/rustyfit/src/profile/mesgdef/developer_data_id.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -49,7 +47,7 @@ impl DeveloperDataId {
     fn count_valid_fields(&self) -> usize {
         (!self.developer_id.is_empty()) as usize
             + (!self.application_id.is_empty()) as usize
-            + (self.manufacturer_id != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.manufacturer_id.0 != u16::MAX) as usize
             + (self.developer_data_index != u8::MAX) as usize
             + (self.application_version != u32::MAX) as usize
     }
@@ -109,7 +107,7 @@ impl From<DeveloperDataId> for Message {
                 is_expanded: false,
             });
         };
-        if m.manufacturer_id != typedef::Manufacturer(u16::MAX) {
+        if m.manufacturer_id.0 != u16::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::MANUFACTURER,

--- a/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_aux_battery_info.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -72,10 +70,10 @@ impl DeviceAuxBatteryInfo {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.device_index.0 != u8::MAX) as usize
             + (self.battery_voltage != u16::MAX) as usize
-            + (self.battery_status != typedef::BatteryStatus(u8::MAX)) as usize
+            + (self.battery_status.0 != u8::MAX) as usize
             + (self.battery_identifier != u8::MAX) as usize
     }
 }
@@ -119,7 +117,7 @@ impl From<DeviceAuxBatteryInfo> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -127,7 +125,7 @@ impl From<DeviceAuxBatteryInfo> for Message {
                 is_expanded: false,
             });
         };
-        if m.device_index != typedef::DeviceIndex(u8::MAX) {
+        if m.device_index.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DEVICE_INDEX,
@@ -143,7 +141,7 @@ impl From<DeviceAuxBatteryInfo> for Message {
                 is_expanded: false,
             });
         };
-        if m.battery_status != typedef::BatteryStatus(u8::MAX) {
+        if m.battery_status.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BATTERY_STATUS,

--- a/rustyfit/src/profile/mesgdef/device_info.rs
+++ b/rustyfit/src/profile/mesgdef/device_info.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -159,23 +157,23 @@ impl DeviceInfo {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.device_index.0 != u8::MAX) as usize
             + (self.device_type != u8::MAX) as usize
-            + (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.manufacturer.0 != u16::MAX) as usize
             + (self.serial_number != u32::MIN) as usize
             + (self.product != u16::MAX) as usize
             + (self.software_version != u16::MAX) as usize
             + (self.hardware_version != u8::MAX) as usize
             + (self.cum_operating_time != u32::MAX) as usize
             + (self.battery_voltage != u16::MAX) as usize
-            + (self.battery_status != typedef::BatteryStatus(u8::MAX)) as usize
-            + (self.sensor_position != typedef::BodyLocation(u8::MAX)) as usize
+            + (self.battery_status.0 != u8::MAX) as usize
+            + (self.sensor_position.0 != u8::MAX) as usize
             + (!self.descriptor.is_empty()) as usize
             + (self.ant_transmission_type != u8::MIN) as usize
             + (self.ant_device_number != u16::MIN) as usize
-            + (self.ant_network != typedef::AntNetwork(u8::MAX)) as usize
-            + (self.source_type != typedef::SourceType(u8::MAX)) as usize
+            + (self.ant_network.0 != u8::MAX) as usize
+            + (self.source_type.0 != u8::MAX) as usize
             + (!self.product_name.is_empty()) as usize
             + (self.battery_level != u8::MAX) as usize
     }
@@ -234,7 +232,7 @@ impl From<DeviceInfo> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -242,7 +240,7 @@ impl From<DeviceInfo> for Message {
                 is_expanded: false,
             });
         };
-        if m.device_index != typedef::DeviceIndex(u8::MAX) {
+        if m.device_index.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DEVICE_INDEX,
@@ -258,7 +256,7 @@ impl From<DeviceInfo> for Message {
                 is_expanded: false,
             });
         };
-        if m.manufacturer != typedef::Manufacturer(u16::MAX) {
+        if m.manufacturer.0 != u16::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::MANUFACTURER,
@@ -314,7 +312,7 @@ impl From<DeviceInfo> for Message {
                 is_expanded: false,
             });
         };
-        if m.battery_status != typedef::BatteryStatus(u8::MAX) {
+        if m.battery_status.0 != u8::MAX {
             fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::BATTERY_STATUS,
@@ -322,7 +320,7 @@ impl From<DeviceInfo> for Message {
                 is_expanded: false,
             });
         };
-        if m.sensor_position != typedef::BodyLocation(u8::MAX) {
+        if m.sensor_position.0 != u8::MAX {
             fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::BODY_LOCATION,
@@ -354,7 +352,7 @@ impl From<DeviceInfo> for Message {
                 is_expanded: false,
             });
         };
-        if m.ant_network != typedef::AntNetwork(u8::MAX) {
+        if m.ant_network.0 != u8::MAX {
             fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::ANT_NETWORK,
@@ -362,7 +360,7 @@ impl From<DeviceInfo> for Message {
                 is_expanded: false,
             });
         };
-        if m.source_type != typedef::SourceType(u8::MAX) {
+        if m.source_type.0 != u8::MAX {
             fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::SOURCE_TYPE,

--- a/rustyfit/src/profile/mesgdef/device_settings.rs
+++ b/rustyfit/src/profile/mesgdef/device_settings.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -183,26 +181,25 @@ impl DeviceSettings {
             + (!self.time_offset.is_empty()) as usize
             + (!self.time_mode.is_empty()) as usize
             + (!self.time_zone_offset.is_empty()) as usize
-            + (self.backlight_mode != typedef::BacklightMode(u8::MAX)) as usize
-            + (self.activity_tracker_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.clock_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.backlight_mode.0 != u8::MAX) as usize
+            + (self.activity_tracker_enabled.0 != u8::MAX) as usize
+            + (self.clock_time.0 != u32::MAX) as usize
             + (!self.pages_enabled.is_empty()) as usize
-            + (self.move_alert_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.date_mode != typedef::DateMode(u8::MAX)) as usize
-            + (self.display_orientation != typedef::DisplayOrientation(u8::MAX)) as usize
-            + (self.mounting_side != typedef::Side(u8::MAX)) as usize
+            + (self.move_alert_enabled.0 != u8::MAX) as usize
+            + (self.date_mode.0 != u8::MAX) as usize
+            + (self.display_orientation.0 != u8::MAX) as usize
+            + (self.mounting_side.0 != u8::MAX) as usize
             + (!self.default_page.is_empty()) as usize
             + (self.autosync_min_steps != u16::MAX) as usize
             + (self.autosync_min_time != u16::MAX) as usize
-            + (self.lactate_threshold_autodetect_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.ble_auto_upload_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.auto_sync_frequency != typedef::AutoSyncFrequency(u8::MAX)) as usize
-            + (self.auto_activity_detect != typedef::AutoActivityDetect(u32::MAX)) as usize
+            + (self.lactate_threshold_autodetect_enabled.0 != u8::MAX) as usize
+            + (self.ble_auto_upload_enabled.0 != u8::MAX) as usize
+            + (self.auto_sync_frequency.0 != u8::MAX) as usize
+            + (self.auto_activity_detect.0 != u32::MAX) as usize
             + (self.number_of_screens != u8::MAX) as usize
-            + (self.smart_notification_display_orientation != typedef::DisplayOrientation(u8::MAX))
-                as usize
-            + (self.tap_interface != typedef::Switch(u8::MAX)) as usize
-            + (self.tap_sensitivity != typedef::TapSensitivity(u8::MAX)) as usize
+            + (self.smart_notification_display_orientation.0 != u8::MAX) as usize
+            + (self.tap_interface.0 != u8::MAX) as usize
+            + (self.tap_sensitivity.0 != u8::MAX) as usize
     }
 }
 
@@ -319,7 +316,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.backlight_mode != typedef::BacklightMode(u8::MAX) {
+        if m.backlight_mode.0 != u8::MAX {
             fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::BACKLIGHT_MODE,
@@ -327,7 +324,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.activity_tracker_enabled != typedef::Bool(u8::MAX) {
+        if m.activity_tracker_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 36,
                 profile_type: ProfileType::BOOL,
@@ -335,7 +332,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.clock_time != typedef::DateTime(u32::MAX) {
+        if m.clock_time.0 != u32::MAX {
             fields.push(Field {
                 num: 39,
                 profile_type: ProfileType::DATE_TIME,
@@ -351,7 +348,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.move_alert_enabled != typedef::Bool(u8::MAX) {
+        if m.move_alert_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 46,
                 profile_type: ProfileType::BOOL,
@@ -359,7 +356,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.date_mode != typedef::DateMode(u8::MAX) {
+        if m.date_mode.0 != u8::MAX {
             fields.push(Field {
                 num: 47,
                 profile_type: ProfileType::DATE_MODE,
@@ -367,7 +364,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.display_orientation != typedef::DisplayOrientation(u8::MAX) {
+        if m.display_orientation.0 != u8::MAX {
             fields.push(Field {
                 num: 55,
                 profile_type: ProfileType::DISPLAY_ORIENTATION,
@@ -375,7 +372,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.mounting_side != typedef::Side(u8::MAX) {
+        if m.mounting_side.0 != u8::MAX {
             fields.push(Field {
                 num: 56,
                 profile_type: ProfileType::SIDE,
@@ -407,7 +404,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.lactate_threshold_autodetect_enabled != typedef::Bool(u8::MAX) {
+        if m.lactate_threshold_autodetect_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 80,
                 profile_type: ProfileType::BOOL,
@@ -415,7 +412,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.ble_auto_upload_enabled != typedef::Bool(u8::MAX) {
+        if m.ble_auto_upload_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 86,
                 profile_type: ProfileType::BOOL,
@@ -423,7 +420,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.auto_sync_frequency != typedef::AutoSyncFrequency(u8::MAX) {
+        if m.auto_sync_frequency.0 != u8::MAX {
             fields.push(Field {
                 num: 89,
                 profile_type: ProfileType::AUTO_SYNC_FREQUENCY,
@@ -431,7 +428,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.auto_activity_detect != typedef::AutoActivityDetect(u32::MAX) {
+        if m.auto_activity_detect.0 != u32::MAX {
             fields.push(Field {
                 num: 90,
                 profile_type: ProfileType::AUTO_ACTIVITY_DETECT,
@@ -447,7 +444,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.smart_notification_display_orientation != typedef::DisplayOrientation(u8::MAX) {
+        if m.smart_notification_display_orientation.0 != u8::MAX {
             fields.push(Field {
                 num: 95,
                 profile_type: ProfileType::DISPLAY_ORIENTATION,
@@ -455,7 +452,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.tap_interface != typedef::Switch(u8::MAX) {
+        if m.tap_interface.0 != u8::MAX {
             fields.push(Field {
                 num: 134,
                 profile_type: ProfileType::SWITCH,
@@ -463,7 +460,7 @@ impl From<DeviceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.tap_sensitivity != typedef::TapSensitivity(u8::MAX) {
+        if m.tap_sensitivity.0 != u8::MAX {
             fields.push(Field {
                 num: 174,
                 profile_type: ProfileType::TAP_SENSITIVITY,

--- a/rustyfit/src/profile/mesgdef/dive_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_alarm.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -137,18 +135,18 @@ impl DiveAlarm {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.depth != u32::MAX) as usize
             + (self.time != i32::MAX) as usize
-            + (self.enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.alarm_type != typedef::DiveAlarmType(u8::MAX)) as usize
-            + (self.sound != typedef::Tone(u8::MAX)) as usize
+            + (self.enabled.0 != u8::MAX) as usize
+            + (self.alarm_type.0 != u8::MAX) as usize
+            + (self.sound.0 != u8::MAX) as usize
             + (!self.dive_types.is_empty()) as usize
             + (self.id != u32::MAX) as usize
-            + (self.popup_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.trigger_on_descent != typedef::Bool(u8::MAX)) as usize
-            + (self.trigger_on_ascent != typedef::Bool(u8::MAX)) as usize
-            + (self.repeating != typedef::Bool(u8::MAX)) as usize
+            + (self.popup_enabled.0 != u8::MAX) as usize
+            + (self.trigger_on_descent.0 != u8::MAX) as usize
+            + (self.trigger_on_ascent.0 != u8::MAX) as usize
+            + (self.repeating.0 != u8::MAX) as usize
             + (self.speed != i32::MAX) as usize
     }
 }
@@ -209,7 +207,7 @@ impl From<DiveAlarm> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -233,7 +231,7 @@ impl From<DiveAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.enabled != typedef::Bool(u8::MAX) {
+        if m.enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BOOL,
@@ -241,7 +239,7 @@ impl From<DiveAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.alarm_type != typedef::DiveAlarmType(u8::MAX) {
+        if m.alarm_type.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DIVE_ALARM_TYPE,
@@ -249,7 +247,7 @@ impl From<DiveAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.sound != typedef::Tone(u8::MAX) {
+        if m.sound.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::TONE,
@@ -276,7 +274,7 @@ impl From<DiveAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.popup_enabled != typedef::Bool(u8::MAX) {
+        if m.popup_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::BOOL,
@@ -284,7 +282,7 @@ impl From<DiveAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.trigger_on_descent != typedef::Bool(u8::MAX) {
+        if m.trigger_on_descent.0 != u8::MAX {
             fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BOOL,
@@ -292,7 +290,7 @@ impl From<DiveAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.trigger_on_ascent != typedef::Bool(u8::MAX) {
+        if m.trigger_on_ascent.0 != u8::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
@@ -300,7 +298,7 @@ impl From<DiveAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.repeating != typedef::Bool(u8::MAX) {
+        if m.repeating.0 != u8::MAX {
             fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
+++ b/rustyfit/src/profile/mesgdef/dive_apnea_alarm.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -137,18 +135,18 @@ impl DiveApneaAlarm {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.depth != u32::MAX) as usize
             + (self.time != i32::MAX) as usize
-            + (self.enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.alarm_type != typedef::DiveAlarmType(u8::MAX)) as usize
-            + (self.sound != typedef::Tone(u8::MAX)) as usize
+            + (self.enabled.0 != u8::MAX) as usize
+            + (self.alarm_type.0 != u8::MAX) as usize
+            + (self.sound.0 != u8::MAX) as usize
             + (!self.dive_types.is_empty()) as usize
             + (self.id != u32::MAX) as usize
-            + (self.popup_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.trigger_on_descent != typedef::Bool(u8::MAX)) as usize
-            + (self.trigger_on_ascent != typedef::Bool(u8::MAX)) as usize
-            + (self.repeating != typedef::Bool(u8::MAX)) as usize
+            + (self.popup_enabled.0 != u8::MAX) as usize
+            + (self.trigger_on_descent.0 != u8::MAX) as usize
+            + (self.trigger_on_ascent.0 != u8::MAX) as usize
+            + (self.repeating.0 != u8::MAX) as usize
             + (self.speed != i32::MAX) as usize
     }
 }
@@ -209,7 +207,7 @@ impl From<DiveApneaAlarm> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -233,7 +231,7 @@ impl From<DiveApneaAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.enabled != typedef::Bool(u8::MAX) {
+        if m.enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BOOL,
@@ -241,7 +239,7 @@ impl From<DiveApneaAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.alarm_type != typedef::DiveAlarmType(u8::MAX) {
+        if m.alarm_type.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DIVE_ALARM_TYPE,
@@ -249,7 +247,7 @@ impl From<DiveApneaAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.sound != typedef::Tone(u8::MAX) {
+        if m.sound.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::TONE,
@@ -276,7 +274,7 @@ impl From<DiveApneaAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.popup_enabled != typedef::Bool(u8::MAX) {
+        if m.popup_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::BOOL,
@@ -284,7 +282,7 @@ impl From<DiveApneaAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.trigger_on_descent != typedef::Bool(u8::MAX) {
+        if m.trigger_on_descent.0 != u8::MAX {
             fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::BOOL,
@@ -292,7 +290,7 @@ impl From<DiveApneaAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.trigger_on_ascent != typedef::Bool(u8::MAX) {
+        if m.trigger_on_ascent.0 != u8::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
@@ -300,7 +298,7 @@ impl From<DiveApneaAlarm> for Message {
                 is_expanded: false,
             });
         };
-        if m.repeating != typedef::Bool(u8::MAX) {
+        if m.repeating.0 != u8::MAX {
             fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/dive_gas.rs
+++ b/rustyfit/src/profile/mesgdef/dive_gas.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -52,11 +50,11 @@ impl DiveGas {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.helium_content != u8::MAX) as usize
             + (self.oxygen_content != u8::MAX) as usize
-            + (self.status != typedef::DiveGasStatus(u8::MAX)) as usize
-            + (self.mode != typedef::DiveGasMode(u8::MAX)) as usize
+            + (self.status.0 != u8::MAX) as usize
+            + (self.mode.0 != u8::MAX) as usize
     }
 }
 
@@ -99,7 +97,7 @@ impl From<DiveGas> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -123,7 +121,7 @@ impl From<DiveGas> for Message {
                 is_expanded: false,
             });
         };
-        if m.status != typedef::DiveGasStatus(u8::MAX) {
+        if m.status.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DIVE_GAS_STATUS,
@@ -131,7 +129,7 @@ impl From<DiveGas> for Message {
                 is_expanded: false,
             });
         };
-        if m.mode != typedef::DiveGasMode(u8::MAX) {
+        if m.mode.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DIVE_GAS_MODE,

--- a/rustyfit/src/profile/mesgdef/dive_settings.rs
+++ b/rustyfit/src/profile/mesgdef/dive_settings.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -358,43 +356,41 @@ impl DiveSettings {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.message_index.0 != u16::MAX) as usize
             + (!self.name.is_empty()) as usize
-            + (self.model != typedef::TissueModelType(u8::MAX)) as usize
+            + (self.model.0 != u8::MAX) as usize
             + (self.gf_low != u8::MAX) as usize
             + (self.gf_high != u8::MAX) as usize
-            + (self.water_type != typedef::WaterType(u8::MAX)) as usize
+            + (self.water_type.0 != u8::MAX) as usize
             + (self.water_density.to_bits() != u32::MAX) as usize
             + (self.po2_warn != u8::MAX) as usize
             + (self.po2_critical != u8::MAX) as usize
             + (self.po2_deco != u8::MAX) as usize
-            + (self.safety_stop_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.safety_stop_enabled.0 != u8::MAX) as usize
             + (self.bottom_depth.to_bits() != u32::MAX) as usize
             + (self.bottom_time != u32::MAX) as usize
-            + (self.apnea_countdown_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.apnea_countdown_enabled.0 != u8::MAX) as usize
             + (self.apnea_countdown_time != u32::MAX) as usize
-            + (self.backlight_mode != typedef::DiveBacklightMode(u8::MAX)) as usize
+            + (self.backlight_mode.0 != u8::MAX) as usize
             + (self.backlight_brightness != u8::MAX) as usize
-            + (self.backlight_timeout != typedef::BacklightTimeout(u8::MAX)) as usize
+            + (self.backlight_timeout.0 != u8::MAX) as usize
             + (self.repeat_dive_interval != u16::MAX) as usize
             + (self.safety_stop_time != u16::MAX) as usize
-            + (self.heart_rate_source_type != typedef::SourceType(u8::MAX)) as usize
+            + (self.heart_rate_source_type.0 != u8::MAX) as usize
             + (self.heart_rate_source != u8::MAX) as usize
-            + (self.travel_gas != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.ccr_low_setpoint_switch_mode != typedef::CcrSetpointSwitchMode(u8::MAX))
-                as usize
+            + (self.travel_gas.0 != u16::MAX) as usize
+            + (self.ccr_low_setpoint_switch_mode.0 != u8::MAX) as usize
             + (self.ccr_low_setpoint != u8::MAX) as usize
             + (self.ccr_low_setpoint_depth != u32::MAX) as usize
-            + (self.ccr_high_setpoint_switch_mode != typedef::CcrSetpointSwitchMode(u8::MAX))
-                as usize
+            + (self.ccr_high_setpoint_switch_mode.0 != u8::MAX) as usize
             + (self.ccr_high_setpoint != u8::MAX) as usize
             + (self.ccr_high_setpoint_depth != u32::MAX) as usize
-            + (self.gas_consumption_display != typedef::GasConsumptionRateType(u8::MAX)) as usize
-            + (self.up_key_enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.dive_sounds != typedef::Tone(u8::MAX)) as usize
+            + (self.gas_consumption_display.0 != u8::MAX) as usize
+            + (self.up_key_enabled.0 != u8::MAX) as usize
+            + (self.dive_sounds.0 != u8::MAX) as usize
             + (self.last_stop_multiple != u8::MAX) as usize
-            + (self.no_fly_time_mode != typedef::NoFlyTimeMode(u8::MAX)) as usize
+            + (self.no_fly_time_mode.0 != u8::MAX) as usize
     }
 }
 
@@ -475,7 +471,7 @@ impl From<DiveSettings> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -483,7 +479,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -499,7 +495,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.model != typedef::TissueModelType(u8::MAX) {
+        if m.model.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::TISSUE_MODEL_TYPE,
@@ -523,7 +519,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.water_type != typedef::WaterType(u8::MAX) {
+        if m.water_type.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::WATER_TYPE,
@@ -563,7 +559,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.safety_stop_enabled != typedef::Bool(u8::MAX) {
+        if m.safety_stop_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
@@ -587,7 +583,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.apnea_countdown_enabled != typedef::Bool(u8::MAX) {
+        if m.apnea_countdown_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::BOOL,
@@ -603,7 +599,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.backlight_mode != typedef::DiveBacklightMode(u8::MAX) {
+        if m.backlight_mode.0 != u8::MAX {
             fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::DIVE_BACKLIGHT_MODE,
@@ -619,7 +615,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.backlight_timeout != typedef::BacklightTimeout(u8::MAX) {
+        if m.backlight_timeout.0 != u8::MAX {
             fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::BACKLIGHT_TIMEOUT,
@@ -643,7 +639,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.heart_rate_source_type != typedef::SourceType(u8::MAX) {
+        if m.heart_rate_source_type.0 != u8::MAX {
             fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::SOURCE_TYPE,
@@ -659,7 +655,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.travel_gas != typedef::MessageIndex(u16::MAX) {
+        if m.travel_gas.0 != u16::MAX {
             fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -667,7 +663,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.ccr_low_setpoint_switch_mode != typedef::CcrSetpointSwitchMode(u8::MAX) {
+        if m.ccr_low_setpoint_switch_mode.0 != u8::MAX {
             fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::CCR_SETPOINT_SWITCH_MODE,
@@ -691,7 +687,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.ccr_high_setpoint_switch_mode != typedef::CcrSetpointSwitchMode(u8::MAX) {
+        if m.ccr_high_setpoint_switch_mode.0 != u8::MAX {
             fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::CCR_SETPOINT_SWITCH_MODE,
@@ -715,7 +711,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.gas_consumption_display != typedef::GasConsumptionRateType(u8::MAX) {
+        if m.gas_consumption_display.0 != u8::MAX {
             fields.push(Field {
                 num: 29,
                 profile_type: ProfileType::GAS_CONSUMPTION_RATE_TYPE,
@@ -723,7 +719,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.up_key_enabled != typedef::Bool(u8::MAX) {
+        if m.up_key_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 30,
                 profile_type: ProfileType::BOOL,
@@ -731,7 +727,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.dive_sounds != typedef::Tone(u8::MAX) {
+        if m.dive_sounds.0 != u8::MAX {
             fields.push(Field {
                 num: 35,
                 profile_type: ProfileType::TONE,
@@ -747,7 +743,7 @@ impl From<DiveSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.no_fly_time_mode != typedef::NoFlyTimeMode(u8::MAX) {
+        if m.no_fly_time_mode.0 != u8::MAX {
             fields.push(Field {
                 num: 37,
                 profile_type: ProfileType::NO_FLY_TIME_MODE,

--- a/rustyfit/src/profile/mesgdef/dive_summary.rs
+++ b/rustyfit/src/profile/mesgdef/dive_summary.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -415,9 +413,9 @@ impl DiveSummary {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.reference_mesg != typedef::MesgNum(u16::MAX)) as usize
-            + (self.reference_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.reference_mesg.0 != u16::MAX) as usize
+            + (self.reference_index.0 != u16::MAX) as usize
             + (self.avg_depth != u32::MAX) as usize
             + (self.max_depth != u32::MAX) as usize
             + (self.surface_interval != u32::MAX) as usize
@@ -498,7 +496,7 @@ impl From<DiveSummary> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -506,7 +504,7 @@ impl From<DiveSummary> for Message {
                 is_expanded: false,
             });
         };
-        if m.reference_mesg != typedef::MesgNum(u16::MAX) {
+        if m.reference_mesg.0 != u16::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::MESG_NUM,
@@ -514,7 +512,7 @@ impl From<DiveSummary> for Message {
                 is_expanded: false,
             });
         };
-        if m.reference_index != typedef::MessageIndex(u16::MAX) {
+        if m.reference_index.0 != u16::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/event.rs
+++ b/rustyfit/src/profile/mesgdef/event.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -192,9 +192,9 @@ impl Event {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.event != typedef::Event(u8::MAX)) as usize
-            + (self.event_type != typedef::EventType(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.event.0 != u8::MAX) as usize
+            + (self.event_type.0 != u8::MAX) as usize
             + (self.data16 != u16::MAX) as usize
             + (self.data != u32::MAX) as usize
             + (self.event_group != u8::MAX) as usize
@@ -204,10 +204,10 @@ impl Event {
             + (self.front_gear != u8::MIN) as usize
             + (self.rear_gear_num != u8::MIN) as usize
             + (self.rear_gear != u8::MIN) as usize
-            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
-            + (self.activity_type != typedef::ActivityType(u8::MAX)) as usize
-            + (self.start_timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.radar_threat_level_max != typedef::RadarThreatLevelType(u8::MAX)) as usize
+            + (self.device_index.0 != u8::MAX) as usize
+            + (self.activity_type.0 != u8::MAX) as usize
+            + (self.start_timestamp.0 != u32::MAX) as usize
+            + (self.radar_threat_level_max.0 != u8::MAX) as usize
             + (self.radar_threat_count != u8::MAX) as usize
             + (self.radar_threat_avg_approach_speed != u8::MAX) as usize
             + (self.radar_threat_max_approach_speed != u8::MAX) as usize
@@ -273,7 +273,7 @@ impl From<Event> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -281,7 +281,7 @@ impl From<Event> for Message {
                 is_expanded: false,
             });
         };
-        if m.event != typedef::Event(u8::MAX) {
+        if m.event.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
@@ -289,7 +289,7 @@ impl From<Event> for Message {
                 is_expanded: false,
             });
         };
-        if m.event_type != typedef::EventType(u8::MAX) {
+        if m.event_type.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
@@ -369,7 +369,7 @@ impl From<Event> for Message {
                 is_expanded: is_expanded(&m.state, 12),
             });
         };
-        if m.device_index != typedef::DeviceIndex(u8::MAX) {
+        if m.device_index.0 != u8::MAX {
             fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::DEVICE_INDEX,
@@ -377,7 +377,7 @@ impl From<Event> for Message {
                 is_expanded: false,
             });
         };
-        if m.activity_type != typedef::ActivityType(u8::MAX) {
+        if m.activity_type.0 != u8::MAX {
             fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::ACTIVITY_TYPE,
@@ -385,7 +385,7 @@ impl From<Event> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_timestamp != typedef::DateTime(u32::MAX) {
+        if m.start_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::DATE_TIME,
@@ -393,7 +393,7 @@ impl From<Event> for Message {
                 is_expanded: false,
             });
         };
-        if m.radar_threat_level_max != typedef::RadarThreatLevelType(u8::MAX) {
+        if m.radar_threat_level_max.0 != u8::MAX {
             fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::RADAR_THREAT_LEVEL_TYPE,

--- a/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_concept_configuration.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -110,10 +110,10 @@ impl ExdDataConceptConfiguration {
             + (self.data_page != u8::MAX) as usize
             + (self.concept_key != u8::MAX) as usize
             + (self.scaling != u8::MAX) as usize
-            + (self.data_units != typedef::ExdDataUnits(u8::MAX)) as usize
-            + (self.qualifier != typedef::ExdQualifiers(u8::MAX)) as usize
-            + (self.descriptor != typedef::ExdDescriptors(u8::MAX)) as usize
-            + (self.is_signed != typedef::Bool(u8::MAX)) as usize
+            + (self.data_units.0 != u8::MAX) as usize
+            + (self.qualifier.0 != u8::MAX) as usize
+            + (self.descriptor.0 != u8::MAX) as usize
+            + (self.is_signed.0 != u8::MAX) as usize
     }
 }
 
@@ -224,7 +224,7 @@ impl From<ExdDataConceptConfiguration> for Message {
                 is_expanded: false,
             });
         };
-        if m.data_units != typedef::ExdDataUnits(u8::MAX) {
+        if m.data_units.0 != u8::MAX {
             fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::EXD_DATA_UNITS,
@@ -232,7 +232,7 @@ impl From<ExdDataConceptConfiguration> for Message {
                 is_expanded: false,
             });
         };
-        if m.qualifier != typedef::ExdQualifiers(u8::MAX) {
+        if m.qualifier.0 != u8::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::EXD_QUALIFIERS,
@@ -240,7 +240,7 @@ impl From<ExdDataConceptConfiguration> for Message {
                 is_expanded: false,
             });
         };
-        if m.descriptor != typedef::ExdDescriptors(u8::MAX) {
+        if m.descriptor.0 != u8::MAX {
             fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::EXD_DESCRIPTORS,
@@ -248,7 +248,7 @@ impl From<ExdDataConceptConfiguration> for Message {
                 is_expanded: false,
             });
         };
-        if m.is_signed != typedef::Bool(u8::MAX) {
+        if m.is_signed.0 != u8::MAX {
             fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_data_field_configuration.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -90,7 +90,7 @@ impl ExdDataFieldConfiguration {
             + (self.concept_field != u8::MAX) as usize
             + (self.field_id != u8::MAX) as usize
             + (self.concept_count != u8::MAX) as usize
-            + (self.display_type != typedef::ExdDisplayType(u8::MAX)) as usize
+            + (self.display_type.0 != u8::MAX) as usize
             + (self.title != [const { String::new() }; 32]) as usize
     }
 }
@@ -184,7 +184,7 @@ impl From<ExdDataFieldConfiguration> for Message {
                 is_expanded: is_expanded(&m.state, 3),
             });
         };
-        if m.display_type != typedef::ExdDisplayType(u8::MAX) {
+        if m.display_type.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::EXD_DISPLAY_TYPE,

--- a/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
+++ b/rustyfit/src/profile/mesgdef/exd_screen_configuration.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -49,8 +47,8 @@ impl ExdScreenConfiguration {
     fn count_valid_fields(&self) -> usize {
         (self.screen_index != u8::MAX) as usize
             + (self.field_count != u8::MAX) as usize
-            + (self.layout != typedef::ExdLayout(u8::MAX)) as usize
-            + (self.screen_enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.layout.0 != u8::MAX) as usize
+            + (self.screen_enabled.0 != u8::MAX) as usize
     }
 }
 
@@ -108,7 +106,7 @@ impl From<ExdScreenConfiguration> for Message {
                 is_expanded: false,
             });
         };
-        if m.layout != typedef::ExdLayout(u8::MAX) {
+        if m.layout.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::EXD_LAYOUT,
@@ -116,7 +114,7 @@ impl From<ExdScreenConfiguration> for Message {
                 is_expanded: false,
             });
         };
-        if m.screen_enabled != typedef::Bool(u8::MAX) {
+        if m.screen_enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/exercise_title.rs
+++ b/rustyfit/src/profile/mesgdef/exercise_title.rs
@@ -4,11 +4,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
-use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -48,8 +45,8 @@ impl ExerciseTitle {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.exercise_category != typedef::ExerciseCategory(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.exercise_category.0 != u16::MAX) as usize
             + (self.exercise_name != u16::MAX) as usize
             + (!self.wkt_step_name.is_empty()) as usize
     }
@@ -93,7 +90,7 @@ impl From<ExerciseTitle> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -101,7 +98,7 @@ impl From<ExerciseTitle> for Message {
                 is_expanded: false,
             });
         };
-        if m.exercise_category != typedef::ExerciseCategory(u16::MAX) {
+        if m.exercise_category.0 != u16::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EXERCISE_CATEGORY,

--- a/rustyfit/src/profile/mesgdef/field_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/field_capabilities.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -50,9 +48,9 @@ impl FieldCapabilities {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.file != typedef::File(u8::MAX)) as usize
-            + (self.mesg_num != typedef::MesgNum(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.file.0 != u8::MAX) as usize
+            + (self.mesg_num.0 != u16::MAX) as usize
             + (self.field_num != u8::MAX) as usize
             + (self.count != u16::MAX) as usize
     }
@@ -97,7 +95,7 @@ impl From<FieldCapabilities> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -105,7 +103,7 @@ impl From<FieldCapabilities> for Message {
                 is_expanded: false,
             });
         };
-        if m.file != typedef::File(u8::MAX) {
+        if m.file.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
@@ -113,7 +111,7 @@ impl From<FieldCapabilities> for Message {
                 is_expanded: false,
             });
         };
-        if m.mesg_num != typedef::MesgNum(u16::MAX) {
+        if m.mesg_num.0 != u16::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESG_NUM,

--- a/rustyfit/src/profile/mesgdef/field_description.rs
+++ b/rustyfit/src/profile/mesgdef/field_description.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -87,7 +85,7 @@ impl FieldDescription {
     fn count_valid_fields(&self) -> usize {
         (self.developer_data_index != u8::MAX) as usize
             + (self.field_definition_number != u8::MAX) as usize
-            + (self.fit_base_type_id != typedef::FitBaseType(u8::MAX)) as usize
+            + (self.fit_base_type_id.0 != u8::MAX) as usize
             + (!self.field_name.is_empty()) as usize
             + (self.array != u8::MAX) as usize
             + (!self.components.is_empty()) as usize
@@ -96,8 +94,8 @@ impl FieldDescription {
             + (!self.units.is_empty()) as usize
             + (!self.bits.is_empty()) as usize
             + (!self.accumulate.is_empty()) as usize
-            + (self.fit_base_unit_id != typedef::FitBaseUnit(u16::MAX)) as usize
-            + (self.native_mesg_num != typedef::MesgNum(u16::MAX)) as usize
+            + (self.fit_base_unit_id.0 != u16::MAX) as usize
+            + (self.native_mesg_num.0 != u16::MAX) as usize
             + (self.native_field_num != u8::MAX) as usize
     }
 }
@@ -165,7 +163,7 @@ impl From<FieldDescription> for Message {
                 is_expanded: false,
             });
         };
-        if m.fit_base_type_id != typedef::FitBaseType(u8::MAX) {
+        if m.fit_base_type_id.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::FIT_BASE_TYPE,
@@ -237,7 +235,7 @@ impl From<FieldDescription> for Message {
                 is_expanded: false,
             });
         };
-        if m.fit_base_unit_id != typedef::FitBaseUnit(u16::MAX) {
+        if m.fit_base_unit_id.0 != u16::MAX {
             fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::FIT_BASE_UNIT,
@@ -245,7 +243,7 @@ impl From<FieldDescription> for Message {
                 is_expanded: false,
             });
         };
-        if m.native_mesg_num != typedef::MesgNum(u16::MAX) {
+        if m.native_mesg_num.0 != u16::MAX {
             fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::MESG_NUM,

--- a/rustyfit/src/profile/mesgdef/file_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/file_capabilities.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -58,9 +56,9 @@ impl FileCapabilities {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.r#type != typedef::File(u8::MAX)) as usize
-            + (self.flags != typedef::FileFlags(u8::MIN)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.r#type.0 != u8::MAX) as usize
+            + (self.flags.0 != u8::MIN) as usize
             + (!self.directory.is_empty()) as usize
             + (self.max_count != u16::MAX) as usize
             + (self.max_size != u32::MAX) as usize
@@ -107,7 +105,7 @@ impl From<FileCapabilities> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -115,7 +113,7 @@ impl From<FileCapabilities> for Message {
                 is_expanded: false,
             });
         };
-        if m.r#type != typedef::File(u8::MAX) {
+        if m.r#type.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
@@ -123,7 +121,7 @@ impl From<FileCapabilities> for Message {
                 is_expanded: false,
             });
         };
-        if m.flags != typedef::FileFlags(u8::MIN) {
+        if m.flags.0 != u8::MIN {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::FILE_FLAGS,

--- a/rustyfit/src/profile/mesgdef/file_creator.rs
+++ b/rustyfit/src/profile/mesgdef/file_creator.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;

--- a/rustyfit/src/profile/mesgdef/file_id.rs
+++ b/rustyfit/src/profile/mesgdef/file_id.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -61,11 +59,11 @@ impl FileId {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.r#type != typedef::File(u8::MAX)) as usize
-            + (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+        (self.r#type.0 != u8::MAX) as usize
+            + (self.manufacturer.0 != u16::MAX) as usize
             + (self.product != u16::MAX) as usize
             + (self.serial_number != u32::MIN) as usize
-            + (self.time_created != typedef::DateTime(u32::MAX)) as usize
+            + (self.time_created.0 != u32::MAX) as usize
             + (self.number != u16::MAX) as usize
             + (!self.product_name.is_empty()) as usize
     }
@@ -111,7 +109,7 @@ impl From<FileId> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.r#type != typedef::File(u8::MAX) {
+        if m.r#type.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
@@ -119,7 +117,7 @@ impl From<FileId> for Message {
                 is_expanded: false,
             });
         };
-        if m.manufacturer != typedef::Manufacturer(u16::MAX) {
+        if m.manufacturer.0 != u16::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MANUFACTURER,
@@ -143,7 +141,7 @@ impl From<FileId> for Message {
                 is_expanded: false,
             });
         };
-        if m.time_created != typedef::DateTime(u32::MAX) {
+        if m.time_created.0 != u32::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/goal.rs
+++ b/rustyfit/src/profile/mesgdef/goal.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -82,19 +80,19 @@ impl Goal {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
-            + (self.start_date != typedef::DateTime(u32::MAX)) as usize
-            + (self.end_date != typedef::DateTime(u32::MAX)) as usize
-            + (self.r#type != typedef::Goal(u8::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.sport.0 != u8::MAX) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
+            + (self.start_date.0 != u32::MAX) as usize
+            + (self.end_date.0 != u32::MAX) as usize
+            + (self.r#type.0 != u8::MAX) as usize
             + (self.value != u32::MAX) as usize
-            + (self.repeat != typedef::Bool(u8::MAX)) as usize
+            + (self.repeat.0 != u8::MAX) as usize
             + (self.target_value != u32::MAX) as usize
-            + (self.recurrence != typedef::GoalRecurrence(u8::MAX)) as usize
+            + (self.recurrence.0 != u8::MAX) as usize
             + (self.recurrence_value != u16::MAX) as usize
-            + (self.enabled != typedef::Bool(u8::MAX)) as usize
-            + (self.source != typedef::GoalSource(u8::MAX)) as usize
+            + (self.enabled.0 != u8::MAX) as usize
+            + (self.source.0 != u8::MAX) as usize
     }
 }
 
@@ -145,7 +143,7 @@ impl From<Goal> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -153,7 +151,7 @@ impl From<Goal> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPORT,
@@ -161,7 +159,7 @@ impl From<Goal> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SUB_SPORT,
@@ -169,7 +167,7 @@ impl From<Goal> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_date != typedef::DateTime(u32::MAX) {
+        if m.start_date.0 != u32::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
@@ -177,7 +175,7 @@ impl From<Goal> for Message {
                 is_expanded: false,
             });
         };
-        if m.end_date != typedef::DateTime(u32::MAX) {
+        if m.end_date.0 != u32::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DATE_TIME,
@@ -185,7 +183,7 @@ impl From<Goal> for Message {
                 is_expanded: false,
             });
         };
-        if m.r#type != typedef::Goal(u8::MAX) {
+        if m.r#type.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::GOAL,
@@ -201,7 +199,7 @@ impl From<Goal> for Message {
                 is_expanded: false,
             });
         };
-        if m.repeat != typedef::Bool(u8::MAX) {
+        if m.repeat.0 != u8::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::BOOL,
@@ -217,7 +215,7 @@ impl From<Goal> for Message {
                 is_expanded: false,
             });
         };
-        if m.recurrence != typedef::GoalRecurrence(u8::MAX) {
+        if m.recurrence.0 != u8::MAX {
             fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::GOAL_RECURRENCE,
@@ -233,7 +231,7 @@ impl From<Goal> for Message {
                 is_expanded: false,
             });
         };
-        if m.enabled != typedef::Bool(u8::MAX) {
+        if m.enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::BOOL,
@@ -241,7 +239,7 @@ impl From<Goal> for Message {
                 is_expanded: false,
             });
         };
-        if m.source != typedef::GoalSource(u8::MAX) {
+        if m.source.0 != u8::MAX {
             fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::GOAL_SOURCE,

--- a/rustyfit/src/profile/mesgdef/gps_metadata.rs
+++ b/rustyfit/src/profile/mesgdef/gps_metadata.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use crate::semconv;
@@ -185,20 +183,20 @@ impl GpsMetadata {
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i16::MAX as f64 {
                 continue;
             }
-            self.velocity[i] = (unscaled as i16);
+            self.velocity[i] = unscaled as i16;
         }
         self
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (self.position_lat != i32::MAX) as usize
             + (self.position_long != i32::MAX) as usize
             + (self.enhanced_altitude != u32::MAX) as usize
             + (self.enhanced_speed != u32::MAX) as usize
             + (self.heading != u16::MAX) as usize
-            + (self.utc_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.utc_timestamp.0 != u32::MAX) as usize
             + (self.velocity != [i16::MAX; 3]) as usize
     }
 }
@@ -257,7 +255,7 @@ impl From<GpsMetadata> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -313,7 +311,7 @@ impl From<GpsMetadata> for Message {
                 is_expanded: false,
             });
         };
-        if m.utc_timestamp != typedef::DateTime(u32::MAX) {
+        if m.utc_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/gyroscope_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -75,7 +73,7 @@ impl GyroscopeData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (!self.sample_time_offset.is_empty()) as usize
             + (!self.gyro_x.is_empty()) as usize
@@ -130,7 +128,7 @@ impl From<GyroscopeData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hr.rs
+++ b/rustyfit/src/profile/mesgdef/hr.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -161,7 +161,7 @@ impl Hr {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.fractional_timestamp != u16::MAX) as usize
             + (self.time256 != u8::MAX) as usize
             + (!self.filtered_bpm.is_empty()) as usize
@@ -216,7 +216,7 @@ impl From<Hr> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hr_zone.rs
+++ b/rustyfit/src/profile/mesgdef/hr_zone.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -45,7 +43,7 @@ impl HrZone {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.high_bpm != u8::MAX) as usize
             + (!self.name.is_empty()) as usize
     }
@@ -88,7 +86,7 @@ impl From<HrZone> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/hrm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/hrm_profile.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -52,10 +50,10 @@ impl HrmProfile {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.enabled.0 != u8::MAX) as usize
             + (self.hrm_ant_id != u16::MIN) as usize
-            + (self.log_hrv != typedef::Bool(u8::MAX)) as usize
+            + (self.log_hrv.0 != u8::MAX) as usize
             + (self.hrm_ant_id_trans_type != u8::MIN) as usize
     }
 }
@@ -99,7 +97,7 @@ impl From<HrmProfile> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -107,7 +105,7 @@ impl From<HrmProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.enabled != typedef::Bool(u8::MAX) {
+        if m.enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::BOOL,
@@ -123,7 +121,7 @@ impl From<HrmProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.log_hrv != typedef::Bool(u8::MAX) {
+        if m.log_hrv.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/hrv.rs
+++ b/rustyfit/src/profile/mesgdef/hrv.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;

--- a/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_status_summary.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -194,14 +192,14 @@ impl HrvStatusSummary {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.weekly_average != u16::MAX) as usize
             + (self.last_night_average != u16::MAX) as usize
             + (self.last_night_5_min_high != u16::MAX) as usize
             + (self.baseline_low_upper != u16::MAX) as usize
             + (self.baseline_balanced_lower != u16::MAX) as usize
             + (self.baseline_balanced_upper != u16::MAX) as usize
-            + (self.status != typedef::HrvStatus(u8::MAX)) as usize
+            + (self.status.0 != u8::MAX) as usize
     }
 }
 
@@ -247,7 +245,7 @@ impl From<HrvStatusSummary> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -303,7 +301,7 @@ impl From<HrvStatusSummary> for Message {
                 is_expanded: false,
             });
         };
-        if m.status != typedef::HrvStatus(u8::MAX) {
+        if m.status.0 != u8::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::HRV_STATUS,

--- a/rustyfit/src/profile/mesgdef/hrv_value.rs
+++ b/rustyfit/src/profile/mesgdef/hrv_value.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -60,7 +58,7 @@ impl HrvValue {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize + (self.value != u16::MAX) as usize
+        (self.timestamp.0 != u32::MAX) as usize + (self.value != u16::MAX) as usize
     }
 }
 
@@ -100,7 +98,7 @@ impl From<HrvValue> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_accelerometer_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -158,7 +156,7 @@ impl HsaAccelerometerData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (self.sampling_interval != u16::MAX) as usize
             + (!self.accel_x.is_empty()) as usize
@@ -209,7 +207,7 @@ impl From<HsaAccelerometerData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_body_battery_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -55,7 +53,7 @@ impl HsaBodyBatteryData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.processing_interval != u16::MAX) as usize
             + (!self.level.is_empty()) as usize
             + (!self.charged.is_empty()) as usize
@@ -102,7 +100,7 @@ impl From<HsaBodyBatteryData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_configuration_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -45,7 +43,7 @@ impl HsaConfigurationData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (!self.data.is_empty()) as usize
             + (self.data_size != u8::MAX) as usize
     }
@@ -88,7 +86,7 @@ impl From<HsaConfigurationData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_event.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_event.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -40,8 +38,7 @@ impl HsaEvent {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.event_id != u8::MAX) as usize
+        (self.timestamp.0 != u32::MAX) as usize + (self.event_id != u8::MAX) as usize
     }
 }
 
@@ -81,7 +78,7 @@ impl From<HsaEvent> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_gyroscope_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -158,7 +156,7 @@ impl HsaGyroscopeData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (self.sampling_interval != u16::MAX) as usize
             + (!self.gyro_x.is_empty()) as usize
@@ -209,7 +207,7 @@ impl From<HsaGyroscopeData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_heart_rate_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -50,7 +48,7 @@ impl HsaHeartRateData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.processing_interval != u16::MAX) as usize
             + (self.status != u8::MAX) as usize
             + (!self.heart_rate.is_empty()) as usize
@@ -95,7 +93,7 @@ impl From<HsaHeartRateData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_respiration_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -76,7 +74,7 @@ impl HsaRespirationData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.processing_interval != u16::MAX) as usize
             + (!self.respiration_rate.is_empty()) as usize
     }
@@ -119,7 +117,7 @@ impl From<HsaRespirationData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_spo2_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -50,7 +48,7 @@ impl HsaSpo2Data {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.processing_interval != u16::MAX) as usize
             + (!self.reading_spo2.is_empty()) as usize
             + (!self.confidence.is_empty()) as usize
@@ -95,7 +93,7 @@ impl From<HsaSpo2Data> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_step_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_step_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -45,7 +43,7 @@ impl HsaStepData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.processing_interval != u16::MAX) as usize
             + (!self.steps.is_empty()) as usize
     }
@@ -88,7 +86,7 @@ impl From<HsaStepData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_stress_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -44,7 +42,7 @@ impl HsaStressData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.processing_interval != u16::MAX) as usize
             + (!self.stress_level.is_empty()) as usize
     }
@@ -87,7 +85,7 @@ impl From<HsaStressData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
+++ b/rustyfit/src/profile/mesgdef/hsa_wrist_temperature_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -76,7 +74,7 @@ impl HsaWristTemperatureData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.processing_interval != u16::MAX) as usize
             + (!self.value.is_empty()) as usize
     }
@@ -119,7 +117,7 @@ impl From<HsaWristTemperatureData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/jump.rs
+++ b/rustyfit/src/profile/mesgdef/jump.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -173,7 +173,7 @@ impl Jump {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.distance.to_bits() != u32::MAX) as usize
             + (self.height.to_bits() != u32::MAX) as usize
             + (self.rotations != u8::MAX) as usize
@@ -236,7 +236,7 @@ impl From<Jump> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/lap.rs
+++ b/rustyfit/src/profile/mesgdef/lap.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -2210,11 +2210,11 @@ impl Lap {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.event != typedef::Event(u8::MAX)) as usize
-            + (self.event_type != typedef::EventType(u8::MAX)) as usize
-            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.timestamp.0 != u32::MAX) as usize
+            + (self.event.0 != u8::MAX) as usize
+            + (self.event_type.0 != u8::MAX) as usize
+            + (self.start_time.0 != u32::MAX) as usize
             + (self.start_position_lat != i32::MAX) as usize
             + (self.start_position_long != i32::MAX) as usize
             + (self.end_position_lat != i32::MAX) as usize
@@ -2235,17 +2235,17 @@ impl Lap {
             + (self.max_power != u16::MAX) as usize
             + (self.total_ascent != u16::MAX) as usize
             + (self.total_descent != u16::MAX) as usize
-            + (self.intensity != typedef::Intensity(u8::MAX)) as usize
-            + (self.lap_trigger != typedef::LapTrigger(u8::MAX)) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.intensity.0 != u8::MAX) as usize
+            + (self.lap_trigger.0 != u8::MAX) as usize
+            + (self.sport.0 != u8::MAX) as usize
             + (self.event_group != u8::MAX) as usize
             + (self.num_lengths != u16::MAX) as usize
             + (self.normalized_power != u16::MAX) as usize
-            + (self.left_right_balance != typedef::LeftRightBalance100(u16::MAX)) as usize
+            + (self.left_right_balance.0 != u16::MAX) as usize
             + (self.first_length_index != u16::MAX) as usize
             + (self.avg_stroke_distance != u16::MAX) as usize
-            + (self.swim_stroke != typedef::SwimStroke(u8::MAX)) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.swim_stroke.0 != u8::MAX) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
             + (self.num_active_lengths != u16::MAX) as usize
             + (self.total_work != u32::MAX) as usize
             + (self.avg_altitude != u16::MAX) as usize
@@ -2271,7 +2271,7 @@ impl Lap {
             + (self.min_altitude != u16::MAX) as usize
             + (self.min_heart_rate != u8::MAX) as usize
             + (self.active_time != u32::MAX) as usize
-            + (self.wkt_step_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.wkt_step_index.0 != u16::MAX) as usize
             + (self.opponent_score != u16::MAX) as usize
             + (!self.stroke_count.is_empty()) as usize
             + (!self.zone_count.is_empty()) as usize
@@ -2506,7 +2506,7 @@ impl From<Lap> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -2514,7 +2514,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -2522,7 +2522,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.event != typedef::Event(u8::MAX) {
+        if m.event.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
@@ -2530,7 +2530,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.event_type != typedef::EventType(u8::MAX) {
+        if m.event_type.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
@@ -2538,7 +2538,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_time != typedef::DateTime(u32::MAX) {
+        if m.start_time.0 != u32::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
@@ -2706,7 +2706,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.intensity != typedef::Intensity(u8::MAX) {
+        if m.intensity.0 != u8::MAX {
             fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::INTENSITY,
@@ -2714,7 +2714,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.lap_trigger != typedef::LapTrigger(u8::MAX) {
+        if m.lap_trigger.0 != u8::MAX {
             fields.push(Field {
                 num: 24,
                 profile_type: ProfileType::LAP_TRIGGER,
@@ -2722,7 +2722,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 25,
                 profile_type: ProfileType::SPORT,
@@ -2754,7 +2754,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.left_right_balance != typedef::LeftRightBalance100(u16::MAX) {
+        if m.left_right_balance.0 != u16::MAX {
             fields.push(Field {
                 num: 34,
                 profile_type: ProfileType::LEFT_RIGHT_BALANCE_100,
@@ -2778,7 +2778,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.swim_stroke != typedef::SwimStroke(u8::MAX) {
+        if m.swim_stroke.0 != u8::MAX {
             fields.push(Field {
                 num: 38,
                 profile_type: ProfileType::SWIM_STROKE,
@@ -2786,7 +2786,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 39,
                 profile_type: ProfileType::SUB_SPORT,
@@ -2994,7 +2994,7 @@ impl From<Lap> for Message {
                 is_expanded: false,
             });
         };
-        if m.wkt_step_index != typedef::MessageIndex(u16::MAX) {
+        if m.wkt_step_index.0 != u16::MAX {
             fields.push(Field {
                 num: 71,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/length.rs
+++ b/rustyfit/src/profile/mesgdef/length.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -263,20 +263,20 @@ impl Length {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.event != typedef::Event(u8::MAX)) as usize
-            + (self.event_type != typedef::EventType(u8::MAX)) as usize
-            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.timestamp.0 != u32::MAX) as usize
+            + (self.event.0 != u8::MAX) as usize
+            + (self.event_type.0 != u8::MAX) as usize
+            + (self.start_time.0 != u32::MAX) as usize
             + (self.total_elapsed_time != u32::MAX) as usize
             + (self.total_timer_time != u32::MAX) as usize
             + (self.total_strokes != u16::MAX) as usize
             + (self.avg_speed != u16::MAX) as usize
-            + (self.swim_stroke != typedef::SwimStroke(u8::MAX)) as usize
+            + (self.swim_stroke.0 != u8::MAX) as usize
             + (self.avg_swimming_cadence != u8::MAX) as usize
             + (self.event_group != u8::MAX) as usize
             + (self.total_calories != u16::MAX) as usize
-            + (self.length_type != typedef::LengthType(u8::MAX)) as usize
+            + (self.length_type.0 != u8::MAX) as usize
             + (self.player_score != u16::MAX) as usize
             + (self.opponent_score != u16::MAX) as usize
             + (!self.stroke_count.is_empty()) as usize
@@ -350,7 +350,7 @@ impl From<Length> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -358,7 +358,7 @@ impl From<Length> for Message {
                 is_expanded: false,
             });
         };
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -366,7 +366,7 @@ impl From<Length> for Message {
                 is_expanded: false,
             });
         };
-        if m.event != typedef::Event(u8::MAX) {
+        if m.event.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
@@ -374,7 +374,7 @@ impl From<Length> for Message {
                 is_expanded: false,
             });
         };
-        if m.event_type != typedef::EventType(u8::MAX) {
+        if m.event_type.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
@@ -382,7 +382,7 @@ impl From<Length> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_time != typedef::DateTime(u32::MAX) {
+        if m.start_time.0 != u32::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
@@ -422,7 +422,7 @@ impl From<Length> for Message {
                 is_expanded: false,
             });
         };
-        if m.swim_stroke != typedef::SwimStroke(u8::MAX) {
+        if m.swim_stroke.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::SWIM_STROKE,
@@ -454,7 +454,7 @@ impl From<Length> for Message {
                 is_expanded: false,
             });
         };
-        if m.length_type != typedef::LengthType(u8::MAX) {
+        if m.length_type.0 != u8::MAX {
             fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::LENGTH_TYPE,

--- a/rustyfit/src/profile/mesgdef/magnetometer_data.rs
+++ b/rustyfit/src/profile/mesgdef/magnetometer_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -75,7 +73,7 @@ impl MagnetometerData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (!self.sample_time_offset.is_empty()) as usize
             + (!self.mag_x.is_empty()) as usize
@@ -130,7 +128,7 @@ impl From<MagnetometerData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/max_met_data.rs
+++ b/rustyfit/src/profile/mesgdef/max_met_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -88,14 +86,14 @@ impl MaxMetData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.update_time != typedef::DateTime(u32::MAX)) as usize
+        (self.update_time.0 != u32::MAX) as usize
             + (self.vo2_max != u16::MAX) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
-            + (self.max_met_category != typedef::MaxMetCategory(u8::MAX)) as usize
-            + (self.calibrated_data != typedef::Bool(u8::MAX)) as usize
-            + (self.hr_source != typedef::MaxMetHeartRateSource(u8::MAX)) as usize
-            + (self.speed_source != typedef::MaxMetSpeedSource(u8::MAX)) as usize
+            + (self.sport.0 != u8::MAX) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
+            + (self.max_met_category.0 != u8::MAX) as usize
+            + (self.calibrated_data.0 != u8::MAX) as usize
+            + (self.hr_source.0 != u8::MAX) as usize
+            + (self.speed_source.0 != u8::MAX) as usize
     }
 }
 
@@ -141,7 +139,7 @@ impl From<MaxMetData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.update_time != typedef::DateTime(u32::MAX) {
+        if m.update_time.0 != u32::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DATE_TIME,
@@ -157,7 +155,7 @@ impl From<MaxMetData> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SPORT,
@@ -165,7 +163,7 @@ impl From<MaxMetData> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::SUB_SPORT,
@@ -173,7 +171,7 @@ impl From<MaxMetData> for Message {
                 is_expanded: false,
             });
         };
-        if m.max_met_category != typedef::MaxMetCategory(u8::MAX) {
+        if m.max_met_category.0 != u8::MAX {
             fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::MAX_MET_CATEGORY,
@@ -181,7 +179,7 @@ impl From<MaxMetData> for Message {
                 is_expanded: false,
             });
         };
-        if m.calibrated_data != typedef::Bool(u8::MAX) {
+        if m.calibrated_data.0 != u8::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::BOOL,
@@ -189,7 +187,7 @@ impl From<MaxMetData> for Message {
                 is_expanded: false,
             });
         };
-        if m.hr_source != typedef::MaxMetHeartRateSource(u8::MAX) {
+        if m.hr_source.0 != u8::MAX {
             fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::MAX_MET_HEART_RATE_SOURCE,
@@ -197,7 +195,7 @@ impl From<MaxMetData> for Message {
                 is_expanded: false,
             });
         };
-        if m.speed_source != typedef::MaxMetSpeedSource(u8::MAX) {
+        if m.speed_source.0 != u8::MAX {
             fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::MAX_MET_SPEED_SOURCE,

--- a/rustyfit/src/profile/mesgdef/memo_glob.rs
+++ b/rustyfit/src/profile/mesgdef/memo_glob.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -62,8 +60,8 @@ impl MemoGlob {
     fn count_valid_fields(&self) -> usize {
         (self.part_index != u32::MAX) as usize
             + (!self.memo.is_empty()) as usize
-            + (self.mesg_num != typedef::MesgNum(u16::MAX)) as usize
-            + (self.parent_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.mesg_num.0 != u16::MAX) as usize
+            + (self.parent_index.0 != u16::MAX) as usize
             + (self.field_num != u8::MAX) as usize
             + (!self.data.is_empty()) as usize
     }
@@ -125,7 +123,7 @@ impl From<MemoGlob> for Message {
                 is_expanded: false,
             });
         };
-        if m.mesg_num != typedef::MesgNum(u16::MAX) {
+        if m.mesg_num.0 != u16::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESG_NUM,
@@ -133,7 +131,7 @@ impl From<MemoGlob> for Message {
                 is_expanded: false,
             });
         };
-        if m.parent_index != typedef::MessageIndex(u16::MAX) {
+        if m.parent_index.0 != u16::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
+++ b/rustyfit/src/profile/mesgdef/mesg_capabilities.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -50,10 +48,10 @@ impl MesgCapabilities {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.file != typedef::File(u8::MAX)) as usize
-            + (self.mesg_num != typedef::MesgNum(u16::MAX)) as usize
-            + (self.count_type != typedef::MesgCount(u8::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.file.0 != u8::MAX) as usize
+            + (self.mesg_num.0 != u16::MAX) as usize
+            + (self.count_type.0 != u8::MAX) as usize
             + (self.count != u16::MAX) as usize
     }
 }
@@ -97,7 +95,7 @@ impl From<MesgCapabilities> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -105,7 +103,7 @@ impl From<MesgCapabilities> for Message {
                 is_expanded: false,
             });
         };
-        if m.file != typedef::File(u8::MAX) {
+        if m.file.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
@@ -113,7 +111,7 @@ impl From<MesgCapabilities> for Message {
                 is_expanded: false,
             });
         };
-        if m.mesg_num != typedef::MesgNum(u16::MAX) {
+        if m.mesg_num.0 != u16::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESG_NUM,
@@ -121,7 +119,7 @@ impl From<MesgCapabilities> for Message {
                 is_expanded: false,
             });
         };
-        if m.count_type != typedef::MesgCount(u8::MAX) {
+        if m.count_type.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::MESG_COUNT,

--- a/rustyfit/src/profile/mesgdef/met_zone.rs
+++ b/rustyfit/src/profile/mesgdef/met_zone.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -90,7 +88,7 @@ impl MetZone {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.high_bpm != u8::MAX) as usize
             + (self.calories != u16::MAX) as usize
             + (self.fat_calories != u8::MAX) as usize
@@ -135,7 +133,7 @@ impl From<MetZone> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/monitoring.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -388,19 +388,19 @@ impl Monitoring {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.device_index.0 != u8::MAX) as usize
             + (self.calories != u16::MAX) as usize
             + (self.distance != u32::MAX) as usize
             + (self.cycles != u32::MAX) as usize
             + (self.active_time != u32::MAX) as usize
-            + (self.activity_type != typedef::ActivityType(u8::MAX)) as usize
-            + (self.activity_subtype != typedef::ActivitySubtype(u8::MAX)) as usize
-            + (self.activity_level != typedef::ActivityLevel(u8::MAX)) as usize
+            + (self.activity_type.0 != u8::MAX) as usize
+            + (self.activity_subtype.0 != u8::MAX) as usize
+            + (self.activity_level.0 != u8::MAX) as usize
             + (self.distance_16 != u16::MAX) as usize
             + (self.cycles_16 != u16::MAX) as usize
             + (self.active_time_16 != u16::MAX) as usize
-            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+            + (self.local_timestamp.0 != u32::MAX) as usize
             + (self.temperature != i16::MAX) as usize
             + (self.temperature_min != i16::MAX) as usize
             + (self.temperature_max != i16::MAX) as usize
@@ -500,7 +500,7 @@ impl From<Monitoring> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -508,7 +508,7 @@ impl From<Monitoring> for Message {
                 is_expanded: false,
             });
         };
-        if m.device_index != typedef::DeviceIndex(u8::MAX) {
+        if m.device_index.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DEVICE_INDEX,
@@ -548,7 +548,7 @@ impl From<Monitoring> for Message {
                 is_expanded: false,
             });
         };
-        if m.activity_type != typedef::ActivityType(u8::MAX) {
+        if m.activity_type.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::ACTIVITY_TYPE,
@@ -556,7 +556,7 @@ impl From<Monitoring> for Message {
                 is_expanded: is_expanded(&m.state, 5),
             });
         };
-        if m.activity_subtype != typedef::ActivitySubtype(u8::MAX) {
+        if m.activity_subtype.0 != u8::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::ACTIVITY_SUBTYPE,
@@ -564,7 +564,7 @@ impl From<Monitoring> for Message {
                 is_expanded: false,
             });
         };
-        if m.activity_level != typedef::ActivityLevel(u8::MAX) {
+        if m.activity_level.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::ACTIVITY_LEVEL,
@@ -596,7 +596,7 @@ impl From<Monitoring> for Message {
                 is_expanded: false,
             });
         };
-        if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
+        if m.local_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::LOCAL_DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_hr_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -45,7 +43,7 @@ impl MonitoringHrData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.resting_heart_rate != u8::MAX) as usize
             + (self.current_day_resting_heart_rate != u8::MAX) as usize
     }
@@ -88,7 +86,7 @@ impl From<MonitoringHrData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/monitoring_info.rs
+++ b/rustyfit/src/profile/mesgdef/monitoring_info.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -121,8 +119,8 @@ impl MonitoringInfo {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.local_timestamp.0 != u32::MAX) as usize
             + (!self.activity_type.is_empty()) as usize
             + (!self.cycles_to_distance.is_empty()) as usize
             + (!self.cycles_to_calories.is_empty()) as usize
@@ -179,7 +177,7 @@ impl From<MonitoringInfo> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -187,7 +185,7 @@ impl From<MonitoringInfo> for Message {
                 is_expanded: false,
             });
         };
-        if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
+        if m.local_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::LOCAL_DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/nap_event.rs
+++ b/rustyfit/src/profile/mesgdef/nap_event.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -75,16 +73,16 @@ impl NapEvent {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.timestamp.0 != u32::MAX) as usize
+            + (self.start_time.0 != u32::MAX) as usize
             + (self.start_timezone_offset != i16::MAX) as usize
-            + (self.end_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.end_time.0 != u32::MAX) as usize
             + (self.end_timezone_offset != i16::MAX) as usize
-            + (self.feedback != typedef::NapPeriodFeedback(u8::MAX)) as usize
-            + (self.is_deleted != typedef::Bool(u8::MAX)) as usize
-            + (self.source != typedef::NapSource(u8::MAX)) as usize
-            + (self.update_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.feedback.0 != u8::MAX) as usize
+            + (self.is_deleted.0 != u8::MAX) as usize
+            + (self.source.0 != u8::MAX) as usize
+            + (self.update_timestamp.0 != u32::MAX) as usize
     }
 }
 
@@ -132,7 +130,7 @@ impl From<NapEvent> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -140,7 +138,7 @@ impl From<NapEvent> for Message {
                 is_expanded: false,
             });
         };
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -148,7 +146,7 @@ impl From<NapEvent> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_time != typedef::DateTime(u32::MAX) {
+        if m.start_time.0 != u32::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::DATE_TIME,
@@ -164,7 +162,7 @@ impl From<NapEvent> for Message {
                 is_expanded: false,
             });
         };
-        if m.end_time != typedef::DateTime(u32::MAX) {
+        if m.end_time.0 != u32::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
@@ -180,7 +178,7 @@ impl From<NapEvent> for Message {
                 is_expanded: false,
             });
         };
-        if m.feedback != typedef::NapPeriodFeedback(u8::MAX) {
+        if m.feedback.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::NAP_PERIOD_FEEDBACK,
@@ -188,7 +186,7 @@ impl From<NapEvent> for Message {
                 is_expanded: false,
             });
         };
-        if m.is_deleted != typedef::Bool(u8::MAX) {
+        if m.is_deleted.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::BOOL,
@@ -196,7 +194,7 @@ impl From<NapEvent> for Message {
                 is_expanded: false,
             });
         };
-        if m.source != typedef::NapSource(u8::MAX) {
+        if m.source.0 != u8::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::NAP_SOURCE,
@@ -204,7 +202,7 @@ impl From<NapEvent> for Message {
                 is_expanded: false,
             });
         };
-        if m.update_timestamp != typedef::DateTime(u32::MAX) {
+        if m.update_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/nmea_sentence.rs
+++ b/rustyfit/src/profile/mesgdef/nmea_sentence.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -47,7 +45,7 @@ impl NmeaSentence {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (!self.sentence.is_empty()) as usize
     }
@@ -90,7 +88,7 @@ impl From<NmeaSentence> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/obdii_data.rs
+++ b/rustyfit/src/profile/mesgdef/obdii_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -75,14 +73,14 @@ impl ObdiiData {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (!self.time_offset.is_empty()) as usize
             + (self.pid != u8::MAX) as usize
             + (!self.raw_data.is_empty()) as usize
             + (!self.pid_data_size.is_empty()) as usize
             + (!self.system_time.is_empty()) as usize
-            + (self.start_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_timestamp.0 != u32::MAX) as usize
             + (self.start_timestamp_ms != u16::MAX) as usize
     }
 }
@@ -130,7 +128,7 @@ impl From<ObdiiData> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -186,7 +184,7 @@ impl From<ObdiiData> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_timestamp != typedef::DateTime(u32::MAX) {
+        if m.start_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/ohr_settings.rs
+++ b/rustyfit/src/profile/mesgdef/ohr_settings.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -39,8 +37,7 @@ impl OhrSettings {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.enabled != typedef::Switch(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize + (self.enabled.0 != u8::MAX) as usize
     }
 }
 
@@ -80,7 +77,7 @@ impl From<OhrSettings> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -88,7 +85,7 @@ impl From<OhrSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.enabled != typedef::Switch(u8::MAX) {
+        if m.enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SWITCH,

--- a/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/one_d_sensor_calibration.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -60,8 +58,8 @@ impl OneDSensorCalibration {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.sensor_type != typedef::SensorType(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.sensor_type.0 != u8::MAX) as usize
             + (self.calibration_factor != u32::MAX) as usize
             + (self.calibration_divisor != u32::MAX) as usize
             + (self.level_shift != u32::MAX) as usize
@@ -109,7 +107,7 @@ impl From<OneDSensorCalibration> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -117,7 +115,7 @@ impl From<OneDSensorCalibration> for Message {
                 is_expanded: false,
             });
         };
-        if m.sensor_type != typedef::SensorType(u8::MAX) {
+        if m.sensor_type.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SENSOR_TYPE,

--- a/rustyfit/src/profile/mesgdef/power_zone.rs
+++ b/rustyfit/src/profile/mesgdef/power_zone.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -45,7 +43,7 @@ impl PowerZone {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.high_value != u16::MAX) as usize
             + (!self.name.is_empty()) as usize
     }
@@ -88,7 +86,7 @@ impl From<PowerZone> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/raw_bbi.rs
+++ b/rustyfit/src/profile/mesgdef/raw_bbi.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -88,7 +88,7 @@ impl RawBbi {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (!self.data.is_empty()) as usize
             + (!self.time.is_empty()) as usize
@@ -143,7 +143,7 @@ impl From<RawBbi> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/record.rs
+++ b/rustyfit/src/profile/mesgdef/record.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -1532,7 +1532,7 @@ impl Record {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.position_lat != i32::MAX) as usize
             + (self.position_long != i32::MAX) as usize
             + (self.altitude != u16::MAX) as usize
@@ -1552,21 +1552,21 @@ impl Record {
             + (self.total_cycles != u32::MAX) as usize
             + (self.compressed_accumulated_power != u16::MAX) as usize
             + (self.accumulated_power != u32::MAX) as usize
-            + (self.left_right_balance != typedef::LeftRightBalance(u8::MAX)) as usize
+            + (self.left_right_balance.0 != u8::MAX) as usize
             + (self.gps_accuracy != u8::MAX) as usize
             + (self.vertical_speed != i16::MAX) as usize
             + (self.calories != u16::MAX) as usize
             + (self.vertical_oscillation != u16::MAX) as usize
             + (self.stance_time_percent != u16::MAX) as usize
             + (self.stance_time != u16::MAX) as usize
-            + (self.activity_type != typedef::ActivityType(u8::MAX)) as usize
+            + (self.activity_type.0 != u8::MAX) as usize
             + (self.left_torque_effectiveness != u8::MAX) as usize
             + (self.right_torque_effectiveness != u8::MAX) as usize
             + (self.left_pedal_smoothness != u8::MAX) as usize
             + (self.right_pedal_smoothness != u8::MAX) as usize
             + (self.combined_pedal_smoothness != u8::MAX) as usize
             + (self.time128 != u8::MAX) as usize
-            + (self.stroke_type != typedef::StrokeType(u8::MAX)) as usize
+            + (self.stroke_type.0 != u8::MAX) as usize
             + (self.zone != u8::MAX) as usize
             + (self.ball_speed != u16::MAX) as usize
             + (self.cadence256 != u16::MAX) as usize
@@ -1577,7 +1577,7 @@ impl Record {
             + (self.saturated_hemoglobin_percent != u16::MAX) as usize
             + (self.saturated_hemoglobin_percent_min != u16::MAX) as usize
             + (self.saturated_hemoglobin_percent_max != u16::MAX) as usize
-            + (self.device_index != typedef::DeviceIndex(u8::MAX)) as usize
+            + (self.device_index.0 != u8::MAX) as usize
             + (self.left_pco != i8::MAX) as usize
             + (self.right_pco != i8::MAX) as usize
             + (!self.left_power_phase.is_empty()) as usize
@@ -1759,7 +1759,7 @@ impl From<Record> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -1919,7 +1919,7 @@ impl From<Record> for Message {
                 is_expanded: is_expanded(&m.state, 29),
             });
         };
-        if m.left_right_balance != typedef::LeftRightBalance(u8::MAX) {
+        if m.left_right_balance.0 != u8::MAX {
             fields.push(Field {
                 num: 30,
                 profile_type: ProfileType::LEFT_RIGHT_BALANCE,
@@ -1975,7 +1975,7 @@ impl From<Record> for Message {
                 is_expanded: false,
             });
         };
-        if m.activity_type != typedef::ActivityType(u8::MAX) {
+        if m.activity_type.0 != u8::MAX {
             fields.push(Field {
                 num: 42,
                 profile_type: ProfileType::ACTIVITY_TYPE,
@@ -2031,7 +2031,7 @@ impl From<Record> for Message {
                 is_expanded: false,
             });
         };
-        if m.stroke_type != typedef::StrokeType(u8::MAX) {
+        if m.stroke_type.0 != u8::MAX {
             fields.push(Field {
                 num: 49,
                 profile_type: ProfileType::STROKE_TYPE,
@@ -2119,7 +2119,7 @@ impl From<Record> for Message {
                 is_expanded: false,
             });
         };
-        if m.device_index != typedef::DeviceIndex(u8::MAX) {
+        if m.device_index.0 != u8::MAX {
             fields.push(Field {
                 num: 62,
                 profile_type: ProfileType::DEVICE_INDEX,

--- a/rustyfit/src/profile/mesgdef/respiration_rate.rs
+++ b/rustyfit/src/profile/mesgdef/respiration_rate.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -60,8 +58,7 @@ impl RespirationRate {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.respiration_rate != i16::MAX) as usize
+        (self.timestamp.0 != u32::MAX) as usize + (self.respiration_rate != i16::MAX) as usize
     }
 }
 
@@ -101,7 +98,7 @@ impl From<RespirationRate> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/schedule.rs
+++ b/rustyfit/src/profile/mesgdef/schedule.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -63,13 +61,13 @@ impl Schedule {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+        (self.manufacturer.0 != u16::MAX) as usize
             + (self.product != u16::MAX) as usize
             + (self.serial_number != u32::MIN) as usize
-            + (self.time_created != typedef::DateTime(u32::MAX)) as usize
-            + (self.completed != typedef::Bool(u8::MAX)) as usize
-            + (self.r#type != typedef::Schedule(u8::MAX)) as usize
-            + (self.scheduled_time != typedef::LocalDateTime(u32::MAX)) as usize
+            + (self.time_created.0 != u32::MAX) as usize
+            + (self.completed.0 != u8::MAX) as usize
+            + (self.r#type.0 != u8::MAX) as usize
+            + (self.scheduled_time.0 != u32::MAX) as usize
     }
 }
 
@@ -114,7 +112,7 @@ impl From<Schedule> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.manufacturer != typedef::Manufacturer(u16::MAX) {
+        if m.manufacturer.0 != u16::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::MANUFACTURER,
@@ -138,7 +136,7 @@ impl From<Schedule> for Message {
                 is_expanded: false,
             });
         };
-        if m.time_created != typedef::DateTime(u32::MAX) {
+        if m.time_created.0 != u32::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DATE_TIME,
@@ -146,7 +144,7 @@ impl From<Schedule> for Message {
                 is_expanded: false,
             });
         };
-        if m.completed != typedef::Bool(u8::MAX) {
+        if m.completed.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::BOOL,
@@ -154,7 +152,7 @@ impl From<Schedule> for Message {
                 is_expanded: false,
             });
         };
-        if m.r#type != typedef::Schedule(u8::MAX) {
+        if m.r#type.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SCHEDULE,
@@ -162,7 +160,7 @@ impl From<Schedule> for Message {
                 is_expanded: false,
             });
         };
-        if m.scheduled_time != typedef::LocalDateTime(u32::MAX) {
+        if m.scheduled_time.0 != u32::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::LOCAL_DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/sdm_profile.rs
+++ b/rustyfit/src/profile/mesgdef/sdm_profile.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -110,12 +108,12 @@ impl SdmProfile {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.enabled.0 != u8::MAX) as usize
             + (self.sdm_ant_id != u16::MIN) as usize
             + (self.sdm_cal_factor != u16::MAX) as usize
             + (self.odometer != u32::MAX) as usize
-            + (self.speed_source != typedef::Bool(u8::MAX)) as usize
+            + (self.speed_source.0 != u8::MAX) as usize
             + (self.sdm_ant_id_trans_type != u8::MIN) as usize
             + (self.odometer_rollover != u8::MAX) as usize
     }
@@ -163,7 +161,7 @@ impl From<SdmProfile> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -171,7 +169,7 @@ impl From<SdmProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.enabled != typedef::Bool(u8::MAX) {
+        if m.enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::BOOL,
@@ -203,7 +201,7 @@ impl From<SdmProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.speed_source != typedef::Bool(u8::MAX) {
+        if m.speed_source.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/segment_file.rs
+++ b/rustyfit/src/profile/mesgdef/segment_file.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -76,9 +74,9 @@ impl SegmentFile {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (!self.file_uuid.is_empty()) as usize
-            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.enabled.0 != u8::MAX) as usize
             + (self.user_profile_primary_key != u32::MAX) as usize
             + (!self.leader_type.is_empty()) as usize
             + (!self.leader_group_primary_key.is_empty()) as usize
@@ -140,7 +138,7 @@ impl From<SegmentFile> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -156,7 +154,7 @@ impl From<SegmentFile> for Message {
                 is_expanded: false,
             });
         };
-        if m.enabled != typedef::Bool(u8::MAX) {
+        if m.enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::BOOL,

--- a/rustyfit/src/profile/mesgdef/segment_id.rs
+++ b/rustyfit/src/profile/mesgdef/segment_id.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -79,13 +77,13 @@ impl SegmentId {
     fn count_valid_fields(&self) -> usize {
         (!self.name.is_empty()) as usize
             + (!self.uuid.is_empty()) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
-            + (self.enabled != typedef::Bool(u8::MAX)) as usize
+            + (self.sport.0 != u8::MAX) as usize
+            + (self.enabled.0 != u8::MAX) as usize
             + (self.user_profile_primary_key != u32::MAX) as usize
             + (self.device_id != u32::MAX) as usize
             + (self.default_race_leader != u8::MAX) as usize
-            + (self.delete_status != typedef::SegmentDeleteStatus(u8::MAX)) as usize
-            + (self.selection_type != typedef::SegmentSelectionType(u8::MAX)) as usize
+            + (self.delete_status.0 != u8::MAX) as usize
+            + (self.selection_type.0 != u8::MAX) as usize
     }
 }
 
@@ -148,7 +146,7 @@ impl From<SegmentId> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SPORT,
@@ -156,7 +154,7 @@ impl From<SegmentId> for Message {
                 is_expanded: false,
             });
         };
-        if m.enabled != typedef::Bool(u8::MAX) {
+        if m.enabled.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::BOOL,
@@ -188,7 +186,7 @@ impl From<SegmentId> for Message {
                 is_expanded: false,
             });
         };
-        if m.delete_status != typedef::SegmentDeleteStatus(u8::MAX) {
+        if m.delete_status.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::SEGMENT_DELETE_STATUS,
@@ -196,7 +194,7 @@ impl From<SegmentId> for Message {
                 is_expanded: false,
             });
         };
-        if m.selection_type != typedef::SegmentSelectionType(u8::MAX) {
+        if m.selection_type.0 != u8::MAX {
             fields.push(Field {
                 num: 8,
                 profile_type: ProfileType::SEGMENT_SELECTION_TYPE,

--- a/rustyfit/src/profile/mesgdef/segment_lap.rs
+++ b/rustyfit/src/profile/mesgdef/segment_lap.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -1550,11 +1550,11 @@ impl SegmentLap {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.event != typedef::Event(u8::MAX)) as usize
-            + (self.event_type != typedef::EventType(u8::MAX)) as usize
-            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.timestamp.0 != u32::MAX) as usize
+            + (self.event.0 != u8::MAX) as usize
+            + (self.event_type.0 != u8::MAX) as usize
+            + (self.start_time.0 != u32::MAX) as usize
             + (self.start_position_lat != i32::MAX) as usize
             + (self.start_position_long != i32::MAX) as usize
             + (self.end_position_lat != i32::MAX) as usize
@@ -1575,7 +1575,7 @@ impl SegmentLap {
             + (self.max_power != u16::MAX) as usize
             + (self.total_ascent != u16::MAX) as usize
             + (self.total_descent != u16::MAX) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.sport.0 != u8::MAX) as usize
             + (self.event_group != u8::MAX) as usize
             + (self.nec_lat != i32::MAX) as usize
             + (self.nec_long != i32::MAX) as usize
@@ -1583,8 +1583,8 @@ impl SegmentLap {
             + (self.swc_long != i32::MAX) as usize
             + (!self.name.is_empty()) as usize
             + (self.normalized_power != u16::MAX) as usize
-            + (self.left_right_balance != typedef::LeftRightBalance100(u16::MAX)) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.left_right_balance.0 != u16::MAX) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
             + (self.total_work != u32::MAX) as usize
             + (self.avg_altitude != u16::MAX) as usize
             + (self.max_altitude != u16::MAX) as usize
@@ -1609,14 +1609,14 @@ impl SegmentLap {
             + (self.min_altitude != u16::MAX) as usize
             + (self.min_heart_rate != u8::MAX) as usize
             + (self.active_time != u32::MAX) as usize
-            + (self.wkt_step_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.sport_event != typedef::SportEvent(u8::MAX)) as usize
+            + (self.wkt_step_index.0 != u16::MAX) as usize
+            + (self.sport_event.0 != u8::MAX) as usize
             + (self.avg_left_torque_effectiveness != u8::MAX) as usize
             + (self.avg_right_torque_effectiveness != u8::MAX) as usize
             + (self.avg_left_pedal_smoothness != u8::MAX) as usize
             + (self.avg_right_pedal_smoothness != u8::MAX) as usize
             + (self.avg_combined_pedal_smoothness != u8::MAX) as usize
-            + (self.status != typedef::SegmentLapStatus(u8::MAX)) as usize
+            + (self.status.0 != u8::MAX) as usize
             + (!self.uuid.is_empty()) as usize
             + (self.avg_fractional_cadence != u8::MAX) as usize
             + (self.max_fractional_cadence != u8::MAX) as usize
@@ -1635,7 +1635,7 @@ impl SegmentLap {
             + (!self.max_power_position.is_empty()) as usize
             + (!self.avg_cadence_position.is_empty()) as usize
             + (!self.max_cadence_position.is_empty()) as usize
-            + (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+            + (self.manufacturer.0 != u16::MAX) as usize
             + (self.total_grit.to_bits() != u32::MAX) as usize
             + (self.total_flow.to_bits() != u32::MAX) as usize
             + (self.avg_grit.to_bits() != u32::MAX) as usize
@@ -1783,7 +1783,7 @@ impl From<SegmentLap> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -1791,7 +1791,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -1799,7 +1799,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.event != typedef::Event(u8::MAX) {
+        if m.event.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
@@ -1807,7 +1807,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.event_type != typedef::EventType(u8::MAX) {
+        if m.event_type.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
@@ -1815,7 +1815,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_time != typedef::DateTime(u32::MAX) {
+        if m.start_time.0 != u32::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
@@ -1983,7 +1983,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 23,
                 profile_type: ProfileType::SPORT,
@@ -2047,7 +2047,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.left_right_balance != typedef::LeftRightBalance100(u16::MAX) {
+        if m.left_right_balance.0 != u16::MAX {
             fields.push(Field {
                 num: 31,
                 profile_type: ProfileType::LEFT_RIGHT_BALANCE_100,
@@ -2055,7 +2055,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 32,
                 profile_type: ProfileType::SUB_SPORT,
@@ -2255,7 +2255,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.wkt_step_index != typedef::MessageIndex(u16::MAX) {
+        if m.wkt_step_index.0 != u16::MAX {
             fields.push(Field {
                 num: 57,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -2263,7 +2263,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport_event != typedef::SportEvent(u8::MAX) {
+        if m.sport_event.0 != u8::MAX {
             fields.push(Field {
                 num: 58,
                 profile_type: ProfileType::SPORT_EVENT,
@@ -2311,7 +2311,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.status != typedef::SegmentLapStatus(u8::MAX) {
+        if m.status.0 != u8::MAX {
             fields.push(Field {
                 num: 64,
                 profile_type: ProfileType::SEGMENT_LAP_STATUS,
@@ -2463,7 +2463,7 @@ impl From<SegmentLap> for Message {
                 is_expanded: false,
             });
         };
-        if m.manufacturer != typedef::Manufacturer(u16::MAX) {
+        if m.manufacturer.0 != u16::MAX {
             fields.push(Field {
                 num: 83,
                 profile_type: ProfileType::MANUFACTURER,

--- a/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
+++ b/rustyfit/src/profile/mesgdef/segment_leaderboard_entry.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -87,9 +85,9 @@ impl SegmentLeaderboardEntry {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (!self.name.is_empty()) as usize
-            + (self.r#type != typedef::SegmentLeaderboardType(u8::MAX)) as usize
+            + (self.r#type.0 != u8::MAX) as usize
             + (self.group_primary_key != u32::MAX) as usize
             + (self.activity_id != u32::MAX) as usize
             + (self.segment_time != u32::MAX) as usize
@@ -138,7 +136,7 @@ impl From<SegmentLeaderboardEntry> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -154,7 +152,7 @@ impl From<SegmentLeaderboardEntry> for Message {
                 is_expanded: false,
             });
         };
-        if m.r#type != typedef::SegmentLeaderboardType(u8::MAX) {
+        if m.r#type.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SEGMENT_LEADERBOARD_TYPE,

--- a/rustyfit/src/profile/mesgdef/segment_point.rs
+++ b/rustyfit/src/profile/mesgdef/segment_point.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -210,7 +210,7 @@ impl SegmentPoint {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.position_lat != i32::MAX) as usize
             + (self.position_long != i32::MAX) as usize
             + (self.distance != u32::MAX) as usize
@@ -267,7 +267,7 @@ impl From<SegmentPoint> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/session.rs
+++ b/rustyfit/src/profile/mesgdef/session.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
+#![allow(clippy::manual_range_patterns)]
 
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
@@ -2651,15 +2651,15 @@ impl Session {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.event != typedef::Event(u8::MAX)) as usize
-            + (self.event_type != typedef::EventType(u8::MAX)) as usize
-            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.timestamp.0 != u32::MAX) as usize
+            + (self.event.0 != u8::MAX) as usize
+            + (self.event_type.0 != u8::MAX) as usize
+            + (self.start_time.0 != u32::MAX) as usize
             + (self.start_position_lat != i32::MAX) as usize
             + (self.start_position_long != i32::MAX) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.sport.0 != u8::MAX) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
             + (self.total_elapsed_time != u32::MAX) as usize
             + (self.total_timer_time != u32::MAX) as usize
             + (self.total_distance != u32::MAX) as usize
@@ -2680,7 +2680,7 @@ impl Session {
             + (self.first_lap_index != u16::MAX) as usize
             + (self.num_laps != u16::MAX) as usize
             + (self.event_group != u8::MAX) as usize
-            + (self.trigger != typedef::SessionTrigger(u8::MAX)) as usize
+            + (self.trigger.0 != u8::MAX) as usize
             + (self.nec_lat != i32::MAX) as usize
             + (self.nec_long != i32::MAX) as usize
             + (self.swc_lat != i32::MAX) as usize
@@ -2689,15 +2689,15 @@ impl Session {
             + (self.normalized_power != u16::MAX) as usize
             + (self.training_stress_score != u16::MAX) as usize
             + (self.intensity_factor != u16::MAX) as usize
-            + (self.left_right_balance != typedef::LeftRightBalance100(u16::MAX)) as usize
+            + (self.left_right_balance.0 != u16::MAX) as usize
             + (self.end_position_lat != i32::MAX) as usize
             + (self.end_position_long != i32::MAX) as usize
             + (self.avg_stroke_count != u32::MAX) as usize
             + (self.avg_stroke_distance != u16::MAX) as usize
-            + (self.swim_stroke != typedef::SwimStroke(u8::MAX)) as usize
+            + (self.swim_stroke.0 != u8::MAX) as usize
             + (self.pool_length != u16::MAX) as usize
             + (self.threshold_power != u16::MAX) as usize
-            + (self.pool_length_unit != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.pool_length_unit.0 != u8::MAX) as usize
             + (self.num_active_lengths != u16::MAX) as usize
             + (self.total_work != u32::MAX) as usize
             + (self.avg_altitude != u16::MAX) as usize
@@ -3015,7 +3015,7 @@ impl From<Session> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -3023,7 +3023,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -3031,7 +3031,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.event != typedef::Event(u8::MAX) {
+        if m.event.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::EVENT,
@@ -3039,7 +3039,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.event_type != typedef::EventType(u8::MAX) {
+        if m.event_type.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::EVENT_TYPE,
@@ -3047,7 +3047,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_time != typedef::DateTime(u32::MAX) {
+        if m.start_time.0 != u32::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
@@ -3071,7 +3071,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SPORT,
@@ -3079,7 +3079,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::SUB_SPORT,
@@ -3247,7 +3247,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.trigger != typedef::SessionTrigger(u8::MAX) {
+        if m.trigger.0 != u8::MAX {
             fields.push(Field {
                 num: 28,
                 profile_type: ProfileType::SESSION_TRIGGER,
@@ -3319,7 +3319,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.left_right_balance != typedef::LeftRightBalance100(u16::MAX) {
+        if m.left_right_balance.0 != u16::MAX {
             fields.push(Field {
                 num: 37,
                 profile_type: ProfileType::LEFT_RIGHT_BALANCE_100,
@@ -3359,7 +3359,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.swim_stroke != typedef::SwimStroke(u8::MAX) {
+        if m.swim_stroke.0 != u8::MAX {
             fields.push(Field {
                 num: 43,
                 profile_type: ProfileType::SWIM_STROKE,
@@ -3383,7 +3383,7 @@ impl From<Session> for Message {
                 is_expanded: false,
             });
         };
-        if m.pool_length_unit != typedef::DisplayMeasure(u8::MAX) {
+        if m.pool_length_unit.0 != u8::MAX {
             fields.push(Field {
                 num: 46,
                 profile_type: ProfileType::DISPLAY_MEASURE,

--- a/rustyfit/src/profile/mesgdef/set.rs
+++ b/rustyfit/src/profile/mesgdef/set.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -122,17 +120,17 @@ impl Set {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.duration != u32::MAX) as usize
             + (self.repetitions != u16::MAX) as usize
             + (self.weight != u16::MAX) as usize
-            + (self.set_type != typedef::SetType(u8::MAX)) as usize
-            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.set_type.0 != u8::MAX) as usize
+            + (self.start_time.0 != u32::MAX) as usize
             + (!self.category.is_empty()) as usize
             + (!self.category_subtype.is_empty()) as usize
-            + (self.weight_display_unit != typedef::FitBaseUnit(u16::MAX)) as usize
-            + (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.wkt_step_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.weight_display_unit.0 != u16::MAX) as usize
+            + (self.message_index.0 != u16::MAX) as usize
+            + (self.wkt_step_index.0 != u16::MAX) as usize
     }
 }
 
@@ -190,7 +188,7 @@ impl From<Set> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::DATE_TIME,
@@ -222,7 +220,7 @@ impl From<Set> for Message {
                 is_expanded: false,
             });
         };
-        if m.set_type != typedef::SetType(u8::MAX) {
+        if m.set_type.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::SET_TYPE,
@@ -230,7 +228,7 @@ impl From<Set> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_time != typedef::DateTime(u32::MAX) {
+        if m.start_time.0 != u32::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::DATE_TIME,
@@ -257,7 +255,7 @@ impl From<Set> for Message {
                 is_expanded: false,
             });
         };
-        if m.weight_display_unit != typedef::FitBaseUnit(u16::MAX) {
+        if m.weight_display_unit.0 != u16::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::FIT_BASE_UNIT,
@@ -265,7 +263,7 @@ impl From<Set> for Message {
                 is_expanded: false,
             });
         };
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -273,7 +271,7 @@ impl From<Set> for Message {
                 is_expanded: false,
             });
         };
-        if m.wkt_step_index != typedef::MessageIndex(u16::MAX) {
+        if m.wkt_step_index.0 != u16::MAX {
             fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
+++ b/rustyfit/src/profile/mesgdef/skin_temp_overnight.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -53,8 +51,8 @@ impl SkinTempOvernight {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.local_timestamp.0 != u32::MAX) as usize
             + (self.average_deviation.to_bits() != u32::MAX) as usize
             + (self.average_7_day_deviation.to_bits() != u32::MAX) as usize
             + (self.nightly_value.to_bits() != u32::MAX) as usize
@@ -100,7 +98,7 @@ impl From<SkinTempOvernight> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -108,7 +106,7 @@ impl From<SkinTempOvernight> for Message {
                 is_expanded: false,
             });
         };
-        if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
+        if m.local_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::LOCAL_DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/slave_device.rs
+++ b/rustyfit/src/profile/mesgdef/slave_device.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -38,8 +36,7 @@ impl SlaveDevice {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
-            + (self.product != u16::MAX) as usize
+        (self.manufacturer.0 != u16::MAX) as usize + (self.product != u16::MAX) as usize
     }
 }
 
@@ -79,7 +76,7 @@ impl From<SlaveDevice> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.manufacturer != typedef::Manufacturer(u16::MAX) {
+        if m.manufacturer.0 != u16::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::MANUFACTURER,

--- a/rustyfit/src/profile/mesgdef/sleep_assessment.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_assessment.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_overnight_severity.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -38,8 +36,7 @@ impl SleepDisruptionOvernightSeverity {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.severity != typedef::SleepDisruptionSeverity(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize + (self.severity.0 != u8::MAX) as usize
     }
 }
 
@@ -79,7 +76,7 @@ impl From<SleepDisruptionOvernightSeverity> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -87,7 +84,7 @@ impl From<SleepDisruptionOvernightSeverity> for Message {
                 is_expanded: false,
             });
         };
-        if m.severity != typedef::SleepDisruptionSeverity(u8::MAX) {
+        if m.severity.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SLEEP_DISRUPTION_SEVERITY,

--- a/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_disruption_severity_period.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -42,9 +40,9 @@ impl SleepDisruptionSeverityPeriod {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.severity != typedef::SleepDisruptionSeverity(u8::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.timestamp.0 != u32::MAX) as usize
+            + (self.severity.0 != u8::MAX) as usize
     }
 }
 
@@ -85,7 +83,7 @@ impl From<SleepDisruptionSeverityPeriod> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -93,7 +91,7 @@ impl From<SleepDisruptionSeverityPeriod> for Message {
                 is_expanded: false,
             });
         };
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -101,7 +99,7 @@ impl From<SleepDisruptionSeverityPeriod> for Message {
                 is_expanded: false,
             });
         };
-        if m.severity != typedef::SleepDisruptionSeverity(u8::MAX) {
+        if m.severity.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SLEEP_DISRUPTION_SEVERITY,

--- a/rustyfit/src/profile/mesgdef/sleep_level.rs
+++ b/rustyfit/src/profile/mesgdef/sleep_level.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -39,8 +37,7 @@ impl SleepLevel {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.sleep_level != typedef::SleepLevel(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize + (self.sleep_level.0 != u8::MAX) as usize
     }
 }
 
@@ -80,7 +77,7 @@ impl From<SleepLevel> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -88,7 +85,7 @@ impl From<SleepLevel> for Message {
                 is_expanded: false,
             });
         };
-        if m.sleep_level != typedef::SleepLevel(u8::MAX) {
+        if m.sleep_level.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SLEEP_LEVEL,

--- a/rustyfit/src/profile/mesgdef/software.rs
+++ b/rustyfit/src/profile/mesgdef/software.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -64,7 +62,7 @@ impl Software {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.version != u16::MAX) as usize
             + (!self.part_number.is_empty()) as usize
     }
@@ -107,7 +105,7 @@ impl From<Software> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/speed_zone.rs
+++ b/rustyfit/src/profile/mesgdef/speed_zone.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -66,7 +64,7 @@ impl SpeedZone {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.high_value != u16::MAX) as usize
             + (!self.name.is_empty()) as usize
     }
@@ -109,7 +107,7 @@ impl From<SpeedZone> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/split.rs
+++ b/rustyfit/src/profile/mesgdef/split.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use crate::semconv;
@@ -360,13 +358,13 @@ impl Split {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.split_type != typedef::SplitType(u8::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.split_type.0 != u8::MAX) as usize
             + (self.total_elapsed_time != u32::MAX) as usize
             + (self.total_timer_time != u32::MAX) as usize
             + (self.total_distance != u32::MAX) as usize
             + (self.avg_speed != u32::MAX) as usize
-            + (self.start_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_time.0 != u32::MAX) as usize
             + (self.total_ascent != u16::MAX) as usize
             + (self.total_descent != u16::MAX) as usize
             + (self.start_position_lat != i32::MAX) as usize
@@ -375,7 +373,7 @@ impl Split {
             + (self.end_position_long != i32::MAX) as usize
             + (self.max_speed != u32::MAX) as usize
             + (self.avg_vert_speed != i32::MAX) as usize
-            + (self.end_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.end_time.0 != u32::MAX) as usize
             + (self.total_calories != u32::MAX) as usize
             + (self.start_elevation != u32::MAX) as usize
             + (self.active_time != u32::MAX) as usize
@@ -437,7 +435,7 @@ impl From<Split> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -445,7 +443,7 @@ impl From<Split> for Message {
                 is_expanded: false,
             });
         };
-        if m.split_type != typedef::SplitType(u8::MAX) {
+        if m.split_type.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPLIT_TYPE,
@@ -485,7 +483,7 @@ impl From<Split> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_time != typedef::DateTime(u32::MAX) {
+        if m.start_time.0 != u32::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::DATE_TIME,
@@ -557,7 +555,7 @@ impl From<Split> for Message {
                 is_expanded: false,
             });
         };
-        if m.end_time != typedef::DateTime(u32::MAX) {
+        if m.end_time.0 != u32::MAX {
             fields.push(Field {
                 num: 27,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/split_summary.rs
+++ b/rustyfit/src/profile/mesgdef/split_summary.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -249,8 +247,8 @@ impl SplitSummary {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.split_type != typedef::SplitType(u8::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.split_type.0 != u8::MAX) as usize
             + (self.num_splits != u16::MAX) as usize
             + (self.total_timer_time != u32::MAX) as usize
             + (self.total_distance != u32::MAX) as usize
@@ -316,7 +314,7 @@ impl From<SplitSummary> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -324,7 +322,7 @@ impl From<SplitSummary> for Message {
                 is_expanded: false,
             });
         };
-        if m.split_type != typedef::SplitType(u8::MAX) {
+        if m.split_type.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPLIT_TYPE,

--- a/rustyfit/src/profile/mesgdef/spo2_data.rs
+++ b/rustyfit/src/profile/mesgdef/spo2_data.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -49,10 +47,10 @@ impl Spo2Data {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.reading_spo2 != u8::MAX) as usize
             + (self.reading_confidence != u8::MAX) as usize
-            + (self.mode != typedef::Spo2MeasurementType(u8::MAX)) as usize
+            + (self.mode.0 != u8::MAX) as usize
     }
 }
 
@@ -94,7 +92,7 @@ impl From<Spo2Data> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -118,7 +116,7 @@ impl From<Spo2Data> for Message {
                 is_expanded: false,
             });
         };
-        if m.mode != typedef::Spo2MeasurementType(u8::MAX) {
+        if m.mode.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::SPO2_MEASUREMENT_TYPE,

--- a/rustyfit/src/profile/mesgdef/sport.rs
+++ b/rustyfit/src/profile/mesgdef/sport.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -44,8 +42,8 @@ impl Sport {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.sport != typedef::Sport(u8::MAX)) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+        (self.sport.0 != u8::MAX) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
             + (!self.name.is_empty()) as usize
     }
 }
@@ -87,7 +85,7 @@ impl From<Sport> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPORT,
@@ -95,7 +93,7 @@ impl From<Sport> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SUB_SPORT,

--- a/rustyfit/src/profile/mesgdef/stress_level.rs
+++ b/rustyfit/src/profile/mesgdef/stress_level.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -40,7 +38,7 @@ impl StressLevel {
 
     fn count_valid_fields(&self) -> usize {
         (self.stress_level_value != i16::MAX) as usize
-            + (self.stress_level_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.stress_level_time.0 != u32::MAX) as usize
     }
 }
 
@@ -88,7 +86,7 @@ impl From<StressLevel> for Message {
                 is_expanded: false,
             });
         };
-        if m.stress_level_time != typedef::DateTime(u32::MAX) {
+        if m.stress_level_time.0 != u32::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/tank_summary.rs
+++ b/rustyfit/src/profile/mesgdef/tank_summary.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -118,8 +116,8 @@ impl TankSummary {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.sensor != typedef::AntChannelId(u32::MIN)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.sensor.0 != u32::MIN) as usize
             + (self.start_pressure != u16::MAX) as usize
             + (self.end_pressure != u16::MAX) as usize
             + (self.volume_used != u32::MAX) as usize
@@ -165,7 +163,7 @@ impl From<TankSummary> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -173,7 +171,7 @@ impl From<TankSummary> for Message {
                 is_expanded: false,
             });
         };
-        if m.sensor != typedef::AntChannelId(u32::MIN) {
+        if m.sensor.0 != u32::MIN {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::ANT_CHANNEL_ID,

--- a/rustyfit/src/profile/mesgdef/tank_update.rs
+++ b/rustyfit/src/profile/mesgdef/tank_update.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -66,8 +64,8 @@ impl TankUpdate {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.sensor != typedef::AntChannelId(u32::MIN)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.sensor.0 != u32::MIN) as usize
             + (self.pressure != u16::MAX) as usize
     }
 }
@@ -109,7 +107,7 @@ impl From<TankUpdate> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -117,7 +115,7 @@ impl From<TankUpdate> for Message {
                 is_expanded: false,
             });
         };
-        if m.sensor != typedef::AntChannelId(u32::MIN) {
+        if m.sensor.0 != u32::MIN {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::ANT_CHANNEL_ID,

--- a/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
+++ b/rustyfit/src/profile/mesgdef/three_d_sensor_calibration.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -87,14 +85,14 @@ impl ThreeDSensorCalibration {
             if unscaled.is_nan() || unscaled.is_infinite() || unscaled > i32::MAX as f64 {
                 continue;
             }
-            self.orientation_matrix[i] = (unscaled as i32);
+            self.orientation_matrix[i] = unscaled as i32;
         }
         self
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.sensor_type != typedef::SensorType(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.sensor_type.0 != u8::MAX) as usize
             + (self.calibration_factor != u32::MAX) as usize
             + (self.calibration_divisor != u32::MAX) as usize
             + (self.level_shift != u32::MAX) as usize
@@ -166,7 +164,7 @@ impl From<ThreeDSensorCalibration> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -174,7 +172,7 @@ impl From<ThreeDSensorCalibration> for Message {
                 is_expanded: false,
             });
         };
-        if m.sensor_type != typedef::SensorType(u8::MAX) {
+        if m.sensor_type.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SENSOR_TYPE,

--- a/rustyfit/src/profile/mesgdef/time_in_zone.rs
+++ b/rustyfit/src/profile/mesgdef/time_in_zone.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -262,9 +260,9 @@ impl TimeInZone {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.reference_mesg != typedef::MesgNum(u16::MAX)) as usize
-            + (self.reference_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.reference_mesg.0 != u16::MAX) as usize
+            + (self.reference_index.0 != u16::MAX) as usize
             + (!self.time_in_hr_zone.is_empty()) as usize
             + (!self.time_in_speed_zone.is_empty()) as usize
             + (!self.time_in_cadence_zone.is_empty()) as usize
@@ -273,11 +271,11 @@ impl TimeInZone {
             + (!self.speed_zone_high_boundary.is_empty()) as usize
             + (!self.cadence_zone_high_boundary.is_empty()) as usize
             + (!self.power_zone_high_boundary.is_empty()) as usize
-            + (self.hr_calc_type != typedef::HrZoneCalc(u8::MAX)) as usize
+            + (self.hr_calc_type.0 != u8::MAX) as usize
             + (self.max_heart_rate != u8::MAX) as usize
             + (self.resting_heart_rate != u8::MAX) as usize
             + (self.threshold_heart_rate != u8::MAX) as usize
-            + (self.pwr_calc_type != typedef::PwrZoneCalc(u8::MAX)) as usize
+            + (self.pwr_calc_type.0 != u8::MAX) as usize
             + (self.functional_threshold_power != u16::MAX) as usize
     }
 }
@@ -333,7 +331,7 @@ impl From<TimeInZone> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -341,7 +339,7 @@ impl From<TimeInZone> for Message {
                 is_expanded: false,
             });
         };
-        if m.reference_mesg != typedef::MesgNum(u16::MAX) {
+        if m.reference_mesg.0 != u16::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::MESG_NUM,
@@ -349,7 +347,7 @@ impl From<TimeInZone> for Message {
                 is_expanded: false,
             });
         };
-        if m.reference_index != typedef::MessageIndex(u16::MAX) {
+        if m.reference_index.0 != u16::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -421,7 +419,7 @@ impl From<TimeInZone> for Message {
                 is_expanded: false,
             });
         };
-        if m.hr_calc_type != typedef::HrZoneCalc(u8::MAX) {
+        if m.hr_calc_type.0 != u8::MAX {
             fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::HR_ZONE_CALC,
@@ -453,7 +451,7 @@ impl From<TimeInZone> for Message {
                 is_expanded: false,
             });
         };
-        if m.pwr_calc_type != typedef::PwrZoneCalc(u8::MAX) {
+        if m.pwr_calc_type.0 != u8::MAX {
             fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::PWR_ZONE_CALC,

--- a/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
+++ b/rustyfit/src/profile/mesgdef/timestamp_correlation.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -107,11 +105,11 @@ impl TimestampCorrelation {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.fractional_timestamp != u16::MAX) as usize
-            + (self.system_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.system_timestamp.0 != u32::MAX) as usize
             + (self.fractional_system_timestamp != u16::MAX) as usize
-            + (self.local_timestamp != typedef::LocalDateTime(u32::MAX)) as usize
+            + (self.local_timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (self.system_timestamp_ms != u16::MAX) as usize
     }
@@ -158,7 +156,7 @@ impl From<TimestampCorrelation> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -174,7 +172,7 @@ impl From<TimestampCorrelation> for Message {
                 is_expanded: false,
             });
         };
-        if m.system_timestamp != typedef::DateTime(u32::MAX) {
+        if m.system_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,
@@ -190,7 +188,7 @@ impl From<TimestampCorrelation> for Message {
                 is_expanded: false,
             });
         };
-        if m.local_timestamp != typedef::LocalDateTime(u32::MAX) {
+        if m.local_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::LOCAL_DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/totals.rs
+++ b/rustyfit/src/profile/mesgdef/totals.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -76,12 +74,12 @@ impl Totals {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.timestamp.0 != u32::MAX) as usize
             + (self.timer_time != u32::MAX) as usize
             + (self.distance != u32::MAX) as usize
             + (self.calories != u32::MAX) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
+            + (self.sport.0 != u8::MAX) as usize
             + (self.elapsed_time != u32::MAX) as usize
             + (self.sessions != u16::MAX) as usize
             + (self.active_time != u32::MAX) as usize
@@ -133,7 +131,7 @@ impl From<Totals> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -141,7 +139,7 @@ impl From<Totals> for Message {
                 is_expanded: false,
             });
         };
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -173,7 +171,7 @@ impl From<Totals> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::SPORT,

--- a/rustyfit/src/profile/mesgdef/training_file.rs
+++ b/rustyfit/src/profile/mesgdef/training_file.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -55,12 +53,12 @@ impl TrainingFile {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.r#type != typedef::File(u8::MAX)) as usize
-            + (self.manufacturer != typedef::Manufacturer(u16::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.r#type.0 != u8::MAX) as usize
+            + (self.manufacturer.0 != u16::MAX) as usize
             + (self.product != u16::MAX) as usize
             + (self.serial_number != u32::MIN) as usize
-            + (self.time_created != typedef::DateTime(u32::MAX)) as usize
+            + (self.time_created.0 != u32::MAX) as usize
     }
 }
 
@@ -104,7 +102,7 @@ impl From<TrainingFile> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -112,7 +110,7 @@ impl From<TrainingFile> for Message {
                 is_expanded: false,
             });
         };
-        if m.r#type != typedef::File(u8::MAX) {
+        if m.r#type.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::FILE,
@@ -120,7 +118,7 @@ impl From<TrainingFile> for Message {
                 is_expanded: false,
             });
         };
-        if m.manufacturer != typedef::Manufacturer(u16::MAX) {
+        if m.manufacturer.0 != u16::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::MANUFACTURER,
@@ -144,7 +142,7 @@ impl From<TrainingFile> for Message {
                 is_expanded: false,
             });
         };
-        if m.time_created != typedef::DateTime(u32::MAX) {
+        if m.time_created.0 != u32::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/training_settings.rs
+++ b/rustyfit/src/profile/mesgdef/training_settings.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;

--- a/rustyfit/src/profile/mesgdef/user_profile.rs
+++ b/rustyfit/src/profile/mesgdef/user_profile.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -245,34 +243,34 @@ impl UserProfile {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (!self.friendly_name.is_empty()) as usize
-            + (self.gender != typedef::Gender(u8::MAX)) as usize
+            + (self.gender.0 != u8::MAX) as usize
             + (self.age != u8::MAX) as usize
             + (self.height != u8::MAX) as usize
             + (self.weight != u16::MAX) as usize
-            + (self.language != typedef::Language(u8::MAX)) as usize
-            + (self.elev_setting != typedef::DisplayMeasure(u8::MAX)) as usize
-            + (self.weight_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.language.0 != u8::MAX) as usize
+            + (self.elev_setting.0 != u8::MAX) as usize
+            + (self.weight_setting.0 != u8::MAX) as usize
             + (self.resting_heart_rate != u8::MAX) as usize
             + (self.default_max_running_heart_rate != u8::MAX) as usize
             + (self.default_max_biking_heart_rate != u8::MAX) as usize
             + (self.default_max_heart_rate != u8::MAX) as usize
-            + (self.hr_setting != typedef::DisplayHeart(u8::MAX)) as usize
-            + (self.speed_setting != typedef::DisplayMeasure(u8::MAX)) as usize
-            + (self.dist_setting != typedef::DisplayMeasure(u8::MAX)) as usize
-            + (self.power_setting != typedef::DisplayPower(u8::MAX)) as usize
-            + (self.activity_class != typedef::ActivityClass(u8::MAX)) as usize
-            + (self.position_setting != typedef::DisplayPosition(u8::MAX)) as usize
-            + (self.temperature_setting != typedef::DisplayMeasure(u8::MAX)) as usize
-            + (self.local_id != typedef::UserLocalId(u16::MAX)) as usize
+            + (self.hr_setting.0 != u8::MAX) as usize
+            + (self.speed_setting.0 != u8::MAX) as usize
+            + (self.dist_setting.0 != u8::MAX) as usize
+            + (self.power_setting.0 != u8::MAX) as usize
+            + (self.activity_class.0 != u8::MAX) as usize
+            + (self.position_setting.0 != u8::MAX) as usize
+            + (self.temperature_setting.0 != u8::MAX) as usize
+            + (self.local_id.0 != u16::MAX) as usize
             + (self.global_id != [u8::MAX; 6]) as usize
-            + (self.wake_time != typedef::LocaltimeIntoDay(u32::MAX)) as usize
-            + (self.sleep_time != typedef::LocaltimeIntoDay(u32::MAX)) as usize
-            + (self.height_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.wake_time.0 != u32::MAX) as usize
+            + (self.sleep_time.0 != u32::MAX) as usize
+            + (self.height_setting.0 != u8::MAX) as usize
             + (self.user_running_step_length != u16::MAX) as usize
             + (self.user_walking_step_length != u16::MAX) as usize
-            + (self.depth_setting != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.depth_setting.0 != u8::MAX) as usize
             + (self.dive_count != u32::MAX) as usize
     }
 }
@@ -351,7 +349,7 @@ impl From<UserProfile> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -367,7 +365,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.gender != typedef::Gender(u8::MAX) {
+        if m.gender.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::GENDER,
@@ -399,7 +397,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.language != typedef::Language(u8::MAX) {
+        if m.language.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::LANGUAGE,
@@ -407,7 +405,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.elev_setting != typedef::DisplayMeasure(u8::MAX) {
+        if m.elev_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 6,
                 profile_type: ProfileType::DISPLAY_MEASURE,
@@ -415,7 +413,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.weight_setting != typedef::DisplayMeasure(u8::MAX) {
+        if m.weight_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::DISPLAY_MEASURE,
@@ -455,7 +453,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.hr_setting != typedef::DisplayHeart(u8::MAX) {
+        if m.hr_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::DISPLAY_HEART,
@@ -463,7 +461,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.speed_setting != typedef::DisplayMeasure(u8::MAX) {
+        if m.speed_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::DISPLAY_MEASURE,
@@ -471,7 +469,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.dist_setting != typedef::DisplayMeasure(u8::MAX) {
+        if m.dist_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 14,
                 profile_type: ProfileType::DISPLAY_MEASURE,
@@ -479,7 +477,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.power_setting != typedef::DisplayPower(u8::MAX) {
+        if m.power_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 16,
                 profile_type: ProfileType::DISPLAY_POWER,
@@ -487,7 +485,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.activity_class != typedef::ActivityClass(u8::MAX) {
+        if m.activity_class.0 != u8::MAX {
             fields.push(Field {
                 num: 17,
                 profile_type: ProfileType::ACTIVITY_CLASS,
@@ -495,7 +493,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.position_setting != typedef::DisplayPosition(u8::MAX) {
+        if m.position_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 18,
                 profile_type: ProfileType::DISPLAY_POSITION,
@@ -503,7 +501,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.temperature_setting != typedef::DisplayMeasure(u8::MAX) {
+        if m.temperature_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 21,
                 profile_type: ProfileType::DISPLAY_MEASURE,
@@ -511,7 +509,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.local_id != typedef::UserLocalId(u16::MAX) {
+        if m.local_id.0 != u16::MAX {
             fields.push(Field {
                 num: 22,
                 profile_type: ProfileType::USER_LOCAL_ID,
@@ -527,7 +525,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.wake_time != typedef::LocaltimeIntoDay(u32::MAX) {
+        if m.wake_time.0 != u32::MAX {
             fields.push(Field {
                 num: 28,
                 profile_type: ProfileType::LOCALTIME_INTO_DAY,
@@ -535,7 +533,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.sleep_time != typedef::LocaltimeIntoDay(u32::MAX) {
+        if m.sleep_time.0 != u32::MAX {
             fields.push(Field {
                 num: 29,
                 profile_type: ProfileType::LOCALTIME_INTO_DAY,
@@ -543,7 +541,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.height_setting != typedef::DisplayMeasure(u8::MAX) {
+        if m.height_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 30,
                 profile_type: ProfileType::DISPLAY_MEASURE,
@@ -567,7 +565,7 @@ impl From<UserProfile> for Message {
                 is_expanded: false,
             });
         };
-        if m.depth_setting != typedef::DisplayMeasure(u8::MAX) {
+        if m.depth_setting.0 != u8::MAX {
             fields.push(Field {
                 num: 47,
                 profile_type: ProfileType::DISPLAY_MEASURE,

--- a/rustyfit/src/profile/mesgdef/video.rs
+++ b/rustyfit/src/profile/mesgdef/video.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;

--- a/rustyfit/src/profile/mesgdef/video_clip.rs
+++ b/rustyfit/src/profile/mesgdef/video_clip.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -61,9 +59,9 @@ impl VideoClip {
 
     fn count_valid_fields(&self) -> usize {
         (self.clip_number != u16::MAX) as usize
-            + (self.start_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.start_timestamp.0 != u32::MAX) as usize
             + (self.start_timestamp_ms != u16::MAX) as usize
-            + (self.end_timestamp != typedef::DateTime(u32::MAX)) as usize
+            + (self.end_timestamp.0 != u32::MAX) as usize
             + (self.end_timestamp_ms != u16::MAX) as usize
             + (self.clip_start != u32::MAX) as usize
             + (self.clip_end != u32::MAX) as usize
@@ -119,7 +117,7 @@ impl From<VideoClip> for Message {
                 is_expanded: false,
             });
         };
-        if m.start_timestamp != typedef::DateTime(u32::MAX) {
+        if m.start_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,
@@ -135,7 +133,7 @@ impl From<VideoClip> for Message {
                 is_expanded: false,
             });
         };
-        if m.end_timestamp != typedef::DateTime(u32::MAX) {
+        if m.end_timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/video_description.rs
+++ b/rustyfit/src/profile/mesgdef/video_description.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -46,7 +44,7 @@ impl VideoDescription {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.message_count != u16::MAX) as usize
             + (!self.text.is_empty()) as usize
     }
@@ -89,7 +87,7 @@ impl From<VideoDescription> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/video_frame.rs
+++ b/rustyfit/src/profile/mesgdef/video_frame.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -45,7 +43,7 @@ impl VideoFrame {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (self.timestamp_ms != u16::MAX) as usize
             + (self.frame_number != u32::MAX) as usize
     }
@@ -88,7 +86,7 @@ impl From<VideoFrame> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,

--- a/rustyfit/src/profile/mesgdef/video_title.rs
+++ b/rustyfit/src/profile/mesgdef/video_title.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -46,7 +44,7 @@ impl VideoTitle {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (self.message_count != u16::MAX) as usize
             + (!self.text.is_empty()) as usize
     }
@@ -89,7 +87,7 @@ impl From<VideoTitle> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/watchface_settings.rs
+++ b/rustyfit/src/profile/mesgdef/watchface_settings.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -42,8 +40,8 @@ impl WatchfaceSettings {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.mode != typedef::WatchfaceMode(u8::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.mode.0 != u8::MAX) as usize
             + (self.layout != u8::MAX) as usize
     }
 }
@@ -85,7 +83,7 @@ impl From<WatchfaceSettings> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -93,7 +91,7 @@ impl From<WatchfaceSettings> for Message {
                 is_expanded: false,
             });
         };
-        if m.mode != typedef::WatchfaceMode(u8::MAX) {
+        if m.mode.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::WATCHFACE_MODE,

--- a/rustyfit/src/profile/mesgdef/weather_alert.rs
+++ b/rustyfit/src/profile/mesgdef/weather_alert.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -61,12 +59,12 @@ impl WeatherAlert {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
             + (!self.report_id.is_empty()) as usize
-            + (self.issue_time != typedef::DateTime(u32::MAX)) as usize
-            + (self.expire_time != typedef::DateTime(u32::MAX)) as usize
-            + (self.severity != typedef::WeatherSeverity(u8::MAX)) as usize
-            + (self.r#type != typedef::WeatherSevereType(u8::MAX)) as usize
+            + (self.issue_time.0 != u32::MAX) as usize
+            + (self.expire_time.0 != u32::MAX) as usize
+            + (self.severity.0 != u8::MAX) as usize
+            + (self.r#type.0 != u8::MAX) as usize
     }
 }
 
@@ -110,7 +108,7 @@ impl From<WeatherAlert> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -126,7 +124,7 @@ impl From<WeatherAlert> for Message {
                 is_expanded: false,
             });
         };
-        if m.issue_time != typedef::DateTime(u32::MAX) {
+        if m.issue_time.0 != u32::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::DATE_TIME,
@@ -134,7 +132,7 @@ impl From<WeatherAlert> for Message {
                 is_expanded: false,
             });
         };
-        if m.expire_time != typedef::DateTime(u32::MAX) {
+        if m.expire_time.0 != u32::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::DATE_TIME,
@@ -142,7 +140,7 @@ impl From<WeatherAlert> for Message {
                 is_expanded: false,
             });
         };
-        if m.severity != typedef::WeatherSeverity(u8::MAX) {
+        if m.severity.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::WEATHER_SEVERITY,
@@ -150,7 +148,7 @@ impl From<WeatherAlert> for Message {
                 is_expanded: false,
             });
         };
-        if m.r#type != typedef::WeatherSevereType(u8::MAX) {
+        if m.r#type.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::WEATHER_SEVERE_TYPE,

--- a/rustyfit/src/profile/mesgdef/weather_conditions.rs
+++ b/rustyfit/src/profile/mesgdef/weather_conditions.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use crate::semconv;
@@ -153,20 +151,20 @@ impl WeatherConditions {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.weather_report != typedef::WeatherReport(u8::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.weather_report.0 != u8::MAX) as usize
             + (self.temperature != i8::MAX) as usize
-            + (self.condition != typedef::WeatherStatus(u8::MAX)) as usize
+            + (self.condition.0 != u8::MAX) as usize
             + (self.wind_direction != u16::MAX) as usize
             + (self.wind_speed != u16::MAX) as usize
             + (self.precipitation_probability != u8::MAX) as usize
             + (self.temperature_feels_like != i8::MAX) as usize
             + (self.relative_humidity != u8::MAX) as usize
             + (!self.location.is_empty()) as usize
-            + (self.observed_at_time != typedef::DateTime(u32::MAX)) as usize
+            + (self.observed_at_time.0 != u32::MAX) as usize
             + (self.observed_location_lat != i32::MAX) as usize
             + (self.observed_location_long != i32::MAX) as usize
-            + (self.day_of_week != typedef::DayOfWeek(u8::MAX)) as usize
+            + (self.day_of_week.0 != u8::MAX) as usize
             + (self.high_temperature != i8::MAX) as usize
             + (self.low_temperature != i8::MAX) as usize
     }
@@ -222,7 +220,7 @@ impl From<WeatherConditions> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -230,7 +228,7 @@ impl From<WeatherConditions> for Message {
                 is_expanded: false,
             });
         };
-        if m.weather_report != typedef::WeatherReport(u8::MAX) {
+        if m.weather_report.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::WEATHER_REPORT,
@@ -246,7 +244,7 @@ impl From<WeatherConditions> for Message {
                 is_expanded: false,
             });
         };
-        if m.condition != typedef::WeatherStatus(u8::MAX) {
+        if m.condition.0 != u8::MAX {
             fields.push(Field {
                 num: 2,
                 profile_type: ProfileType::WEATHER_STATUS,
@@ -302,7 +300,7 @@ impl From<WeatherConditions> for Message {
                 is_expanded: false,
             });
         };
-        if m.observed_at_time != typedef::DateTime(u32::MAX) {
+        if m.observed_at_time.0 != u32::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::DATE_TIME,
@@ -326,7 +324,7 @@ impl From<WeatherConditions> for Message {
                 is_expanded: false,
             });
         };
-        if m.day_of_week != typedef::DayOfWeek(u8::MAX) {
+        if m.day_of_week.0 != u8::MAX {
             fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::DAY_OF_WEEK,

--- a/rustyfit/src/profile/mesgdef/weight_scale.rs
+++ b/rustyfit/src/profile/mesgdef/weight_scale.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -287,8 +285,8 @@ impl WeightScale {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.timestamp != typedef::DateTime(u32::MAX)) as usize
-            + (self.weight != typedef::Weight(u16::MAX)) as usize
+        (self.timestamp.0 != u32::MAX) as usize
+            + (self.weight.0 != u16::MAX) as usize
             + (self.percent_fat != u16::MAX) as usize
             + (self.percent_hydration != u16::MAX) as usize
             + (self.visceral_fat_mass != u16::MAX) as usize
@@ -299,7 +297,7 @@ impl WeightScale {
             + (self.active_met != u16::MAX) as usize
             + (self.metabolic_age != u8::MAX) as usize
             + (self.visceral_fat_rating != u8::MAX) as usize
-            + (self.user_profile_index != typedef::MessageIndex(u16::MAX)) as usize
+            + (self.user_profile_index.0 != u16::MAX) as usize
             + (self.bmi != u16::MAX) as usize
     }
 }
@@ -352,7 +350,7 @@ impl From<WeightScale> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.timestamp != typedef::DateTime(u32::MAX) {
+        if m.timestamp.0 != u32::MAX {
             fields.push(Field {
                 num: 253,
                 profile_type: ProfileType::DATE_TIME,
@@ -360,7 +358,7 @@ impl From<WeightScale> for Message {
                 is_expanded: false,
             });
         };
-        if m.weight != typedef::Weight(u16::MAX) {
+        if m.weight.0 != u16::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::WEIGHT,
@@ -448,7 +446,7 @@ impl From<WeightScale> for Message {
                 is_expanded: false,
             });
         };
-        if m.user_profile_index != typedef::MessageIndex(u16::MAX) {
+        if m.user_profile_index.0 != u16::MAX {
             fields.push(Field {
                 num: 12,
                 profile_type: ProfileType::MESSAGE_INDEX,

--- a/rustyfit/src/profile/mesgdef/workout.rs
+++ b/rustyfit/src/profile/mesgdef/workout.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -93,14 +91,14 @@ impl Workout {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
-            + (self.capabilities != typedef::WorkoutCapabilities(u32::MIN)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.sport.0 != u8::MAX) as usize
+            + (self.capabilities.0 != u32::MIN) as usize
             + (self.num_valid_steps != u16::MAX) as usize
             + (!self.wkt_name.is_empty()) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
             + (self.pool_length != u16::MAX) as usize
-            + (self.pool_length_unit != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.pool_length_unit.0 != u8::MAX) as usize
             + (!self.wkt_description.is_empty()) as usize
     }
 }
@@ -148,7 +146,7 @@ impl From<Workout> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -156,7 +154,7 @@ impl From<Workout> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 4,
                 profile_type: ProfileType::SPORT,
@@ -164,7 +162,7 @@ impl From<Workout> for Message {
                 is_expanded: false,
             });
         };
-        if m.capabilities != typedef::WorkoutCapabilities(u32::MIN) {
+        if m.capabilities.0 != u32::MIN {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::WORKOUT_CAPABILITIES,
@@ -188,7 +186,7 @@ impl From<Workout> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 11,
                 profile_type: ProfileType::SUB_SPORT,
@@ -204,7 +202,7 @@ impl From<Workout> for Message {
                 is_expanded: false,
             });
         };
-        if m.pool_length_unit != typedef::DisplayMeasure(u8::MAX) {
+        if m.pool_length_unit.0 != u8::MAX {
             fields.push(Field {
                 num: 15,
                 profile_type: ProfileType::DISPLAY_MEASURE,

--- a/rustyfit/src/profile/mesgdef/workout_session.rs
+++ b/rustyfit/src/profile/mesgdef/workout_session.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -80,13 +78,13 @@ impl WorkoutSession {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
-            + (self.sport != typedef::Sport(u8::MAX)) as usize
-            + (self.sub_sport != typedef::SubSport(u8::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
+            + (self.sport.0 != u8::MAX) as usize
+            + (self.sub_sport.0 != u8::MAX) as usize
             + (self.num_valid_steps != u16::MAX) as usize
             + (self.first_step_index != u16::MAX) as usize
             + (self.pool_length != u16::MAX) as usize
-            + (self.pool_length_unit != typedef::DisplayMeasure(u8::MAX)) as usize
+            + (self.pool_length_unit.0 != u8::MAX) as usize
     }
 }
 
@@ -131,7 +129,7 @@ impl From<WorkoutSession> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -139,7 +137,7 @@ impl From<WorkoutSession> for Message {
                 is_expanded: false,
             });
         };
-        if m.sport != typedef::Sport(u8::MAX) {
+        if m.sport.0 != u8::MAX {
             fields.push(Field {
                 num: 0,
                 profile_type: ProfileType::SPORT,
@@ -147,7 +145,7 @@ impl From<WorkoutSession> for Message {
                 is_expanded: false,
             });
         };
-        if m.sub_sport != typedef::SubSport(u8::MAX) {
+        if m.sub_sport.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::SUB_SPORT,
@@ -179,7 +177,7 @@ impl From<WorkoutSession> for Message {
                 is_expanded: false,
             });
         };
-        if m.pool_length_unit != typedef::DisplayMeasure(u8::MAX) {
+        if m.pool_length_unit.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::DISPLAY_MEASURE,

--- a/rustyfit/src/profile/mesgdef/workout_step.rs
+++ b/rustyfit/src/profile/mesgdef/workout_step.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::borrow::ToOwned;
@@ -130,22 +128,22 @@ impl WorkoutStep {
     }
 
     fn count_valid_fields(&self) -> usize {
-        (self.message_index != typedef::MessageIndex(u16::MAX)) as usize
+        (self.message_index.0 != u16::MAX) as usize
             + (!self.wkt_step_name.is_empty()) as usize
-            + (self.duration_type != typedef::WktStepDuration(u8::MAX)) as usize
+            + (self.duration_type.0 != u8::MAX) as usize
             + (self.duration_value != u32::MAX) as usize
-            + (self.target_type != typedef::WktStepTarget(u8::MAX)) as usize
+            + (self.target_type.0 != u8::MAX) as usize
             + (self.target_value != u32::MAX) as usize
             + (self.custom_target_value_low != u32::MAX) as usize
             + (self.custom_target_value_high != u32::MAX) as usize
-            + (self.intensity != typedef::Intensity(u8::MAX)) as usize
+            + (self.intensity.0 != u8::MAX) as usize
             + (!self.notes.is_empty()) as usize
-            + (self.equipment != typedef::WorkoutEquipment(u8::MAX)) as usize
-            + (self.exercise_category != typedef::ExerciseCategory(u16::MAX)) as usize
+            + (self.equipment.0 != u8::MAX) as usize
+            + (self.exercise_category.0 != u16::MAX) as usize
             + (self.exercise_name != u16::MAX) as usize
             + (self.exercise_weight != u16::MAX) as usize
-            + (self.weight_display_unit != typedef::FitBaseUnit(u16::MAX)) as usize
-            + (self.secondary_target_type != typedef::WktStepTarget(u8::MAX)) as usize
+            + (self.weight_display_unit.0 != u16::MAX) as usize
+            + (self.secondary_target_type.0 != u8::MAX) as usize
             + (self.secondary_target_value != u32::MAX) as usize
             + (self.secondary_custom_target_value_low != u32::MAX) as usize
             + (self.secondary_custom_target_value_high != u32::MAX) as usize
@@ -205,7 +203,7 @@ impl From<WorkoutStep> for Message {
         let mut fields =
             Vec::<Field>::with_capacity(m.count_valid_fields() + m.unknown_fields.len());
 
-        if m.message_index != typedef::MessageIndex(u16::MAX) {
+        if m.message_index.0 != u16::MAX {
             fields.push(Field {
                 num: 254,
                 profile_type: ProfileType::MESSAGE_INDEX,
@@ -221,7 +219,7 @@ impl From<WorkoutStep> for Message {
                 is_expanded: false,
             });
         };
-        if m.duration_type != typedef::WktStepDuration(u8::MAX) {
+        if m.duration_type.0 != u8::MAX {
             fields.push(Field {
                 num: 1,
                 profile_type: ProfileType::WKT_STEP_DURATION,
@@ -237,7 +235,7 @@ impl From<WorkoutStep> for Message {
                 is_expanded: false,
             });
         };
-        if m.target_type != typedef::WktStepTarget(u8::MAX) {
+        if m.target_type.0 != u8::MAX {
             fields.push(Field {
                 num: 3,
                 profile_type: ProfileType::WKT_STEP_TARGET,
@@ -269,7 +267,7 @@ impl From<WorkoutStep> for Message {
                 is_expanded: false,
             });
         };
-        if m.intensity != typedef::Intensity(u8::MAX) {
+        if m.intensity.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::INTENSITY,
@@ -285,7 +283,7 @@ impl From<WorkoutStep> for Message {
                 is_expanded: false,
             });
         };
-        if m.equipment != typedef::WorkoutEquipment(u8::MAX) {
+        if m.equipment.0 != u8::MAX {
             fields.push(Field {
                 num: 9,
                 profile_type: ProfileType::WORKOUT_EQUIPMENT,
@@ -293,7 +291,7 @@ impl From<WorkoutStep> for Message {
                 is_expanded: false,
             });
         };
-        if m.exercise_category != typedef::ExerciseCategory(u16::MAX) {
+        if m.exercise_category.0 != u16::MAX {
             fields.push(Field {
                 num: 10,
                 profile_type: ProfileType::EXERCISE_CATEGORY,
@@ -317,7 +315,7 @@ impl From<WorkoutStep> for Message {
                 is_expanded: false,
             });
         };
-        if m.weight_display_unit != typedef::FitBaseUnit(u16::MAX) {
+        if m.weight_display_unit.0 != u16::MAX {
             fields.push(Field {
                 num: 13,
                 profile_type: ProfileType::FIT_BASE_UNIT,
@@ -325,7 +323,7 @@ impl From<WorkoutStep> for Message {
                 is_expanded: false,
             });
         };
-        if m.secondary_target_type != typedef::WktStepTarget(u8::MAX) {
+        if m.secondary_target_type.0 != u8::MAX {
             fields.push(Field {
                 num: 19,
                 profile_type: ProfileType::WKT_STEP_TARGET,

--- a/rustyfit/src/profile/mesgdef/zones_target.rs
+++ b/rustyfit/src/profile/mesgdef/zones_target.rs
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#![allow(unused, clippy::manual_range_patterns)]
-
 use crate::profile::{ProfileType, typedef};
 use crate::proto::*;
 use alloc::vec::Vec;
@@ -53,8 +51,8 @@ impl ZonesTarget {
         (self.max_heart_rate != u8::MAX) as usize
             + (self.threshold_heart_rate != u8::MAX) as usize
             + (self.functional_threshold_power != u16::MAX) as usize
-            + (self.hr_calc_type != typedef::HrZoneCalc(u8::MAX)) as usize
-            + (self.pwr_calc_type != typedef::PwrZoneCalc(u8::MAX)) as usize
+            + (self.hr_calc_type.0 != u8::MAX) as usize
+            + (self.pwr_calc_type.0 != u8::MAX) as usize
     }
 }
 
@@ -121,7 +119,7 @@ impl From<ZonesTarget> for Message {
                 is_expanded: false,
             });
         };
-        if m.hr_calc_type != typedef::HrZoneCalc(u8::MAX) {
+        if m.hr_calc_type.0 != u8::MAX {
             fields.push(Field {
                 num: 5,
                 profile_type: ProfileType::HR_ZONE_CALC,
@@ -129,7 +127,7 @@ impl From<ZonesTarget> for Message {
                 is_expanded: false,
             });
         };
-        if m.pwr_calc_type != typedef::PwrZoneCalc(u8::MAX) {
+        if m.pwr_calc_type.0 != u8::MAX {
             fields.push(Field {
                 num: 7,
                 profile_type: ProfileType::PWR_ZONE_CALC,


### PR DESCRIPTION
- use `self.timestamp.0 != u32::MAX` instead of `self.timestamp != typedef::DateTime(u32::MAX)`
- remove `#![allow(unused)]` and allow clippy to warn us about unused imports and unnecessary symbols.
- only add `#![allow(clippy::manual_range_patterns)]` when we have component expansion, this this will only warn when we have manual range patterns on `is_expanded()` method.