### PR TITLE
feat: add release_heap_memory method

### DIFF
--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -182,6 +182,19 @@ impl Decoder {
         }))
     }
 
+    /// Releases heap memory used by the `Decoder` back to the allocator, so it can be reused
+    /// by subsequent allocations in memory-constrained environments such as embedded systems
+    /// when a statically allocated `Decoder` is no longer in use.
+    pub fn release_heap_memory(&mut self) {
+        for mesg_def in &mut self.mesg_definitions {
+            mesg_def.field_definitions = Vec::new();
+            mesg_def.developer_field_definitions = Vec::new();
+        }
+        self.mesg.fields = Vec::new();
+        self.mesg.developer_fields = Vec::new();
+        self.field_descriptions = Vec::new();
+    }
+
     fn decode_file_header<R>(
         &mut self,
         reader: &mut R,

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -176,6 +176,14 @@ impl Encoder {
         Ok(())
     }
 
+    /// Releases heap memory used by the `Encoder` back to the allocator, so it can be reused
+    /// by subsequent allocations in memory-constrained environments such as embedded systems
+    /// when a statically allocated `Encoder` is no longer in use.
+    pub fn release_heap_memory(&mut self) {
+        self.lru = Lru::new();
+        self.message_validator = MessageValidator::new();
+    }
+
     fn select_protocol_version(&mut self, file_header: &mut FileHeader) {
         if self.options.protocol_version.0 != 0 {
             file_header.protocol_version = self.options.protocol_version;


### PR DESCRIPTION
By default, Decoder and Encoder retain heap-allocated memory capacity as long as they are still in use, this reduces the need for reallocation, improving performance. 

However, in embedded systems, RAM is a limited resource and we usually do one thing at a time. When Decoder and Encoder are statically allocated, they live for the lifetime of the program, so the heap memory they hold will be retained as well. Since we don't use them simultaneously, providing a method to release the heap memory before "parking" the instance will allow that memory to be reused by the other instance or another process/task.