### PR TITLE
fix: StreamEncoder's message validation when using default protocol version

### DIFF
--- a/rustyfit/src/encoder/mod.rs
+++ b/rustyfit/src/encoder/mod.rs
@@ -145,9 +145,16 @@ impl Encoder {
     {
         self.reset();
 
+        let protocol_version = if self.options.protocol_version.0 != 0 {
+            self.options.protocol_version
+        } else {
+            ProtocolVersion::V1
+        };
+
         Stream {
             writer,
             encoder: self,
+            protocol_version,
             counter: 0,
         }
     }
@@ -657,6 +664,7 @@ impl Default for Builder {
 pub struct Stream<'a, W> {
     writer: W,
     encoder: &'a mut Encoder,
+    protocol_version: ProtocolVersion,
     counter: usize,
 }
 
@@ -672,7 +680,7 @@ impl<'a, W: Write + Seek> Stream<'a, W> {
         if let Err(err) = self
             .encoder
             .message_validator
-            .validate_message(mesg, self.encoder.options.protocol_version)
+            .validate_message(mesg, self.protocol_version)
         {
             return Err(Error::MessageValidation {
                 mesg_index: self.counter,
@@ -697,14 +705,9 @@ impl<'a, W: Write + Seek> Stream<'a, W> {
 
         self.encoder.encode_crc(&mut self.writer)?;
 
-        let mut protocol_version = self.encoder.options.protocol_version;
-        if protocol_version == ProtocolVersion(0) {
-            protocol_version = ProtocolVersion::V1;
-        }
-
         let file_header = FileHeader {
             size: 14,
-            protocol_version,
+            protocol_version: self.protocol_version,
             profile_version: PROFILE_VERSION,
             data_size: self.encoder.data_size,
             crc: 0, // calculated
@@ -734,9 +737,9 @@ mod tests {
     use crate::{
         Encoder,
         crc16::Crc16,
-        encoder::write_value,
+        encoder::{Error, write_value},
         profile::{self, mesgdef, typedef},
-        proto::{FIT, Field, FileHeader, Message, ProtocolVersion, Value},
+        proto::{DeveloperField, FIT, Field, FileHeader, Message, ProtocolVersion, Value},
     };
     use alloc::{borrow::ToOwned, vec, vec::Vec};
     use embedded_io::{ErrorKind, ErrorType, Seek, Write};
@@ -1322,6 +1325,77 @@ mod tests {
         assert_eq!(
             enc_storage, stream_storage,
             "Encoder and Stream should produce same result"
+        );
+    }
+
+    #[test]
+    fn test_stream_encoder_protocol_version() {
+        let mut enc = Encoder::new();
+        let mut buf = Vec::new();
+        let writer = FromStd::new(Cursor::new(&mut buf));
+        let mut stream = enc.stream(writer);
+
+        assert_eq!(
+            stream.protocol_version,
+            ProtocolVersion::V1,
+            "should use default protocol version 1.0"
+        );
+
+        // Should validate using stream's protocol_version (V1)
+        match stream
+            .write_message(&mut Message {
+                header: 0,
+                num: typedef::MesgNum::RECORD,
+                fields: Vec::new(),
+                developer_fields: vec![DeveloperField {
+                    num: 0,
+                    developer_data_index: 0,
+                    value: Value::Uint8(10),
+                }],
+            })
+            .expect_err("protocol version 1.0 does not support developer data")
+        {
+            Error::MessageValidation { .. } => {}
+            err => {
+                panic!("unexpected error: {err}")
+            }
+        };
+
+        buf.clear();
+
+        // Should encode file_header with stream's protocol_version (V1)
+        let writer = FromStd::new(Cursor::new(&mut buf));
+        let mut stream = enc.stream(writer);
+
+        stream
+            .write_message(&mut {
+                let mut file_id = mesgdef::FileId::new();
+                file_id.manufacturer = typedef::Manufacturer::GARMIN;
+                file_id.product = typedef::GarminProduct::FENIX8_SOLAR.0;
+                file_id.r#type = typedef::File::ACTIVITY;
+                Message::from(file_id)
+            })
+            .unwrap();
+
+        stream.finish().unwrap();
+
+        assert_eq!(
+            buf[1],
+            ProtocolVersion::V1.0,
+            "file header's protocol version mismatch"
+        );
+
+        let expected_protocol_version = ProtocolVersion::V2;
+        let mut enc = Encoder::builder()
+            .protocol_version(expected_protocol_version)
+            .build();
+
+        let writer = FromStd::new(Cursor::new(Vec::new()));
+        let stream = enc.stream(writer);
+
+        assert_eq!(
+            stream.protocol_version, expected_protocol_version,
+            "Stream should use given protocol version (V2)"
         );
     }
 }

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -1,7 +1,7 @@
 use embedded_io_adapters::std::FromStd;
 use rustyfit::{
     Decoder, DecoderEvent, Encoder, EncoderBuilder, Endianness, HeaderOption, StreamingIterator,
-    proto::Message,
+    proto::{Message, ProtocolVersion},
 };
 use std::{
     error::Error,
@@ -175,7 +175,9 @@ fn do_roudtrip_by_streaming(path: &PathBuf) -> Result<(), Box<dyn Error>> {
     cursor.seek(SeekFrom::Start(0)).unwrap();
     let mut writer = FromStd::new(&mut cursor);
 
-    let mut enc = Encoder::new();
+    let mut enc = Encoder::builder()
+        .protocol_version(ProtocolVersion::V2)
+        .build();
     let mut stream_enc = enc.stream(&mut writer);
 
     for mesg in expected_messages.clone().iter_mut() {

--- a/rustyfit/tests/roundtrip.rs
+++ b/rustyfit/tests/roundtrip.rs
@@ -15,7 +15,7 @@ fn decode_encode_roundtrip() {
     walk_path(
         &Path::new("tests/data").to_path_buf(),
         &mut |path: &PathBuf| {
-            do_roudtrip_with_encoder_options(
+            do_roundtrip_with_encoder_options(
                 path,
                 EncoderBuilder::new()
                     .endianness(Endianness::LittleEndian)
@@ -31,7 +31,7 @@ fn decode_encode_roundtrip_compressed() {
     walk_path(
         &Path::new("tests/data").to_path_buf(),
         &mut |path: &PathBuf| {
-            do_roudtrip_with_encoder_options(
+            do_roundtrip_with_encoder_options(
                 path,
                 EncoderBuilder::new()
                     .endianness(Endianness::BigEndian)
@@ -46,7 +46,7 @@ fn decode_encode_roundtrip_compressed() {
 fn streaming_decode_encode_roundtrip() {
     walk_path(
         &Path::new("tests/data").to_path_buf(),
-        &mut |path: &PathBuf| do_roudtrip_by_streaming(path),
+        &mut |path: &PathBuf| do_roundtrip_by_streaming(path),
     )
     .unwrap();
 }
@@ -72,7 +72,7 @@ where
     Ok(())
 }
 
-fn do_roudtrip_with_encoder_options(
+fn do_roundtrip_with_encoder_options(
     path: &PathBuf,
     encoder_builder: EncoderBuilder,
 ) -> Result<(), Box<dyn Error>> {
@@ -146,15 +146,7 @@ fn do_roudtrip_with_encoder_options(
     Ok(())
 }
 
-fn do_roudtrip_by_streaming(path: &PathBuf) -> Result<(), Box<dyn Error>> {
-    if let Some(file_name) = path.file_name()
-        && ["WeightScaleMultiUser.fit", "Settings.fit"]
-            .iter()
-            .any(|x| *x == file_name)
-    {
-        return Ok(());
-    }
-
+fn do_roundtrip_by_streaming(path: &PathBuf) -> Result<(), Box<dyn Error>> {
     let file = File::open(path).unwrap();
     let br = BufReader::new(file);
     let mut reader = FromStd::new(br);


### PR DESCRIPTION
If protocol version is not specified,  we use V1 as a fallback. StreamEncoder wrote V1 on file header but not validating message using V1, so the resulting file might have V1 on file header but may contains developer data.