### PR TITLE
fix: checksum logic for file header's size 12

### DIFF
--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -214,25 +214,27 @@ impl Decoder {
             return Err(Error::NotFITFile);
         }
 
+        self.buf[12..14].fill(0); // crc will be zero when size is 12.
         reader.read_exact(&mut self.buf[1..size as usize])?;
 
         if &self.buf[8..12] != FileHeader::DATA_TYPE.as_bytes() {
             return Err(Error::NotFITFile);
         }
 
-        let crc = match size {
-            14 => u16::from_le_bytes([self.buf[12], self.buf[13]]),
-            _ => 0,
-        };
+        let crc = u16::from_le_bytes([self.buf[12], self.buf[13]]);
 
-        if size == 14 && crc != 0 {
+        if self.options.checksum {
+            // If size is 12, checksum both file header and data together.
+            // If size is 14, checksum file header and data separately.
             self.crc16.write(&self.buf[..12]);
-            let found = crc;
-            let calculated = self.crc16.sum16();
-            if self.options.checksum && found != calculated {
-                return Err(Error::ChecksumMismatch { found, calculated });
+            if size == 14 {
+                let found = crc;
+                let calculated = self.crc16.sum16();
+                self.crc16.reset();
+                if found != 0 && found != calculated {
+                    return Err(Error::ChecksumMismatch { found, calculated });
+                }
             }
-            self.crc16.reset();
         }
 
         Ok(Some(FileHeader {

--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -218,9 +218,10 @@ impl Encoder {
     where
         W: Write + Seek,
     {
-        if file_header.size != 12 {
-            file_header.size = 14;
-        }
+        // When size is 12, we need to do checksum for both file header and data combined.
+        // However, we can only know file header's data size after writing the data and
+        // CRC checksum can only be done sequentially, we don't support size 12.
+        file_header.size = 14;
 
         if file_header.profile_version == 0 {
             file_header.profile_version = PROFILE_VERSION;
@@ -753,13 +754,74 @@ mod tests {
 
     use crate::{
         Encoder,
+        crc16::Crc16,
         encoder::write_value,
-        profile::{mesgdef, typedef},
-        proto::{FIT, FileHeader, Message, ProtocolVersion, Value},
+        profile::{self, mesgdef, typedef},
+        proto::{FIT, Field, FileHeader, Message, ProtocolVersion, Value},
     };
     use alloc::{borrow::ToOwned, vec, vec::Vec};
     use embedded_io::{ErrorKind, ErrorType, Seek, Write};
     use embedded_io_adapters::std::FromStd;
+
+    #[test]
+    fn test_encode_checksum_for_file_header_size_12() {
+        // We always set the file header's size to be 14,
+        // checking the checksum values is enough.
+        let mut enc = Encoder::new();
+        let mut buf = Vec::<u8>::new();
+        let writer = Cursor::new(&mut buf);
+
+        let mut fit = FIT {
+            file_header: FileHeader {
+                size: 12,
+                protocol_version: ProtocolVersion::V1,
+                profile_version: profile::PROFILE_VERSION,
+                data_size: 0,
+                crc: 0,
+            },
+            messages: vec![Message {
+                header: 0,
+                num: typedef::MesgNum::FILE_ID,
+                fields: vec![Field {
+                    num: mesgdef::FileId::MANUFACTURER,
+                    base_type: typedef::FitBaseType::UINT16,
+                    value: Value::Uint16(typedef::Manufacturer::DEVELOPMENT.0),
+                    is_expanded: false,
+                }],
+                developer_fields: Vec::new(),
+            }],
+            crc: 0,
+        };
+
+        enc.encode(FromStd::new(writer), &mut fit).unwrap();
+
+        let file_header_crc = u16::from_le_bytes(buf[12..14].try_into().unwrap());
+
+        let mut crc16 = Crc16::new();
+        crc16.write(&buf[..12]);
+        let file_header_crc_calculated = crc16.sum16();
+
+        if file_header_crc != file_header_crc_calculated {
+            panic!(
+                "expected file_header_crc: {}, calculated: {}",
+                file_header_crc, file_header_crc_calculated
+            );
+        }
+
+        let len = buf.len();
+        let fit_crc = u16::from_le_bytes(buf[len - 2..len].try_into().unwrap());
+
+        crc16.reset();
+        crc16.write(&buf[14..len - 2]);
+        let fit_crc_calculated = crc16.sum16();
+
+        if fit_crc != fit_crc_calculated {
+            panic!(
+                "expected fit_crc: {}, calculated: {}",
+                fit_crc, fit_crc_calculated
+            );
+        }
+    }
 
     #[test]
     fn compress_timestamp_into_header() {

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -1,7 +1,7 @@
 use embedded_io_adapters::std::FromStd;
 use rustyfit::{
-    Decoder, DecoderError, DecoderEvent, Encoder, EncoderBuilder, Endianness, HeaderOption,
-    StreamingIterator, proto::Message,
+    Decoder, DecoderEvent, Encoder, EncoderBuilder, Endianness, HeaderOption, StreamingIterator,
+    proto::Message,
 };
 use std::{
     error::Error,
@@ -85,22 +85,7 @@ fn do_roudtrip_with_encoder_options(
     let buf = Vec::<u8>::with_capacity(5000 * 1024); // 5 MB, large enough to avoid realloc.
     let mut cursor = Cursor::new(buf);
 
-    'decode: while let Some(fit) = &mut match dec.decode(&mut reader) {
-        Ok(fit) => fit,
-        Err(err) => {
-            if let DecoderError::ChecksumMismatch { .. } = err {
-                // NOTE: Doubts exist regarding the integrity of these files.
-                if let Some(file_name) = path.file_name()
-                    && ["WeightScaleMultiUser.fit", "Settings.fit"]
-                        .iter()
-                        .any(|x| *x == file_name)
-                {
-                    continue 'decode;
-                }
-            }
-            return Err(format!("decode: {:?}", err).into());
-        }
-    } {
+    while let Some(fit) = &mut dec.decode(&mut reader)? {
         cursor.seek(SeekFrom::Start(0)).unwrap();
 
         let mut enc = encoder_builder.build();


### PR DESCRIPTION
I thought when `file header`'s size is 12 (legacy), only the `data` needs to be checksummed. But it turns out that both `file header` and `data` should be checksummed together. Now test decode for `Settings.fit` and `WeightScaleMultiUser.fit` has passed.

For encoding, since we can only know file header's data size after writing the `data` and CRC checksum can only be done sequentially, so we drop support for the buggy file header's data size 12 implementation since it almost always returns a corrupted result, we will always encode size 14 from now on, it has been the default anyway.

Related issue: https://github.com/muktihari/fit/pull/641