### PR TITLE
chore: derive Clone, Copy for Crc16 and change sum16 to self

### DIFF
--- a/rustyfit/src/crc16.rs
+++ b/rustyfit/src/crc16.rs
@@ -3,6 +3,7 @@ static TABLE: [u16; 16] = [
     0x5000, 0x9C01, 0x8801, 0x4400,
 ];
 
+#[derive(Clone, Copy)]
 pub(crate) struct Crc16(u16);
 
 impl Crc16 {
@@ -22,7 +23,7 @@ impl Crc16 {
         }
     }
 
-    pub fn sum16(&self) -> u16 {
+    pub fn sum16(self) -> u16 {
         self.0
     }
 


### PR DESCRIPTION
Crc16 small for Copy operation, explicitly copy instead of reference it when collecting sum16's value