### PR TITLE
chore: use as_chunks instead of chunks_exact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CLIPPY_TOOLCHAIN_VERSION: 1.97.1
+  CLIPPY_TOOLCHAIN_VERSION: 1.98.1
 
 jobs:
   build:

--- a/rustyfit/src/decoder/mod.rs
+++ b/rustyfit/src/decoder/mod.rs
@@ -292,7 +292,7 @@ impl Decoder {
 
             mesg_def
                 .field_definitions
-                .extend(buf.chunks_exact(3).map(|b| FieldDefinition {
+                .extend(buf.as_chunks::<3>().0.iter().map(|b| FieldDefinition {
                     num: b[0],
                     size: b[1],
                     base_type: FitBaseType(b[2]),
@@ -325,11 +325,16 @@ impl Decoder {
 
                 mesg_def
                     .developer_field_definitions
-                    .extend(buf.chunks_exact(3).map(|b| DeveloperFieldDefinition {
-                        num: b[0],
-                        size: b[1],
-                        developer_data_index: b[2],
-                    }));
+                    .extend(
+                        buf.as_chunks::<3>()
+                            .0
+                            .iter()
+                            .map(|b| DeveloperFieldDefinition {
+                                num: b[0],
+                                size: b[1],
+                                developer_data_index: b[2],
+                            }),
+                    );
             }
         }
 

--- a/rustyfit/src/proto.rs
+++ b/rustyfit/src/proto.rs
@@ -350,12 +350,16 @@ impl Value {
                     let mut vals: Vec<i16> = Vec::with_capacity(buf.len() / 2);
                     match arch {
                         0 => vals.extend(
-                            buf.chunks_exact(2)
-                                .map(|x| i16::from_le_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|&x| i16::from_le_bytes(x)),
                         ),
                         _ => vals.extend(
-                            buf.chunks_exact(2)
-                                .map(|x| i16::from_be_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|&x| i16::from_be_bytes(x)),
                         ),
                     };
                     vals
@@ -370,12 +374,16 @@ impl Value {
                     let mut vals: Vec<u16> = Vec::with_capacity(buf.len() / 2);
                     match arch {
                         0 => vals.extend(
-                            buf.chunks_exact(2)
-                                .map(|x| u16::from_le_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|&x| u16::from_le_bytes(x)),
                         ),
                         _ => vals.extend(
-                            buf.chunks_exact(2)
-                                .map(|x| u16::from_be_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|&x| u16::from_be_bytes(x)),
                         ),
                     };
                     vals
@@ -390,12 +398,16 @@ impl Value {
                     let mut vals: Vec<i32> = Vec::with_capacity(buf.len() / 4);
                     match arch {
                         0 => vals.extend(
-                            buf.chunks_exact(4)
-                                .map(|x| i32::from_le_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<4>()
+                                .0
+                                .iter()
+                                .map(|&x| i32::from_le_bytes(x)),
                         ),
                         _ => vals.extend(
-                            buf.chunks_exact(4)
-                                .map(|x| i32::from_be_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<4>()
+                                .0
+                                .iter()
+                                .map(|&x| i32::from_be_bytes(x)),
                         ),
                     };
                     vals
@@ -410,12 +422,16 @@ impl Value {
                     let mut vals: Vec<u32> = Vec::with_capacity(buf.len() / 4);
                     match arch {
                         0 => vals.extend(
-                            buf.chunks_exact(4)
-                                .map(|x| u32::from_le_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<4>()
+                                .0
+                                .iter()
+                                .map(|&x| u32::from_le_bytes(x)),
                         ),
                         _ => vals.extend(
-                            buf.chunks_exact(4)
-                                .map(|x| u32::from_be_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<4>()
+                                .0
+                                .iter()
+                                .map(|&x| u32::from_be_bytes(x)),
                         ),
                     };
                     vals
@@ -455,12 +471,16 @@ impl Value {
                     let mut vals: Vec<f32> = Vec::with_capacity(buf.len() / 4);
                     match arch {
                         0 => vals.extend(
-                            buf.chunks_exact(4)
-                                .map(|x| f32::from_le_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<4>()
+                                .0
+                                .iter()
+                                .map(|&x| f32::from_le_bytes(x)),
                         ),
                         _ => vals.extend(
-                            buf.chunks_exact(4)
-                                .map(|x| f32::from_be_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<4>()
+                                .0
+                                .iter()
+                                .map(|&x| f32::from_be_bytes(x)),
                         ),
                     };
                     vals
@@ -475,12 +495,16 @@ impl Value {
                     let mut vals: Vec<f64> = Vec::with_capacity(buf.len() / 8);
                     match arch {
                         0 => vals.extend(
-                            buf.chunks_exact(8)
-                                .map(|x| f64::from_le_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<8>()
+                                .0
+                                .iter()
+                                .map(|&x| f64::from_le_bytes(x)),
                         ),
                         _ => vals.extend(
-                            buf.chunks_exact(8)
-                                .map(|x| f64::from_be_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<8>()
+                                .0
+                                .iter()
+                                .map(|&x| f64::from_be_bytes(x)),
                         ),
                     }
                     vals
@@ -495,12 +519,16 @@ impl Value {
                     let mut vals: Vec<i64> = Vec::with_capacity(buf.len() / 8);
                     match arch {
                         0 => vals.extend(
-                            buf.chunks_exact(8)
-                                .map(|x| i64::from_le_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<8>()
+                                .0
+                                .iter()
+                                .map(|&x| i64::from_le_bytes(x)),
                         ),
                         _ => vals.extend(
-                            buf.chunks_exact(8)
-                                .map(|x| i64::from_be_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<8>()
+                                .0
+                                .iter()
+                                .map(|&x| i64::from_be_bytes(x)),
                         ),
                     }
                     vals
@@ -515,12 +543,16 @@ impl Value {
                     let mut vals: Vec<u64> = Vec::with_capacity(buf.len() / 8);
                     match arch {
                         0 => vals.extend(
-                            buf.chunks_exact(8)
-                                .map(|x| u64::from_le_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<8>()
+                                .0
+                                .iter()
+                                .map(|&x| u64::from_le_bytes(x)),
                         ),
                         _ => vals.extend(
-                            buf.chunks_exact(8)
-                                .map(|x| u64::from_be_bytes(x.try_into().unwrap())),
+                            buf.as_chunks::<8>()
+                                .0
+                                .iter()
+                                .map(|&x| u64::from_be_bytes(x)),
                         ),
                     }
                     vals


### PR DESCRIPTION
Latest `clippy` (starting from v1.98.0) now warn the use of `chunks_exact` having constant argument and suggest using `as_chunks` instead. This PR keeps the code up-to-date with `clippy` suggestion. I don't see any performance improvement but binary size show a slight reduction, (`examples/no_std_decode` program shows ~1KB reduction), maybe because the compiler now can omit boundcheck or panic handler since we access an array instead of a slice, just a guess.