### PR TITLE
chore: clippy pin rust toolchain version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CLIPPY_TOOLCHAIN_VERSION: 1.97.1
 
 jobs:
   build:
@@ -15,8 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Setup Rust toolchain
+        run: rustup component add --toolchain $CLIPPY_TOOLCHAIN_VERSION-x86_64-unknown-linux-gnu clippy
+
       - name: Run clippy all with deny warnings
-        run: cargo clippy --verbose --all-targets --all-features -- -D warnings
+        run: cargo +$CLIPPY_TOOLCHAIN_VERSION clippy --verbose --all-targets --all-features -- -D warnings
 
       - name: Run cargo tests
         run: cargo test --verbose --all-features


### PR DESCRIPTION
Since we use `-Dwarnings` on CI, newer rust versions may introduce new warnings that might break the CI. The rust v1.98.0 breaks the current code so we stick with v1.97.1 from time being, update later.